### PR TITLE
fixes selector to render variable in title card, fixes hard coded english language bug

### DIFF
--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -7,6 +7,7 @@ import MoveButtons from "../MoveButtons";
 import SelectorEditor from "../editors/SelectorEditor";
 import PropTypes from "prop-types";
 import deepClone from "../../utils/deepClone";
+import varSwap from "../../utils/varSwap";
 import "./SelectorCard.css";
 
 /**
@@ -111,6 +112,7 @@ class SelectorCard extends Component {
   render() {
     const {minData, isOpen, alertObj} = this.state;
     const {variables, parentArray, type} = this.props;
+    const {formatters} = this.context;
 
     if (!minData) return <Loading />;
 
@@ -132,7 +134,7 @@ class SelectorCard extends Component {
 
         {/* title & edit toggle button */}
         <h5 className="cms-card-header">
-          {minData.title}
+          {varSwap(minData.title, formatters, variables)}
           <button className="cms-button" onClick={this.openEditor.bind(this)}>
             Edit <span className="bp3-icon bp3-icon-cog" />
           </button>

--- a/packages/cms/src/profile/TopicEditor.jsx
+++ b/packages/cms/src/profile/TopicEditor.jsx
@@ -286,7 +286,7 @@ class TopicEditor extends Component {
               type="selector"
               onSave={() => this.forceUpdate()}
               onDelete={this.onDelete.bind(this)}
-              variables={variables.en}
+              variables={variables[localeDefault]}
               parentArray={minData.selectors}
               onMove={this.onMove.bind(this)}
             />


### PR DESCRIPTION
@cnavarreteliz requested that Selector titles be translatable. This already works by using a variable in `{{brackets}}` due to `varSwarRecursive`, however it still rendered poorly on the front of the card.  This PR fixes that.

Also, There was a hard-coded english language reference still in the codebase. This has been changed to the generic `localeDefault`.