### PR TITLE
fixes materalizer and formatter bugs, and camelifies keynames in ez-mode generator

### DIFF
--- a/packages/cms/src/components/editors/GeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/GeneratorEditor.jsx
@@ -33,6 +33,9 @@ class GeneratorEditor extends Component {
       const {simple} = data;
       this.setState({data, variables, simple});
     }
+    else {
+      this.setState({data, variables});
+    }
   }
 
   changeField(field, e) {

--- a/packages/cms/src/components/editors/SimpleGeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/SimpleGeneratorEditor.jsx
@@ -21,6 +21,13 @@ export default class SimpleGeneratorEditor extends Component {
     if (prevProps.payload !== this.props.payload) this.populate.bind(this)();
   }
 
+  camelize(str) {
+    return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => {
+      if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces
+      return index === 0 ? match.toLowerCase() : match.toUpperCase();
+    });
+  }
+
   populate() {
     const {payload, simpleConfig} = this.props;
     // If the error prop exists in the payload, then the user has either not yet configured,
@@ -47,7 +54,7 @@ export default class SimpleGeneratorEditor extends Component {
       objects = pl.map((obj, i) => 
         Object.keys(obj).map(k => ({
           use: true,
-          keyName: `${k}${i + 1}`,
+          keyName: `${this.camelize(k)}${i + 1}`,
           pKey: k,
           pVal: obj[k]
         }))
@@ -114,7 +121,7 @@ export default class SimpleGeneratorEditor extends Component {
     const objects = pl.map((obj, i) => 
       Object.keys(obj).map(k => ({
         use: true,
-        keyName: `${k}${i + 1}`,
+        keyName: `${this.camelize(k)}${i + 1}`,
         pKey: k,
         pVal: obj[k]
       }))

--- a/packages/cms/src/formatter/FormatterEditor.jsx
+++ b/packages/cms/src/formatter/FormatterEditor.jsx
@@ -61,7 +61,7 @@ class FormatterEditor extends Component {
               .sort((a, b) => a.name.localeCompare(b.name))
               .map(g => <GeneratorCard
                 key={g.id}
-                id={g.id}
+                item={g}
                 onSave={this.onSave.bind(this)}
                 onDelete={this.onDelete.bind(this)}
                 type="formatter"


### PR DESCRIPTION
I accidentally removed an `else` that caused Materializers not to render. This fixes that reversion.  

Also fixes a bug in formatters that was causing the formatter page to not retrieve the list properly.

Also puts in a "camelify" method to generators so the suggested keys get camelCased and have no spaces in them.