### PR TITLE
[cms] Issue 468 - adds profile levels/hierarchy

### DIFF
--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -379,7 +379,8 @@ module.exports = function(app) {
 
   app.post("/api/cms/profile/newScaffold", isEnabled, (req, res) => {
     const profileData = req.body;
-    db.profile.create({slug: profileData.slug, ordering: profileData.ordering, dimension: profileData.dimName}).then(profile => {
+    console.log("why tho", profileData);
+    db.profile.create({slug: profileData.slug, ordering: profileData.ordering, dimension: profileData.dimName, levels: profileData.levels}).then(profile => {
       db.profile_content.create({id: profile.id, lang: envLoc}).then(() => {
         db.topic.create({ordering: 0, profile_id: profile.id}).then(topic => {
           db.topic_content.create({id: topic.id, lang: envLoc}).then(() => {

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -26,7 +26,8 @@ module.exports = function(app) {
     }
 
     if (dimension) where.dimension = dimension;
-    if (levels) where.heirarchy = {[sequelize.Op.in]: levels};
+    // In sequelize, the IN statement is implicit (hierarchy: ['Division', 'State'])
+    if (levels) where.hierarchy = levels.split(",");
     if (id) where.id = id.includes(",") ? id.split(",") : id;
 
     const rows = await db.search.findAll({

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -15,7 +15,7 @@ module.exports = function(app) {
     let {limit = "10"} = req.query;
     limit = parseInt(limit, 10);
 
-    const {id, q, dimension} = req.query;
+    const {id, q, dimension, levels} = req.query;
 
     if (q) {
       where[sequelize.Op.or] = [
@@ -26,6 +26,7 @@ module.exports = function(app) {
     }
 
     if (dimension) where.dimension = dimension;
+    if (levels) where.heirarchy = {[sequelize.Op.in]: levels};
     if (id) where.id = id.includes(",") ? id.split(",") : id;
 
     const rows = await db.search.findAll({

--- a/packages/cms/src/components/Search/Search.jsx
+++ b/packages/cms/src/components/Search/Search.jsx
@@ -29,9 +29,10 @@ class Search extends Component {
       this.setState({active: true, results: [], userQuery});
     }
     else if (url) {
-      const {dimension, limit} = this.props;
+      const {dimension, limit, levels} = this.props;
       let fullUrl = `${url}?q=${userQuery}&limit=${limit}`;
       if (dimension) fullUrl += `&dimension=${dimension}`;
+      if (levels) fullUrl += `&levels=${levels.join()}`;
       this.setState({userQuery});
       axios.get(fullUrl)
         .then(res => res.data)

--- a/packages/cms/src/db/profile.js
+++ b/packages/cms/src/db/profile.js
@@ -12,7 +12,8 @@ module.exports = function(sequelize, db) {
         defaultValue: "new-profile-slug"
       },
       ordering: db.INTEGER,
-      dimension: db.STRING
+      dimension: db.STRING,
+      levels: db.ARRAY(db.TEXT)
     },
     {
       freezeTableName: true,

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -77,6 +77,7 @@ class ProfileBuilder extends Component {
       itemType: "profile",
       masterSlug: p.slug,
       masterDimension: p.dimension,
+      masterLevels: p.levels,
       data: p,
       childNodes: p.topics.map(t => {
         const defCon = t.content.find(c => c.lang === localeDefault);
@@ -88,6 +89,7 @@ class ProfileBuilder extends Component {
           itemType: "topic",
           masterSlug: p.slug,
           masterDimension: p.dimension,
+          masterLevels: p.levels,
           data: t
         };
       })
@@ -192,6 +194,7 @@ class ProfileBuilder extends Component {
     objTopic.data.ordering = loc;
     objTopic.masterSlug = parent.masterSlug;
     objTopic.masterDimension = parent.masterDimension;
+    objTopic.masterLevels = parent.masterLevels;
 
     const objProfile = {
       hasCaret: true,

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -338,7 +338,6 @@ class ProfileBuilder extends Component {
       // Use this to auto-populate the preview when the user changes profiles.
       const levels = node.masterLevels ? node.masterLevels.join() : false;
       const levelString = levels ? `&levels=${levels}` : "";
-      console.log("Searching: ", levelString);
       axios.get(`/api/search?q=&dimension=${node.masterDimension}${levelString}`).then(resp => {
         const preview = resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0].id : "";
         this.setState({currentNode: node, currentSlug: node.masterSlug, preview});

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -333,7 +333,10 @@ class ProfileBuilder extends Component {
     else {
       // An empty search string will automatically provide the highest z-index results.
       // Use this to auto-populate the preview when the user changes profiles.
-      axios.get(`/api/search?q=&dimension=${node.masterDimension}`).then(resp => {
+      const levels = node.masterLevels ? node.masterLevels.join() : false;
+      const levelString = levels ? `&levels=${levels}` : "";
+      console.log("Searching: ", levelString);
+      axios.get(`/api/search?q=&dimension=${node.masterDimension}${levelString}`).then(resp => {
         const preview = resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0].id : "";
         this.setState({currentNode: node, currentSlug: node.masterSlug, preview});
       });
@@ -363,6 +366,7 @@ class ProfileBuilder extends Component {
    */
   onCreateProfile(profileData) {
     profileData.ordering = this.state.nodes.length;
+    console.log(profileData);
     axios.post("/api/cms/profile/newScaffold", profileData).then(resp => {
       const profiles = resp.data;
       const profileModalOpen = false;
@@ -517,6 +521,7 @@ class ProfileBuilder extends Component {
           <Search
             render={d => <span onClick={this.onSelectPreview.bind(this, d)}>{d.name}</span>}
             dimension={currentNode.masterDimension}
+            levels={currentNode.masterLevels}
             limit={20}
           />
         </div>;

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -368,7 +368,6 @@ class ProfileBuilder extends Component {
    */
   onCreateProfile(profileData) {
     profileData.ordering = this.state.nodes.length;
-    console.log(profileData);
     axios.post("/api/cms/profile/newScaffold", profileData).then(resp => {
       const profiles = resp.data;
       const profileModalOpen = false;


### PR DESCRIPTION
This closes #468 by adding hierarchy (levels) to profiles.  The search endpoint now has a `?levels=Comma,Separated,Levels` option to filter your results by level.  This filtering is done implicitly in the CMS - if you are on a given profile, the search bar will only return levels that are appropriate for the currently open profile.

**IMPORTANT NOTE**: This includes a breaking database change (adds the `levels` column to the `profile` table).  When deployed on existing installs, this column will need to be created.

