### PR TITLE
adds  to possible payload returns for search results

### DIFF
--- a/packages/cms/src/components/editors/SimpleGeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/SimpleGeneratorEditor.jsx
@@ -36,7 +36,9 @@ export default class SimpleGeneratorEditor extends Component {
     // If a simple config has been provided, then the user has used simple mode in the past.
     // Populate the simple menu accordingly and make it the default mode.
     let objects = [];
-    const pl = payload.data ? payload.data : payload;
+    let pl = payload;
+    if (payload.results) pl = payload.results;
+    if (payload.data) pl = payload.data;
     if (simpleConfig) {
       objects = simpleConfig.map((objArr, i) =>
         objArr.map(o => ({
@@ -117,7 +119,9 @@ export default class SimpleGeneratorEditor extends Component {
   rebuild() {
     const {payload} = this.props;
     if (payload.error) return;
-    const pl = payload.data ? payload.data : payload;
+    let pl = payload;
+    if (payload.results) pl = payload.results;
+    if (payload.data) pl = payload.data;
     const objects = pl.map((obj, i) =>
       Object.keys(obj).map(k => ({
         use: true,

--- a/packages/cms/src/components/editors/SimpleGeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/SimpleGeneratorEditor.jsx
@@ -71,7 +71,9 @@ export default class SimpleGeneratorEditor extends Component {
   compileCode() {
     const {objects} = this.state;
     const {payload} = this.props;
-    const prepend = payload.data ? "resp.data" : "resp";
+    let prepend = "resp";
+    if (payload.results) prepend = "resp.results";
+    if (payload.data) prepend = "resp.data";
     const code =
     `return {${objects
       // For every object that was returned in the payload (represented as an array of keys), and the index of that object


### PR DESCRIPTION
Simple mode was breaking for searches on the `search` table because it uses `results` instead of `data`.  This handles that case.