### PR TITLE
[core] Bundle/code splitting

### DIFF
--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -3,13 +3,13 @@ import {Route, IndexRoute} from "react-router";
 
 import App from "App";
 import Home from "pages/Home";
-import Slug from "pages/Slug";
+// import Slug from "pages/Slug";
 import Login from "pages/Login";
 import SignUp from "pages/SignUp";
-import Profile from "profile/Profile";
+// import Profile from "profile/Profile";
 import Error from "pages/NotFound";
 
-import {Reset, UserAdmin} from "../src";
+import {Reset, UserAdmin, loadComponent} from "../src";
 
 /** */
 function checkForId(nextState, replaceState) {
@@ -32,6 +32,9 @@ class Wrapper extends React.Component {
     return <div id="Wrapper">{this.props.children}</div>;
   }
 }
+
+const Slug = loadComponent(() => import("pages/Slug"));
+const Profile = loadComponent(() => import("profile/Profile"));
 
 /** */
 export default function RouteCreate() {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "grizzly": "^2.1.5",
     "hard-source-webpack-plugin": "^0.13.1",
     "helmet": "^3.9.0",
+    "html-webpack-plugin": "^3.2.0",
     "i18next": "^10.0.7",
     "i18next-express-middleware": "^1.7.0",
     "i18next-node-fs-backend": "^2.1.1",

--- a/src/helpers/loadComponent.js
+++ b/src/helpers/loadComponent.js
@@ -1,13 +1,23 @@
 import React from "react";
 
+function MiniLoading(props) {
+  return React.createElement("div", {className: "mini-loading"}, "Loading...");
+}
+
 function loadComponent(componentLoader) {
+  let Component;
+  if (typeof window === "undefined") {
+    componentLoader().then(c => {
+      Component = c.default;
+    });
+  }
   return class extends React.PureComponent {
-    static preneed = [componentLoader];
-    static need = [componentLoader];
-    static postneed = [componentLoader];
+    static preneed = Component ? Component.preneed : [componentLoader];
+    static need = Component ? Component.need : [componentLoader];
+    static postneed = Component ? Component.postneed : [componentLoader];
 
     state = {
-      Component: null
+      Component: Component || null
     };
 
     componentDidMount() {
@@ -20,9 +30,9 @@ function loadComponent(componentLoader) {
       const {Component} = this.state;
       return Component
         ? React.createElement(Component, this.props)
-        : React.createElement("div", {}, "Loading...");
+        : React.createElement(MiniLoading, this.props);
     }
-  }
+  };
 }
 
 export default loadComponent;

--- a/src/helpers/loadComponent.js
+++ b/src/helpers/loadComponent.js
@@ -1,0 +1,28 @@
+import React from "react";
+
+function loadComponent(componentLoader) {
+  return class extends React.PureComponent {
+    static preneed = [componentLoader];
+    static need = [componentLoader];
+    static postneed = [componentLoader];
+
+    state = {
+      Component: null
+    };
+
+    componentDidMount() {
+      componentLoader().then(module => {
+        this.setState({Component: module.default});
+      });
+    }
+
+    render() {
+      const {Component} = this.state;
+      return Component
+        ? React.createElement(Component, this.props)
+        : React.createElement("div", {}, "Loading...");
+    }
+  }
+}
+
+export default loadComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -21,3 +21,4 @@ export {consts};
 
 // Helpers
 export {default as cubeFold} from "./helpers/cubeFold";
+export {default as loadComponent} from "./helpers/loadComponent";

--- a/src/middlewares/preRenderMiddleware.js
+++ b/src/middlewares/preRenderMiddleware.js
@@ -1,38 +1,55 @@
 import React from "react";
 
 export default function preRenderMiddleware(store, {components, params}) {
-
   const data = store.data || {},
-        debug = process.env.NODE_ENV === "development",
-        dispatch = store.dispatch;
+    debug = process.env.NODE_ENV === "development",
+    dispatch = store.dispatch;
 
   function parseComponents(str) {
+    function needListFlattening(arr, component) {
+      (component[str] || []).forEach(n => {
+        if (n.WrappedComponent) n = n.WrappedComponent;
+        if (React.Component.isPrototypeOf(n)) arr = arr.concat(n[str] || []);
+        else if (typeof n === "function") arr.push(n);
+      });
+      return arr;
+    }
+
+    function needListFiltering(need) {
+      return need.key && need.key in data ? false : ((data[need.key] = "loading"), true);
+    }
+
+    function needListDispatching(need) {
+      const action = need(params, store.getState());
+      if (typeof action.then === "function") {
+        return action.then(module => {
+          const needs = []
+            .concat(module.default || [])
+            .filter(Boolean)
+            .reduce(needListFlattening, [])
+            .filter(needListFiltering)
+            .map(needListDispatching);
+          return Promise.all(needs);
+        });
+      }
+      if (debug && action.promise) {
+        action.promise = action.promise.catch(err => {
+          console.error(`\n\n 🛑  ${str.toUpperCase()} PROMISE ERROR\n`);
+          if (action.description) console.error(`${action.description}\n`);
+          console.error(err.stack);
+        });
+      }
+      return dispatch(action);
+    }
+
     return components
       .filter(Boolean)
-      .reduce((arr, component) => {
-        (component[str] || []).forEach(n => {
-          if (n.WrappedComponent) n = n.WrappedComponent;
-          if (React.Component.isPrototypeOf(n)) arr = arr.concat(n[str] || []);
-          else if (typeof n === "function") arr.push(n);
-        });
-        return arr;
-      }, [])
-      .filter(need => need.key && need.key in data ? false : (data[need.key] = "loading", true))
-      .map(need => {
-        const action = need(params, store.getState());
-        if (debug && action.promise) {
-          action.promise = action.promise.catch(err => {
-            console.error(`\n\n 🛑  ${str.toUpperCase()} PROMISE ERROR\n`);
-            if (action.description) console.error(`${action.description}\n`);
-            console.error(err.stack);
-          });
-        }
-        return dispatch(action);
-      });
+      .reduce(needListFlattening, [])
+      .filter(needListFiltering)
+      .map(needListDispatching);
   }
 
   return Promise.all(parseComponents("preneed"))
     .then(() => Promise.all(parseComponents("need")))
     .then(() => Promise.all(parseComponents("postneed")));
-
 }

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -76,7 +76,7 @@ const baseTag = process.env.CANON_BASE_URL === undefined ? ""
 function getGeneratedTags(base) {
   let headLink = [`<link rel="stylesheet" type="text/css" href="/assets/styles.css" />`];
   let bodyScripts = [`<script type="text/javascript" src="/assets/app.js"></script>`];
-  if (process.env.NODE_ENV == "production") {
+  if (!__DEV__) {
     const filePath = path.join(process.cwd(), 'static/assets/index.html');
     const html = fs.readFileSync(filePath).toString();
     headLink = html.match(/<link [^>]+>/g) || [];

--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -35,6 +35,7 @@ module.exports = {
   },
   plugins: [
     new webpack.ProgressPlugin(progress),
+    new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
     new MiniCssExtractPlugin({
       filename: "styles.css"
     }),

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -1,4 +1,5 @@
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin,
+      HtmlWebpackPlugin = require("html-webpack-plugin"),
       InlineEnviromentVariablesPlugin = require("inline-environment-variables-webpack-plugin"),
       MiniCssExtractPlugin = require("mini-css-extract-plugin"),
       appDir = process.cwd(),
@@ -22,6 +23,17 @@ module.exports = [
       filename: "[name].js",
       publicPath
     },
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+        cacheGroups: {
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors'
+          }
+        }
+      }
+    },
     module: {
       rules: commonLoaders({extract: true})
     },
@@ -44,7 +56,8 @@ module.exports = [
         analyzerMode: "static",
         openAnalyzer: false,
         reportFilename: "../reports/webpack-prod-client.html"
-      })
+      }),
+      new HtmlWebpackPlugin(),
     ],
     stats: {
       entrypoints: false,

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -27,6 +27,11 @@ module.exports = [
       splitChunks: {
         chunks: 'all',
         cacheGroups: {
+          d3plus: {
+            priority: 10,
+            test: /d3plus|blueprintjs/,
+            name: 'bigvendors'
+          },
           vendor: {
             test: /[\\/]node_modules[\\/]/,
             name: 'vendors'
@@ -86,6 +91,7 @@ module.exports = [
       extensions: [".js", ".jsx", ".css"]
     },
     plugins: [
+      new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
       new MiniCssExtractPlugin({
         filename: "server.css"
       }),

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -20,17 +20,23 @@ module.exports = [
     entry: {app: "./client"},
     output: {
       path: assetsPath,
-      filename: "[name].js",
+      filename: "app.js",
+      chunkFilename: "[name].app.js",
       publicPath
     },
     optimization: {
       splitChunks: {
         chunks: 'all',
         cacheGroups: {
-          d3plus: {
+          blueprint: {
             priority: 10,
-            test: /d3plus|blueprintjs/,
-            name: 'bigvendors'
+            test: /blueprintjs/,
+            name: 'bp3'
+          },
+          d3plus: {
+            priority: 9,
+            test: /d3plus/,
+            name: 'd3plus'
           },
           vendor: {
             test: /[\\/]node_modules[\\/]/,
@@ -49,7 +55,7 @@ module.exports = [
     plugins: [
       new MiniCssExtractPlugin({
         filename: 'styles.css',
-        chunkFilename: 'styles.[id].css',
+        chunkFilename: '[name].styles.css',
       }),
       new webpack.DefinePlugin(Object.keys(process.env)
         .filter(e => e.startsWith("CANON_CONST_"))

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -43,7 +43,8 @@ module.exports = [
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: "styles.css"
+        filename: 'styles.css',
+        chunkFilename: 'styles.[id].css',
       }),
       new webpack.DefinePlugin(Object.keys(process.env)
         .filter(e => e.startsWith("CANON_CONST_"))
@@ -57,7 +58,7 @@ module.exports = [
         openAnalyzer: false,
         reportFilename: "../reports/webpack-prod-client.html"
       }),
-      new HtmlWebpackPlugin(),
+      new HtmlWebpackPlugin()
     ],
     stats: {
       entrypoints: false,
@@ -86,7 +87,7 @@ module.exports = [
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: "styles.css"
+        filename: "server.css"
       }),
       // new webpack.optimize.UglifyJsPlugin({compressor: {warnings: false}, mangle: {keep_fnames: true}}),
       new webpack.DefinePlugin(Object.keys(process.env)


### PR DESCRIPTION
This enables basic bundle splitting for vendor code. More fine grained splitting can be achieved following documentation, but on my tests, webpack is smart enough.
Chunk injection will be required for future configurations of bundle and code splitting.