### PR TITLE
changes render behavior for perc bar for a cdc chart

### DIFF
--- a/packages/cms/app/pages/Bar.jsx
+++ b/packages/cms/app/pages/Bar.jsx
@@ -1,0 +1,31 @@
+import React, {Component} from "react";
+import Viz from "../../src/components/Viz";
+
+export default class Bar extends Component {
+  
+  render() {
+
+    const logic = `return {
+      type: "PercentageBar",
+      data: [
+        {name: "jim", count: 5},
+        {name: "dave", count: 7},
+        {name: "alex", count: 10}
+      ],
+      dataFormat: d => d,
+      total: 100,
+      groupBy: "name",
+      value: "count"  
+  }
+  `;
+
+    return (
+      <div id="Bar">
+        <Viz 
+          config={{logic}}
+        />
+      </div>
+    );
+  }
+
+}

--- a/packages/cms/app/pages/Bar.jsx
+++ b/packages/cms/app/pages/Bar.jsx
@@ -18,6 +18,9 @@ export default class Bar extends Component {
       ],
       dataFormat: d => d,
       groupBy: "name",
+      cutoff: data => data.filter(d => d.name == "jim" || d.name == "dave" || d.name == "jonathan" || d.name == "walther"),
+      cutoffText: "showing blah blah blah blah blah",
+      sort: (a, b) => a.name == "jonathan" ? -1 : 1,
       value: "count"
   }
   `;

--- a/packages/cms/app/pages/Bar.jsx
+++ b/packages/cms/app/pages/Bar.jsx
@@ -19,7 +19,7 @@ export default class Bar extends Component {
       dataFormat: d => d,
       groupBy: "name",
       cutoff: data => data.filter(d => d.name == "jim" || d.name == "dave" || d.name == "jonathan" || d.name == "walther"),
-      cutoffText: "showing blah blah blah blah blah",
+      cutoffText: "showing similar names",
       sort: (a, b) => a.name == "jonathan" ? -1 : 1,
       value: "count"
   }

--- a/packages/cms/app/pages/Bar.jsx
+++ b/packages/cms/app/pages/Bar.jsx
@@ -10,11 +10,15 @@ export default class Bar extends Component {
       data: [
         {name: "jim", count: 5},
         {name: "dave", count: 7},
-        {name: "alex", count: 10}
+        {name: "alex", count: 10},
+        {name: "walther", count: 2},
+        {name: "james", count: 14},
+        {name: "jonathan", count: 6},
+        {name: "valerie", count: 6}
       ],
       dataFormat: d => d,
       groupBy: "name",
-      value: "count"  
+      value: "count"
   }
   `;
 

--- a/packages/cms/app/pages/Bar.jsx
+++ b/packages/cms/app/pages/Bar.jsx
@@ -13,7 +13,6 @@ export default class Bar extends Component {
         {name: "alex", count: 10}
       ],
       dataFormat: d => d,
-      total: 100,
       groupBy: "name",
       value: "count"  
   }

--- a/packages/cms/app/routes.jsx
+++ b/packages/cms/app/routes.jsx
@@ -4,12 +4,14 @@ import {Route, IndexRoute, browserHistory} from "react-router";
 import App from "./App";
 import Home from "./pages/Home";
 import Search from "./pages/Search";
+import Bar from "./pages/Bar";
 
 export default function RouteCreate() {
   return (
     <Route path="/" component={App} history={browserHistory}>
       <IndexRoute component={Home} />
       <Route path="/search" component={Search} />
+      <Route path="/bar" component={Bar} />
     </Route>
   );
 }

--- a/packages/cms/src/components/Viz/PercentageBar.css
+++ b/packages/cms/src/components/Viz/PercentageBar.css
@@ -1,0 +1,7 @@
+.show-more {
+  display: flex;
+}
+
+.cutoff-text {
+  margin: 5px;
+}

