### PR TITLE
removes plots when there is 1 member in timeDimension

### DIFF
--- a/packages/vizbuilder/src/helpers/chartconfig.js
+++ b/packages/vizbuilder/src/helpers/chartconfig.js
@@ -268,7 +268,7 @@ export default function createChartConfig({
       availableCharts.delete("barchart");
     }
 
-    if (!hasTimeDim) {
+    if (!hasTimeDim || members[timeDrilldownName].length === 1) {
       availableCharts.delete("stacked");
       availableCharts.delete("barchartyear");
       availableCharts.delete("lineplot");


### PR DESCRIPTION
closes #174 

Considering the @frabarz PR #173 I used `members[timeDrilldownName].length` for to check the length of available years.