### PR TITLE
[cms] changes formatter get from localjs to db

### DIFF
--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -1,4 +1,4 @@
-// import libs from "./utils/libs";
+import libs from "./utils/libs";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 import ProfileBuilder from "./profile/ProfileBuilder";
@@ -6,7 +6,7 @@ import StoryBuilder from "./story/StoryBuilder";
 import FormatterEditor from "./formatter/FormatterEditor";
 import {fetchData} from "@datawheel/canon-core";
 import {connect} from "react-redux";
-import formatters from "./utils/formatters";
+// import formatters from "./utils/formatters";
 
 import "./Builder.css";
 import "./themes/cms-dark.css";
@@ -18,17 +18,15 @@ class Builder extends Component {
     super(props);
     this.state = {
       currentTab: "profiles",
-      formatters,
-      theme: "cms-light"
+      // formatters,
+      theme: "cms-light",
 
-      /*
       formatters: (props.formatters || []).reduce((acc, d) => {
         const f = Function("n", "libs", "formatters", d.logic);
         const fName = d.name.replace(/^\w/g, chr => chr.toLowerCase());
         acc[fName] = n => f(n, libs, acc);
         return acc;
       }, {})
-      */
     };
   }
 


### PR DESCRIPTION
The ability to "seed" a database via a model is not yet part of canon. The eventual plan will be for canon to fill the `formatter` table using `seed` content from the model, but this is not yet implemented.

As a stop-gap, it was temporarily decided that formatters in the CMS would load from a bundled js file. However, this means that when a current user of canon uses the CMS, adding new formatters to the db has no effect.

This PR changes it back to the original functionality: Load the formatters from the DB.  Note that this will cause NEW installations of the canon cms to have an empty array of formatters, and they will need to be added to the DB manually, until the `seed` functionality is added to canon. 