--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -16,7 +16,10 @@ class PercentageBar extends Component {
 
     const defaults = {
       cutoff: 5,
-      numberFormat: (d, value, total) => `${Number(d[value] / total * 100).toFixed(2)}%`,
+      numberFormat: (d, value, total) => {
+        const perc = Number(d[value] / total * 100);
+        return isNaN(perc) ? "No Data" : `${perc.toFixed(2)}%`;
+      },
       showText: "Show More",
       hideText: "Hide"
     };
@@ -27,13 +30,13 @@ class PercentageBar extends Component {
     if (typeof config.data === "string") {
       axios.get(config.data).then(resp => {
         config.data = dataFormat(resp.data);
-        if (!config.total) config.total = config.data.reduce((acc, d) => acc += d[config.value], 0);
+        if (!config.total) config.total = config.data.reduce((acc, d) => isNaN(d[config.value]) ? acc : acc + Number(d[config.value]), 0);
         this.setState({config});
       });
     }
     else {
       config.data = dataFormat(config.data);
-      if (!config.total) config.total = config.data.reduce((acc, d) => acc += d[config.value], 0);
+      if (!config.total) config.total = config.data.reduce((acc, d) => isNaN(d[config.value]) ? acc : acc + Number(d[config.value]), 0);
       this.setState({config});
     }
   }
@@ -47,8 +50,6 @@ class PercentageBar extends Component {
     const {data, cutoff, title, value, groupBy, total, numberFormat, showText, hideText} = config;
 
     const displayData = showAll ? data : data.slice(0, cutoff);
-
-    console.log(numberFormat);
   
     return <div className="PercentageBar">
       <h3 className="pb-title">{title}</h3>
@@ -61,9 +62,9 @@ class PercentageBar extends Component {
             <div className="pt-progress-bar pt-intent-primary pt-no-stripes">
               {!isNaN(percent) && <div className="pt-progress-meter" style={{width: `${percent}%`}}>
               </div>}      
-              <p className="percent-label xs-size">{numberFormat(d, value, total)}</p>    
+              
             </div>
-            
+            <p className="percent-label xs-size">{numberFormat(d, value, total)}</p>    
           </div>;
         })
       }

--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -1,6 +1,8 @@
 import axios from "axios";
 import React, {Component} from "react";
 
