### PR TITLE
fixes bug using properties with logiclayer

### DIFF
--- a/packages/logiclayer/src/api/logiclayer.js
+++ b/packages/logiclayer/src/api/logiclayer.js
@@ -530,7 +530,7 @@ module.exports = function(app) {
                   if (properties.includes(prop)) {
                     const propString = `${dimension}, ${hierarchy}, ${prop}`;
                     if (logging) console.log(`Property: ${propString}`);
-                    query.property(dimension, hierarchy, prop);
+                    query.property(dimension, level, prop);
                   }
                 });
               }

--- a/packages/logiclayer/src/api/logiclayer.js
+++ b/packages/logiclayer/src/api/logiclayer.js
@@ -528,7 +528,7 @@ module.exports = function(app) {
                 query.drilldown(dimension, hierarchy, level);
                 (properties.length && d.properties ? d.properties : []).forEach(prop => {
                   if (properties.includes(prop)) {
-                    const propString = `${dimension}, ${hierarchy}, ${prop}`;
+                    const propString = `${dimension}, ${level}, ${prop}`;
                     if (logging) console.log(`Property: ${propString}`);
                     query.property(dimension, level, prop);
                   }


### PR DESCRIPTION
This bug was discovered adding custom `properties` with logiclayer. 

To solve it, I changed `hierarchy` by `level`, because the property is related with the Level instead of the Hierarchy. 

We didn't have the issue in DataUSA because the hierarchy name was the same with the level name. (Example: `University`)