### PR TITLE
fixes bug that prevented user input after backspacing

### DIFF
--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -57,8 +57,10 @@ class TextCard extends Component {
     const {type, fields, plainfields} = this.props;
     const {minData} = this.state;
     const payload = {id: minData.id};
-    fields.forEach(field => payload[field] = minData[field]);
-    if (plainfields) plainfields.forEach(field => payload[field] = minData[field]);
+    // For some reason, an empty quill editor reports its contents as <p><br></p>. Do not save 
+    // this to the database - save an empty string instead.
+    fields.forEach(field => payload[field] = minData[field] === "<p><br></p>" ? "" : minData[field]);
+    if (plainfields) plainfields.forEach(field => payload[field] = minData[field] === "<p><br></p>" ? "" : minData[field]);
     payload.allowed = minData.allowed;
     axios.post(`/api/cms/${type}/update`, payload).then(resp => {
       if (resp.status === 200) {

--- a/packages/cms/src/components/editors/TextEditor.jsx
+++ b/packages/cms/src/components/editors/TextEditor.jsx
@@ -32,7 +32,7 @@ class TextEditor extends Component {
 
   handleEditor(field, t) {
     const {data} = this.state;
-    if (t === "<p><br></p>") t = "";
+    // if (t === "<p><br></p>") t = "";
     data[field] = t;
     this.setState({data});
   }


### PR DESCRIPTION
The Quill editor, when blank, reports its contents as `<p><br></p>`.  In order to not save this to the db, we had been manually overriding this by setting the Quill contents to `""` whenever the above pattern was seen.

However, setting the quill contents to `""` causes a range error, such that if the user backspaces the contents down to nothing, they cannot regain control of the editor until it is remounted.  

This circumvents the problem by allowing the `<p><br></p>` to exist while editing, and simply stripping it before shipping to the db.