### PR TITLE
adds <id> url swap to both gen and viz simple editors

### DIFF
--- a/packages/cms/src/components/cards/GeneratorCard.jsx
+++ b/packages/cms/src/components/cards/GeneratorCard.jsx
@@ -73,7 +73,7 @@ class GeneratorCard extends Component {
   }
 
   render() {
-    const {type, variables, item, parentArray} = this.props;
+    const {type, variables, item, parentArray, preview} = this.props;
     const {displayData, minData, isOpen} = this.state;
 
     let description = "";
@@ -160,7 +160,7 @@ class GeneratorCard extends Component {
         >
 
           <div className="pt-dialog-body">
-            <GeneratorEditor data={minData} variables={variables} type={type} />
+            <GeneratorEditor preview={preview} data={minData} variables={variables} type={type} />
           </div>
           <FooterButtons
             onDelete={this.delete.bind(this)}

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -60,7 +60,7 @@ class VisualizationCard extends Component {
     if (!minData) return <Loading />;
 
     const {formatters} = this.context;
-    const {selectors, type, variables, parentArray, item} = this.props;
+    const {selectors, type, variables, parentArray, item, preview} = this.props;
 
     minData.selectors = selectors;
     const {logic} = varSwapRecursive(minData, formatters, variables);
@@ -96,7 +96,7 @@ class VisualizationCard extends Component {
           title="Variable Editor"
         >
           <div className="pt-dialog-body">
-            <GeneratorEditor data={minData} variables={variables} type={type} />
+            <GeneratorEditor preview={preview} data={minData} variables={variables} type={type} />
           </div>
           <FooterButtons
             onDelete={this.delete.bind(this)}

--- a/packages/cms/src/components/editors/GeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/GeneratorEditor.jsx
@@ -4,6 +4,7 @@ import AceWrapper from "./AceWrapper";
 import SimpleGeneratorEditor from "./SimpleGeneratorEditor";
 import SimpleVisualizationEditor from "./SimpleVisualizationEditor";
 import {Switch, Alert, Intent} from "@blueprintjs/core";
+import urlSwap from "../../utils/urlSwap";
 
 import "./GeneratorEditor.css";
 
@@ -81,8 +82,13 @@ class GeneratorEditor extends Component {
   previewPayload(forceSimple) {
     const {data} = this.state;
     const {api} = data;
+    const {preview, variables} = this.props;
     if (api) {
-      axios.get(api).then(resp => {
+      // The API will have an <id> in it that needs to be replaced with the current preview.
+      // Use urlSwap to swap ANY instances of variables between brackets (e.g. <varname>) 
+      // With its corresponding value.
+      const url = urlSwap(api, Object.assign({}, variables, {id: preview}));
+      axios.get(url).then(resp => {
         const payload = resp.data;
         let {simple} = this.state;
         // This comparison is important! forceSimple must be EXACTLY true to indicate we are overriding it. Otherwise it's a 
@@ -168,7 +174,7 @@ class GeneratorEditor extends Component {
   render() {
 
     const {data, variables, payload, simple, alertObj} = this.state;
-    const {type} = this.props;
+    const {type, preview} = this.props;
 
     const preMessage = {
       generator: <p className="pt-text-muted">You have access to the variable <strong>resp</strong>, which represents the response to the above API call.</p>,
@@ -254,7 +260,7 @@ class GeneratorEditor extends Component {
               ? payload 
                 ? <SimpleGeneratorEditor payload={payload} simpleConfig={data.logic_simple} onSimpleChange={this.onSimpleChange.bind(this)}/> 
                 : null
-              : <SimpleVisualizationEditor simpleConfig={data.logic_simple} onSimpleChange={this.onSimpleChange.bind(this)}/>
+              : <SimpleVisualizationEditor preview={preview} variables={variables} simpleConfig={data.logic_simple} onSimpleChange={this.onSimpleChange.bind(this)}/>
             : <AceWrapper
               className="editor"
               variables={variables}

--- a/packages/cms/src/components/editors/SimpleVisualizationEditor.jsx
+++ b/packages/cms/src/components/editors/SimpleVisualizationEditor.jsx
@@ -87,7 +87,7 @@ export default class SimpleVisualizationEditor extends Component {
             const strippedVar = v.replace("<", "").replace(">", "");
             fixedUrl = fixedUrl.replace(v, `\$\{variables.${strippedVar}\}`);
           });
-          return `\n  "${k}": "${fixedUrl}"`;
+          return `\n  "${k}": \`${fixedUrl}\``;
         }
         else {
           return `\n  "${k}": "${object[k]}"`;  

--- a/packages/cms/src/profile/ProfileEditor.jsx
+++ b/packages/cms/src/profile/ProfileEditor.jsx
@@ -156,6 +156,7 @@ class ProfileEditor extends Component {
             .map(g => <GeneratorCard
               key={g.id}
               item={g}
+              preview={preview}
               onSave={this.onSave.bind(this)}
               onDelete={this.onDelete.bind(this)}
               type="generator"

--- a/packages/cms/src/profile/TopicEditor.jsx
+++ b/packages/cms/src/profile/TopicEditor.jsx
@@ -110,7 +110,7 @@ class TopicEditor extends Component {
   render() {
 
     const {minData} = this.state;
-    const {variables} = this.props;
+    const {variables, preview} = this.props;
 
     if (!minData || !variables) return <Loading />;
 
@@ -281,6 +281,7 @@ class TopicEditor extends Component {
             <VisualizationCard
               key={v.id}
               item={v}
+              preview={preview}
               onDelete={this.onDelete.bind(this)}
               type="topic_visualization"
               variables={variables}


### PR DESCRIPTION
This PR performs a `urlSwap` on the API paths for simple editors for generators and visualizations.

For generators, this is only important in terms of fetching the payload for the "preview." When users type `/api?id=<id>` into the `API` section of a generator and Fetch that data, I need to pre-process that url and swap `<id>` with whatever the user is currently previewing in the CMS, so the payload comes back accurately.  For good measure, this actually uses the FULL `urlSwap`, so the user is free to use any other variable between brackets that they wish to use (e.g. `&name=<name>`).

For the ez viz builder, this is actually much more complex.  It's simple enough to swap in the `<id>` and other vars in the API URL when the user clicks fetch (just as before, with generators). However, remember that in a viz we are not storing database rows, we are **authoring javascript** that will be executed.  This means that I need to post-process the URL, so that if the user enters something like `/api?id=<id>` this will compile down to 

```
data: `/api?id=${variables.id}` 
```

so that the **javascript** compiles properly for the viz config.  This actually adds a lot more power to the kind of vizes that can be built with the ez viz builder, because you can load up the URL with whatever variable switches you want.