### PR TITLE
fixes bug in cms viz render and model seeding

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -246,9 +246,12 @@ async function start() {
       await db.sync()
         .then(({models}) => {
           const seeds = [];
-          Object.keys(models).forEach(name => {
+          Object.keys(models).forEach(async name => {
             const model = models[name];
-            if (model.seed) {
+            const count = await model.count();
+            const isEmpty = count === 0;
+            // Only populate a table with seed data if it is empty
+            if (model.seed && isEmpty) {
               seeds.push(model.bulkCreate(model.seed));
             }
           });

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -112,7 +112,9 @@ class VisualizationCard extends Component {
     const {selectors, type, variables, parentArray, item, preview, locale, localeDefault} = this.props;
 
     minData.selectors = selectors;
-    const {logic} = varSwapRecursive(minData, formatters, variables);
+    let logic = false;
+    // Only perform a viz render if the user is finished editing and has closed the window.
+    if (!isOpen) logic = varSwapRecursive(minData, formatters, variables).logic;
     const re = new RegExp(/height\:[\s]*([0-9]+)/g);
     let height = re.exec(logic);
     height = height ? height[1] : "400";
@@ -183,7 +185,7 @@ class VisualizationCard extends Component {
             onSave={this.save.bind(this)}
           />
         </Dialog>
-        { logic ? <Viz config={{logic}} locale={locale} variables={variables} configOverride={{height, scrollContainer: "#item-editor"}} options={false} /> : <p>No configuration defined.</p> }
+        { logic && !isOpen ? <Viz config={{logic}} locale={locale} variables={variables} configOverride={{height, scrollContainer: "#item-editor"}} options={false} /> : <p>No configuration defined.</p> }
       </div>
     );
   }

--- a/packages/cms/src/utils/varSwapRecursive.js
+++ b/packages/cms/src/utils/varSwapRecursive.js
@@ -40,9 +40,17 @@ const varSwapRecursive = (sourceObj, formatterFunctions, variables, query = {}, 
         obj[skey] = varSwap(obj[skey], formatterFunctions, variables);
         // If the key is named logic, this is javascript. Transpile it for IE.
         if (skey === "logic") {
-          let code = buble.transform(obj[skey]).code; 
-          if (code.startsWith("!")) code = code.slice(1);
-          obj[skey] = code;
+          try {
+            let code = buble.transform(obj[skey]).code; 
+            if (code.startsWith("!")) code = code.slice(1);
+            obj[skey] = code;
+          }
+          catch (e) {
+            console.log("Error in ES5 transpiling in varSwapRecursive");
+            // Note: There is no need to do anything special here. In Viz/index.jsx, we will eventually run propify.
+            // Propify handles malformed js and sets an error instead of attempting to render the viz, so we can simply
+            // leave the key as malformed es6, let propify catch it later, and pass the error to the front-end.
+          }
         }
       }
       // If this property is an array, recursively swap all elements


### PR DESCRIPTION
This PR addresses a few problems:

1) The babel transpiler for ES6->ES5 (for IE) was not wrapped in a try catch. This caused a red screen as soon as you typed a breaking letter into a viz in the CMS
2) Expanding on the problem above, typing letters in the CMS **should not** be making live render changes to the viz underneath. This was likely causing perf problems. We now only render the viz when the window is not open (i.e., the user has pressed save to close the window)
3) There was no "is empty" check for the `seed` functionality in server.js, which was adding a brand new set of stock formatters on *every run*.  We now check to see that a table is empty before seeding it with data.