### PR TITLE
Issue 481 - `canon_cms_` prefixing and canon-core table fix

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -243,7 +243,7 @@ async function start() {
     }
     if (dbDetect) {
       const {db} = app.settings;
-      await db.sync({alter: true})
+      await db.sync()
         .then(({models}) => {
           const seeds = [];
           Object.keys(models).forEach(name => {

--- a/packages/cms/src/db/author.js
+++ b/packages/cms/src/db/author.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "story",
+          model: "canon_cms_story",
           key: "id"
         }
       },

--- a/packages/cms/src/db/author.js
+++ b/packages/cms/src/db/author.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_author",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/author_content.js
+++ b/packages/cms/src/db/author_content.js
@@ -37,6 +37,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_author_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/author_content.js
+++ b/packages/cms/src/db/author_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "author",
+          model: "canon_cms_author",
           key: "id"
         }
       },

--- a/packages/cms/src/db/formatter.js
+++ b/packages/cms/src/db/formatter.js
@@ -25,6 +25,7 @@ module.exports = function(sequelize, db) {
       }
     },
     {
+      tableName: "canon_cms_formatter",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/generator.js
+++ b/packages/cms/src/db/generator.js
@@ -41,6 +41,7 @@ module.exports = function(sequelize, db) {
       }
     },
     {
+      tableName: "canon_cms_generator",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/generator.js
+++ b/packages/cms/src/db/generator.js
@@ -35,7 +35,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "profile",
+          model: "canon_cms_profile",
           key: "id"
         }
       }

--- a/packages/cms/src/db/images.js
+++ b/packages/cms/src/db/images.js
@@ -16,6 +16,7 @@ module.exports = function(sequelize, db) {
       license: db.INTEGER
     },
     {
+      tableName: "canon_cms_images",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/materializer.js
+++ b/packages/cms/src/db/materializer.js
@@ -24,7 +24,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "profile",
+          model: "canon_cms_profile",
           key: "id"
         }
       }

--- a/packages/cms/src/db/materializer.js
+++ b/packages/cms/src/db/materializer.js
@@ -30,6 +30,7 @@ module.exports = function(sequelize, db) {
       }
     },
     {
+      tableName: "canon_cms_materializer",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/profile.js
+++ b/packages/cms/src/db/profile.js
@@ -16,6 +16,7 @@ module.exports = function(sequelize, db) {
       levels: db.ARRAY(db.TEXT)
     },
     {
+      tableName: "canon_cms_profile",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/profile_content.js
+++ b/packages/cms/src/db/profile_content.js
@@ -29,6 +29,7 @@ module.exports = function(sequelize, db) {
       }
     },
     {
+      tableName: "canon_cms_profile_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/profile_content.js
+++ b/packages/cms/src/db/profile_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "profile",
+          model: "canon_cms_profile",
           key: "id"
         }
       },

--- a/packages/cms/src/db/search.js
+++ b/packages/cms/src/db/search.js
@@ -26,6 +26,7 @@ module.exports = function(sequelize, db) {
       imageId: db.INTEGER
     },
     {
+      tableName: "canon_cms_search",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/selector.js
+++ b/packages/cms/src/db/selector.js
@@ -38,6 +38,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_selector",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/selector.js
+++ b/packages/cms/src/db/selector.js
@@ -19,7 +19,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "topic",
+          model: "canon_cms_topic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/story.js
+++ b/packages/cms/src/db/story.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_story",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/story_content.js
+++ b/packages/cms/src/db/story_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "story",
+          model: "canon_cms_story",
           key: "id"
         }
       },

--- a/packages/cms/src/db/story_content.js
+++ b/packages/cms/src/db/story_content.js
@@ -29,6 +29,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_story_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/story_description.js
+++ b/packages/cms/src/db/story_description.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "story",
+          model: "canon_cms_story",
           key: "id"
         }
       },

--- a/packages/cms/src/db/story_description.js
+++ b/packages/cms/src/db/story_description.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_story_description",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/story_description_content.js
+++ b/packages/cms/src/db/story_description_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_story_description_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/story_description_content.js
+++ b/packages/cms/src/db/story_description_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "story_description",
+          model: "canon_cms_story_description",
           key: "id"
         }
       },

--- a/packages/cms/src/db/story_footnote.js
+++ b/packages/cms/src/db/story_footnote.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "story",
+          model: "canon_cms_story",
           key: "id"
         }
       },

--- a/packages/cms/src/db/story_footnote.js
+++ b/packages/cms/src/db/story_footnote.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_story_footnote",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/story_footnote_content.js
+++ b/packages/cms/src/db/story_footnote_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "story_footnote",
+          model: "canon_cms_story_footnote",
           key: "id"
         }
       },

