### PR TITLE
[cms] reorganizes profile layout to separate top-level profile info from stats

### DIFF
--- a/packages/cms/src/components/cards/TextCard.css
+++ b/packages/cms/src/components/cards/TextCard.css
@@ -140,11 +140,8 @@
   }
 }
 
-
-/* first splash stat takes up full width */
-.cms-stats-card-list > .cms-card:first-child {
+.cms-profile-header {
   flex-basis: 100%;
-  max-width: calc(100% - 2rem);
 }
 
 /* individual stats */

--- a/packages/cms/src/profile/ProfileEditor.jsx
+++ b/packages/cms/src/profile/ProfileEditor.jsx
@@ -196,6 +196,27 @@ class ProfileEditor extends Component {
             )}
         </div>
 
+        {/* Top-level Profile */}
+        <h2 className="cms-section-heading">
+          Profile
+          <button className="cms-button cms-section-heading-button" onClick={this.addItem.bind(this, "profile_stat")}>
+            <span className="pt-icon pt-icon-plus" />
+          </button>
+        </h2>
+        <div
+          className="cms-splash-wrapper"
+          style={{backgroundImage: `url("/api/profile/${minData.slug}/${preview}/thumb")`}}
+        >
+          <div className="cms-card-list cms-profile-header">
+            <TextCard
+              id={minData.id}
+              fields={["title", "subtitle"]}
+              type="profile"
+              variables={variables}
+            />
+          </div>
+        </div>
+
         {/* splash stats */}
         <h2 className="cms-section-heading">
           Stats
@@ -208,12 +229,6 @@ class ProfileEditor extends Component {
           style={{backgroundImage: `url("/api/profile/${minData.slug}/${preview}/thumb")`}}
         >
           <div className="cms-card-list cms-stats-card-list">
-            <TextCard
-              id={minData.id}
-              fields={["title", "subtitle"]}
-              type="profile"
-              variables={variables}
-            />
             { minData.stats && minData.stats.map(s =>
               <TextCard
                 key={s.id}


### PR DESCRIPTION
Closes issue #270 by moving profile info out of stats block and moving stats header down to refer to Stat Block only