### PR TITLE
wraps formatters in try-catch to avoid js crashes

### DIFF
--- a/packages/cms/src/api/formatters.js
+++ b/packages/cms/src/api/formatters.js
@@ -11,9 +11,16 @@ module.exports = function(app) {
         results = results.map(r => {
           r = r.toJSON();
           if (r.logic) {
-            let code = buble.transform(r.logic).code; 
-            if (code.startsWith("!")) code = code.slice(1);
-            r.logic = code;
+            // Formatters may be malformed. Wrap in a try/catch to avoid js crashes.
+            try {
+              let code = buble.transform(r.logic).code; 
+              if (code.startsWith("!")) code = code.slice(1);
+              r.logic = code;
+            }
+            catch (e) {
+              console.log("Error in Formatter Syntax: ", e.message);
+              r.logic = "return \"N/A\";";
+            }
           }
           return r;
         });

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -73,7 +73,14 @@ const formatters4eval = formatters => formatters.reduce((acc, f) => {
     ? f.name.toLowerCase()
     : f.name.replace(/^\w/g, chr => chr.toLowerCase());
 
-  acc[name] = FUNC.parse({logic: f.logic, vars: ["n"]}, acc);
+  // Formatters may be malformed. Wrap in a try/catch to avoid js crashes.
+  try {
+    acc[name] = FUNC.parse({logic: f.logic, vars: ["n"]}, acc);
+  }
+  catch (e) {
+    console.log("Server-side Malformed Formatter encountered: ", e.message);
+    acc[name] = FUNC.parse({logic: "return \"N/A\";", vars: ["n"]}, acc);
+  }
 
   return acc;
 


### PR DESCRIPTION
When compiling formatters, they may be malformed.  These runtime errors can bring down entire sites. This PR wraps all formatter logic in try/catch to prevent this.

Note that this must take place in TWO places:

1) In `/api/formatters`, we use `buble` to transpile the code to ES5 for the front-end. 

2) On the actual server-side formatter logic (when the application hits `/api/variables..` for example), when the code gets "turned into real functions" by `formatters4eval`.

This catches errors in both locations. 

Closes #418