--- a/packages/cms/src/db/story_footnote_content.js
+++ b/packages/cms/src/db/story_footnote_content.js
@@ -25,6 +25,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_story_footnote_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic.js
+++ b/packages/cms/src/db/storytopic.js
@@ -26,6 +26,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_storytopic",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic.js
+++ b/packages/cms/src/db/storytopic.js
@@ -15,7 +15,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "story",
+          model: "canon_cms_story",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_content.js
+++ b/packages/cms/src/db/storytopic_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_storytopic_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_content.js
+++ b/packages/cms/src/db/storytopic_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "storytopic",
+          model: "canon_cms_storytopic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_description.js
+++ b/packages/cms/src/db/storytopic_description.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_storytopic_description",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_description.js
+++ b/packages/cms/src/db/storytopic_description.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "storytopic",
+          model: "canon_cms_storytopic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_description_content.js
+++ b/packages/cms/src/db/storytopic_description_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "storytopic_description",
+          model: "canon_cms_storytopic_description",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_description_content.js
+++ b/packages/cms/src/db/storytopic_description_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_storytopic_description_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_stat.js
+++ b/packages/cms/src/db/storytopic_stat.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_storytopic_stat",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_stat.js
+++ b/packages/cms/src/db/storytopic_stat.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "storytopic",
+          model: "canon_cms_storytopic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_stat_content.js
+++ b/packages/cms/src/db/storytopic_stat_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "storytopic_stat",
+          model: "canon_cms_storytopic_stat",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_stat_content.js
+++ b/packages/cms/src/db/storytopic_stat_content.js
@@ -33,6 +33,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_storytopic_stat_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_subtitle.js
+++ b/packages/cms/src/db/storytopic_subtitle.js
@@ -18,6 +18,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_storytopic_subtitle",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_subtitle.js
+++ b/packages/cms/src/db/storytopic_subtitle.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "storytopic",
+          model: "canon_cms_storytopic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_subtitle_content.js
+++ b/packages/cms/src/db/storytopic_subtitle_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_storytopic_subtitle_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/storytopic_subtitle_content.js
+++ b/packages/cms/src/db/storytopic_subtitle_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "storytopic_subtitle",
+          model: "canon_cms_storytopic_subtitle",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_visualization.js
+++ b/packages/cms/src/db/storytopic_visualization.js
@@ -15,7 +15,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "storytopic",
+          model: "canon_cms_storytopic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/storytopic_visualization.js
+++ b/packages/cms/src/db/storytopic_visualization.js
@@ -22,6 +22,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_storytopic_visualization",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic.js
+++ b/packages/cms/src/db/topic.js
@@ -30,6 +30,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_topic",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic.js
+++ b/packages/cms/src/db/topic.js
@@ -15,7 +15,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "profile",
+          model: "canon_cms_profile",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_content.js
+++ b/packages/cms/src/db/topic_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_topic_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_content.js
+++ b/packages/cms/src/db/topic_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "topic",
+          model: "canon_cms_topic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_description.js
+++ b/packages/cms/src/db/topic_description.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "topic",
+          model: "canon_cms_topic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_description.js
+++ b/packages/cms/src/db/topic_description.js
@@ -22,6 +22,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_topic_description",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_description_content.js
+++ b/packages/cms/src/db/topic_description_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "topic_description",
+          model: "canon_cms_topic_description",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_description_content.js
+++ b/packages/cms/src/db/topic_description_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_topic_description_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_stat.js
+++ b/packages/cms/src/db/topic_stat.js
@@ -22,6 +22,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_topic_stat",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_stat.js
+++ b/packages/cms/src/db/topic_stat.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "topic",
+          model: "canon_cms_topic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_stat_content.js
+++ b/packages/cms/src/db/topic_stat_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "topic_stat",
+          model: "canon_cms_topic_stat",
           key: "id"
         }        
       },

--- a/packages/cms/src/db/topic_stat_content.js
+++ b/packages/cms/src/db/topic_stat_content.js
@@ -33,6 +33,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_topic_stat_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_subtitle.js
+++ b/packages/cms/src/db/topic_subtitle.js
@@ -22,6 +22,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_topic_subtitle",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_subtitle.js
+++ b/packages/cms/src/db/topic_subtitle.js
@@ -11,7 +11,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "topic",
+          model: "canon_cms_topic",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_subtitle_content.js
+++ b/packages/cms/src/db/topic_subtitle_content.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, db) {
         primaryKey: true,
         onDelete: "cascade",
         references: {
-          model: "topic_subtitle",
+          model: "canon_cms_topic_subtitle",
           key: "id"
         }
       },

--- a/packages/cms/src/db/topic_subtitle_content.js
+++ b/packages/cms/src/db/topic_subtitle_content.js
@@ -21,6 +21,7 @@ module.exports = function(sequelize, db) {
       }
     }, 
     {
+      tableName: "canon_cms_topic_subtitle_content",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_visualization.js
+++ b/packages/cms/src/db/topic_visualization.js
@@ -34,6 +34,7 @@ module.exports = function(sequelize, db) {
       ordering: db.INTEGER
     }, 
     {
+      tableName: "canon_cms_topic_visualization",
       freezeTableName: true,
       timestamps: false
     }

--- a/packages/cms/src/db/topic_visualization.js
+++ b/packages/cms/src/db/topic_visualization.js
@@ -15,7 +15,7 @@ module.exports = function(sequelize, db) {
         type: db.INTEGER,
         onDelete: "cascade",
         references: {
-          model: "topic",
+          model: "canon_cms_topic",
           key: "id"
         }
       },


### PR DESCRIPTION
This PR closes #481 by adding `canon_cms_` prefix to all tables, making upgrade/removal easier for devops to know which tables are cms-related.

**NOTE 1**: This is a breaking upgrade for existing CMSes - they need to rename all their tables with `canon_cms_` prepended on the table names.

**NOTE 2**: This also contains a change for canon_core. It removes the `{alter: true}` option from the db.sync that is performed on `npm run dev` table creation.  I made this change for two reasons:

- The sequelize docs state [here](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-method-sync) that `{alter: true}` is not recommended for production as it paves columns whose data type has changed
- The thread [here](https://github.com/sequelize/sequelize/issues/8984) indicates that the usage of `{alter: true}` is the reason for the known bug in canon_core which causes tables to not be created if ANY tables exist in the db (due to alter:true attempting to re-create an existing index, thereby failing the table inserts).

