### PR TITLE
fixes bug with loading formatters by adding leading slash to api call

### DIFF
--- a/packages/cms/src/formatter/FormatterEditor.jsx
+++ b/packages/cms/src/formatter/FormatterEditor.jsx
@@ -20,7 +20,7 @@ class FormatterEditor extends Component {
   }
 
   hitDB() {
-    axios.get("api/cms/formattertree").then(resp => {
+    axios.get("/api/cms/formattertree").then(resp => {
       this.setState({formatters: resp.data});
     });
   }


### PR DESCRIPTION
Missing leading slash in FormatterEditor was causing api gets in the formatter tab to fail, this (one-character) PR fixes that.