+import "./PercentageBar.css";
+
 class PercentageBar extends Component {
 
   constructor(props) {
@@ -16,6 +18,7 @@ class PercentageBar extends Component {
 
     const defaults = {
       cutoff: 5,
+      cutoffText: false,
       numberFormat: (d, value, total) => {
         const perc = Number(d[value] / total * 100);
         return isNaN(perc) ? "No Data" : `${perc.toFixed(2)}%`;
@@ -47,9 +50,13 @@ class PercentageBar extends Component {
 
     if (!config) return null;
 
-    const {data, cutoff, title, value, groupBy, total, numberFormat, showText, hideText} = config;
+    const {data, cutoff, cutoffText, title, value, groupBy, sort, total, numberFormat, showText, hideText} = config;
 
-    const displayData = showAll ? data : data.slice(0, cutoff);
+    const cutoffFunction = typeof cutoff === "number" ? data => data.slice(0, cutoff) : cutoff;
+
+    let displayData = showAll ? data : cutoffFunction(data);
+
+    if (sort) displayData = displayData.sort(sort);
   
     return <div className="PercentageBar">
       <h3 className="pb-title">{title}</h3>
@@ -68,7 +75,10 @@ class PercentageBar extends Component {
           </div>;
         })
       }
-      {data.length > cutoff && <button onClick={() => this.setState({showAll: !this.state.showAll})}>{showAll ? hideText : showText}</button>}
+      <div className="show-more">
+        {!showAll && cutoffText && <div className="cutoff-text">{cutoffText}</div>}
+        {(showAll || data.length > displayData.length) && <button onClick={() => this.setState({showAll: !this.state.showAll})}>{showAll ? hideText : showText}</button>}
+      </div>
     </div>;
 
   }

--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -1,6 +1,5 @@
 import axios from "axios";
 import React, {Component} from "react";
-import {abbreviate} from "../../utils/formatters";
 
 class PercentageBar extends Component {
 
@@ -42,7 +41,7 @@ class PercentageBar extends Component {
 
     if (!config) return null;
 
-    const {data, cutoff, title, value, groupBy, total} = config;
+    const {data, cutoff, title, value, groupBy, total, showPercent} = config;
 
     const displayData = showAll ? data : data.slice(0, cutoff);
   
@@ -58,7 +57,7 @@ class PercentageBar extends Component {
             <div className="pt-progress-bar pt-intent-primary pt-no-stripes">
               {!isNaN(percent) && <div className="pt-progress-meter" style={{width: `${percent}%`}}>
               </div>}      
-              <p className="percent-label xs-size">{isNaN(percent) ? "No data" : number ? abbreviate(number) : `${percent.toFixed(2)}%` }</p>    
+              <p className="percent-label xs-size">{`${!isNaN(Number(number)) ? Number(number).toFixed(2) : number}${showPercent ? "%" : ""}`}</p>    
             </div>
           </div>;
         })

--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -15,7 +15,8 @@ class PercentageBar extends Component {
     const {dataFormat} = this.props;
 
     const defaults = {
-      cutoff: 5
+      cutoff: 5,
+      numberFormat: (d, value, total) => `${Number(d[value] / total * 100).toFixed(2)}%`
     };
 
     const config = Object.assign({}, defaults, propConfig);
@@ -41,11 +42,11 @@ class PercentageBar extends Component {
 
     if (!config) return null;
 
-    const {data, cutoff, title, value, groupBy, total, showPercent/*, numberFormat*/} = config;
-
-    //if (!numberFormat) numberFormat = d => `${Number(d[value] / total * 100).toFixed(2)}%`;
+    const {data, cutoff, title, value, groupBy, total, numberFormat} = config;
 
     const displayData = showAll ? data : data.slice(0, cutoff);
+
+    console.log(numberFormat);
   
     return <div className="PercentageBar">
       <h3 className="pb-title">{title}</h3>
@@ -53,14 +54,14 @@ class PercentageBar extends Component {
         displayData.map((d, i) => {
           const percent = d[value] / total * 100;
           const label = d[groupBy];
-          const number = d[value];
           return <div key={`pb-${i}`}className="percent-wrapper">
             <p className="label s-size">{label}</p>
             <div className="pt-progress-bar pt-intent-primary pt-no-stripes">
               {!isNaN(percent) && <div className="pt-progress-meter" style={{width: `${percent}%`}}>
               </div>}      
-              <p className="percent-label xs-size">{`${!isNaN(Number(number)) ? Number(number).toFixed(2) : number}${showPercent ? "%" : ""}`}</p>    
+              <p className="percent-label xs-size">{numberFormat(d, value, total)}</p>    
             </div>
+            
           </div>;
         })
       }

--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -41,7 +41,9 @@ class PercentageBar extends Component {
 
     if (!config) return null;
 
-    const {data, cutoff, title, value, groupBy, total, showPercent} = config;
+    const {data, cutoff, title, value, groupBy, total, showPercent/*, numberFormat*/} = config;
+
+    //if (!numberFormat) numberFormat = d => `${Number(d[value] / total * 100).toFixed(2)}%`;
 
     const displayData = showAll ? data : data.slice(0, cutoff);
   

--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -16,7 +16,9 @@ class PercentageBar extends Component {
 
     const defaults = {
       cutoff: 5,
-      numberFormat: (d, value, total) => `${Number(d[value] / total * 100).toFixed(2)}%`
+      numberFormat: (d, value, total) => `${Number(d[value] / total * 100).toFixed(2)}%`,
+      showText: "Show More",
+      hideText: "Hide"
     };
 
     const config = Object.assign({}, defaults, propConfig);
@@ -42,7 +44,7 @@ class PercentageBar extends Component {
 
     if (!config) return null;
 
-    const {data, cutoff, title, value, groupBy, total, numberFormat} = config;
+    const {data, cutoff, title, value, groupBy, total, numberFormat, showText, hideText} = config;
 
     const displayData = showAll ? data : data.slice(0, cutoff);
 
@@ -65,7 +67,7 @@ class PercentageBar extends Component {
           </div>;
         })
       }
-      {data.length > cutoff && <button onClick={() => this.setState({showAll: !this.state.showAll})}>{showAll ? "Hide" : "Show More"}</button>}
+      {data.length > cutoff && <button onClick={() => this.setState({showAll: !this.state.showAll})}>{showAll ? hideText : showText}</button>}
     </div>;
 
   }


### PR DESCRIPTION
This adds a `showPercent` switch to the data config for perc bars so I can properly render one of the charts for CDC