### PR TITLE
Add formatter locale

### DIFF
--- a/packages/cms/app/pages/Profile.jsx
+++ b/packages/cms/app/pages/Profile.jsx
@@ -12,9 +12,9 @@ class Profile extends Component {
     const {variables} = profile;
     return {
       formatters: formatters.reduce((acc, d) => {
-        const f = Function("n", "libs", "formatters", d.logic);
+        const f = Function("n", "libs", "locale", "formatters", d.logic);
         const fName = d.name.replace(/^\w/g, chr => chr.toLowerCase());
-        acc[fName] = n => f(n, libs, acc);
+        acc[fName] = n => f(n, libs, locale, acc);
         return acc;
       }, {}),
       router,

--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -1,4 +1,4 @@
-import libs from "./utils/libs";
+import funcifyFormatterByLocale from "./utils/funcifyFormatterByLocale";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 import ProfileBuilder from "./profile/ProfileBuilder";
@@ -22,13 +22,7 @@ class Builder extends Component {
       localeDefault: false,
       secondaryLocale: false,
       // showLocale: false,
-
-      formatters: (props.formatters || []).reduce((acc, d) => {
-        const f = Function("n", "libs", "formatters", d.logic);
-        const fName = d.name.replace(/^\w/g, chr => chr.toLowerCase());
-        acc[fName] = n => f(n, libs, acc);
-        return acc;
-      }, {})
+      formatters: {}
     };
   }
 
@@ -40,14 +34,20 @@ class Builder extends Component {
     // env.CANON_LANGUAGES = false;
     // Retrieve the langs from canon vars, use it to build the second language select dropdown.
     const localeDefault = env.CANON_LANGUAGE_DEFAULT || "en";
+    const formatters = {};
+    formatters[localeDefault] = funcifyFormatterByLocale(this.props.formatters, localeDefault);
     if (env.CANON_LANGUAGES && env.CANON_LANGUAGES.includes(",")) {
       const locales = env.CANON_LANGUAGES.split(",").filter(l => l !== localeDefault);
       const secondaryLocale = locales[0];
-      this.setState({locales, secondaryLocale, localeDefault});
+      locales.forEach(locale => {
+        formatters[locale] = funcifyFormatterByLocale(this.props.formatters, locale);
+      });
+      this.setState({locales, formatters, secondaryLocale, localeDefault});
     }
     else {
-      this.setState({localeDefault});
+      this.setState({localeDefault, formatters});
     }
+    console.log(formatters);
   }
 
   getChildContext() {

--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -6,7 +6,6 @@ import StoryBuilder from "./story/StoryBuilder";
 import FormatterEditor from "./formatter/FormatterEditor";
 import {fetchData} from "@datawheel/canon-core";
 import {connect} from "react-redux";
-import {Switch} from "@blueprintjs/core";
 
 import "./cms.css";
 import "./themes/cms-dark.css";
@@ -47,7 +46,6 @@ class Builder extends Component {
     else {
       this.setState({localeDefault, formatters});
     }
-    console.log(formatters);
   }
 
   getChildContext() {

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -83,7 +83,7 @@ const storyReq = {
   ]
 };
 
-const formatters4eval = formatters => formatters.reduce((acc, f) => {
+const formatters4eval = (formatters, locale) => formatters.reduce((acc, f) => {
 
   const name = f.name === f.name.toUpperCase()
     ? f.name.toLowerCase()
@@ -91,11 +91,11 @@ const formatters4eval = formatters => formatters.reduce((acc, f) => {
 
   // Formatters may be malformed. Wrap in a try/catch to avoid js crashes.
   try {
-    acc[name] = FUNC.parse({logic: f.logic, vars: ["n"]}, acc);
+    acc[name] = FUNC.parse({logic: f.logic, vars: ["n"]}, acc, locale);
   }
   catch (e) {
     console.log("Server-side Malformed Formatter encountered: ", e.message);
-    acc[name] = FUNC.parse({logic: "return \"N/A\";", vars: ["n"]}, acc);
+    acc[name] = FUNC.parse({logic: "return \"N/A\";", vars: ["n"]}, acc, locale);
   }
 
   return acc;
@@ -230,7 +230,7 @@ module.exports = function(app) {
       .then(resp => {
         const [pid, attr, formatters, generators] = resp;
         // Create a hash table so the formatters are directly accessible by name
-        const formatterFunctions = formatters4eval(formatters);
+        const formatterFunctions = formatters4eval(formatters, locale);
         // Deduplicate generators that share an API endpoint
         const requests = Array.from(new Set(generators.map(g => g.api)));
         // Generators use <id> as a placeholder. Replace instances of <id> with the provided id from the URL
@@ -311,7 +311,7 @@ module.exports = function(app) {
         delete variables._genStatus;
         delete variables._matStatus;
         const formatters = resp[1];
-        const formatterFunctions = formatters4eval(formatters);
+        const formatterFunctions = formatters4eval(formatters, locale);
         const request = axios.get(`${origin}/api/internalprofile/${slug}${localeString}`);
         return Promise.all([variables, formatterFunctions, request]);
       })
@@ -362,7 +362,7 @@ module.exports = function(app) {
         delete variables._genStatus;
         delete variables._matStatus;
         const formatters = resp[1];
-        const formatterFunctions = formatters4eval(formatters);
+        const formatterFunctions = formatters4eval(formatters, locale);
         let topic = extractLocaleContent(resp[2], locale, "topic");
         topic = varSwapRecursive(topic, formatterFunctions, variables, req.query);
         if (topic.subtitles) topic.subtitles.sort(sorter);

--- a/packages/cms/src/components/Profile.jsx
+++ b/packages/cms/src/components/Profile.jsx
@@ -1,7 +1,6 @@
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 import {connect} from "react-redux";
-
 import {fetchData} from "@datawheel/canon-core";
 import Topic from "./Topic";
 import libs from "../utils/libs";
@@ -13,9 +12,9 @@ class Profile extends Component {
     const {variables} = profile;
     return {
       formatters: formatters.reduce((acc, d) => {
-        const f = Function("n", "libs", "formatters", d.logic);
+        const f = Function("n", "libs", "locale", "formatters", d.logic);
         const fName = d.name.replace(/^\w/g, chr => chr.toLowerCase());
-        acc[fName] = n => f(n, libs, acc);
+        acc[fName] = n => f(n, libs, locale, acc);
         return acc;
       }, {}),
       router,

--- a/packages/cms/src/components/Viz/index.jsx
+++ b/packages/cms/src/components/Viz/index.jsx
@@ -20,7 +20,13 @@ class Viz extends Component {
     const variables = this.props.variables || this.context.variables;
     const locale = this.props.locale || this.context.locale;
 
-    const formatters = this.context.formatters[locale];
+    // This Viz component may be embedded in two ways - as a VisualizationCard in the
+    // CMS, or as an actual Viz on a front-end site. In the former case, formatters
+    // is a lookup object of languages, so we must fetch the appropriate formatter set.
+    // In the latter, the locale is passed in based on params and then used in propify.
+    // Thus, we use a flat formatter list, passed down by Profile.jsx, not needing a 
+    // locale-nested format.    
+    const formatters = this.context.formatters[locale] || this.context.formatters;
 
     const {config, configOverride, className, options, slug, topic} = this.props;
 

--- a/packages/cms/src/components/Viz/index.jsx
+++ b/packages/cms/src/components/Viz/index.jsx
@@ -36,7 +36,7 @@ class Viz extends Component {
     // If the result of propify has an "error" property, then the provided javascript was malformed and propify
     // caught an error. Instead of attempting to render the viz, simply show the error to the user.
     if (vizProps.error) {
-      return <div>{`Error: ${vizProps.error}`}</div>;
+      return <div>{`Error in Viz index: ${vizProps.error}`}</div>;
     }
     vizProps.config = Object.assign(vizProps.config, configOverride);
 

--- a/packages/cms/src/components/Viz/index.jsx
+++ b/packages/cms/src/components/Viz/index.jsx
@@ -16,10 +16,11 @@ class Viz extends Component {
   }
 
   render() {
-    const {formatters} = this.context;
 
     const variables = this.props.variables || this.context.variables;
     const locale = this.props.locale || this.context.locale;
+
+    const formatters = this.context.formatters[locale];
 
     const {config, configOverride, className, options, slug, topic} = this.props;
 

--- a/packages/cms/src/components/cards/GeneratorCard.jsx
+++ b/packages/cms/src/components/cards/GeneratorCard.jsx
@@ -123,7 +123,7 @@ class GeneratorCard extends Component {
   }
 
   render() {
-    const {type, variables, item, parentArray, preview, locale, localeDefault} = this.props;
+    const {attr, type, variables, item, parentArray, preview, locale, localeDefault} = this.props;
     const {displayData, minData, isOpen, alertObj} = this.state;
 
     let description = "";
@@ -232,6 +232,7 @@ class GeneratorCard extends Component {
             <GeneratorEditor
               markAsDirty={this.markAsDirty.bind(this)}
               preview={preview}
+              attr={attr}
               locale={locale}
               data={minData}
               variables={variables}

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -111,8 +111,8 @@ class SelectorCard extends Component {
 
   render() {
     const {minData, isOpen, alertObj} = this.state;
-    const {variables, parentArray, type} = this.props;
-    const {formatters} = this.context;
+    const {variables, parentArray, type, locale} = this.props;
+    const formatters = this.context.formatters[locale];
 
     if (!minData) return <Loading />;
 

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -72,7 +72,7 @@ class TextCard extends Component {
 
   formatDisplay() {
     const {variables, selectors, locale} = this.props;
-    const {formatters} = this.context;
+    const formatters = this.context.formatters[locale];
 
     const minData = this.populateLanguageContent.bind(this)(this.state.minData);
     // Setting "selectors" here is pretty hacky. The varSwap needs selectors in order

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -108,8 +108,8 @@ class VisualizationCard extends Component {
 
     if (!minData) return <Loading />;
 
-    const {formatters} = this.context;
     const {selectors, type, variables, parentArray, item, preview, locale, localeDefault} = this.props;
+    const formatters = this.context.formatters[locale];
 
     minData.selectors = selectors;
     let logic = false;

--- a/packages/cms/src/components/editors/GeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/GeneratorEditor.jsx
@@ -104,12 +104,12 @@ class GeneratorEditor extends Component {
   previewPayload(forceSimple) {
     const {data} = this.state;
     const {api} = data;
-    const {preview, variables, locale} = this.props;
+    const {attr, preview, variables, locale} = this.props;
     if (api) {
       // The API will have an <id> in it that needs to be replaced with the current preview.
       // Use urlSwap to swap ANY instances of variables between brackets (e.g. <varname>)
       // With its corresponding value. Same goes for locale
-      const url = urlSwap(api, Object.assign({}, variables, {id: preview, locale}));
+      const url = urlSwap(api, Object.assign({}, attr, variables, {id: preview, locale}));
       axios.get(url).then(resp => {
         const payload = resp.data;
         let {simple} = this.state;

--- a/packages/cms/src/components/editors/TextEditor.jsx
+++ b/packages/cms/src/components/editors/TextEditor.jsx
@@ -69,7 +69,7 @@ class TextEditor extends Component {
 
     const {data, fields} = this.state;
     const {variables, locale} = this.props;
-    const {formatters} = this.context;
+    const formatters = this.context.formatters[locale];
 
     if (!data || !fields || !variables || !formatters) return null;
 

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -67,8 +67,8 @@ class ProfileBuilder extends Component {
 
   buildNodes(openNode) {
     const {profiles} = this.state;
-    const {stripHTML} = this.context.formatters;
     const {localeDefault} = this.props;
+    const {stripHTML} = this.context.formatters[localeDefault];
     // const {profileSlug, topicSlug} = this.props.pathObj;
     const nodes = profiles.map(p => ({
       id: `profile${p.id}`,
@@ -142,8 +142,8 @@ class ProfileBuilder extends Component {
     const {nodes} = this.state;
     const {variablesHash, currentSlug} = this.state;
     const {localeDefault} = this.props;
-    const {stripHTML} = this.context.formatters;
-    const {formatters} = this.context;
+    const formatters = this.context.formatters[localeDefault];
+    const {stripHTML} = formatters;
     const variables = variablesHash[currentSlug] && variablesHash[currentSlug][localeDefault] ? deepClone(variablesHash[currentSlug][localeDefault]) : null;
     n = this.locateNode(n.itemType, n.data.id);
     let parent;
@@ -273,7 +273,7 @@ class ProfileBuilder extends Component {
   deleteItem(n) {
     const {nodes} = this.state;
     const {localeDefault} = this.props;
-    const {stripHTML} = this.context.formatters;
+    const {stripHTML} = this.context.formatters[localeDefault];
     // If this method is running, then the user has clicked "Confirm" in the Deletion Alert. Setting the state of
     // nodeToDelete back to false will close the Alert popover.
     const nodeToDelete = false;
@@ -402,8 +402,8 @@ class ProfileBuilder extends Component {
     const {nodes} = this.state;
     const {variablesHash, currentSlug} = this.state;
     const {localeDefault} = this.props;
-    const {stripHTML} = this.context.formatters;
-    const {formatters} = this.context;
+    const formatters = this.context.formatters[localeDefault];
+    const {stripHTML} = formatters;
     const variables = variablesHash[currentSlug] && variablesHash[currentSlug][localeDefault] ? deepClone(variablesHash[currentSlug][localeDefault]) : null;
     const node = this.locateNode.bind(this)(type, id);
     // Update the label based on the new value. If this is a topic, this is the only thing needed
@@ -443,8 +443,8 @@ class ProfileBuilder extends Component {
   formatTreeVariables() {
     const {variablesHash, currentSlug, nodes} = this.state;
     const {localeDefault} = this.props;
-    const {stripHTML} = this.context.formatters;
-    const {formatters} = this.context;
+    const formatters = this.context.formatters[localeDefault];
+    const {stripHTML} = formatters;
     const variables = variablesHash[currentSlug] && variablesHash[currentSlug][localeDefault] ? deepClone(variablesHash[currentSlug][localeDefault]) : null;
     const p = this.locateProfileNodeBySlug(currentSlug);
     p.label = varSwap(p.data.slug, formatters, variables);

--- a/packages/cms/src/profile/ProfileEditor.jsx
+++ b/packages/cms/src/profile/ProfileEditor.jsx
@@ -6,7 +6,6 @@ import Loading from "components/Loading";
 
 import GeneratorCard from "../components/cards/GeneratorCard";
 import TextCard from "../components/cards/TextCard";
-import MoveButtons from "../components/MoveButtons";
 
 import "./ProfileEditor.css";
 
@@ -167,6 +166,7 @@ class ProfileEditor extends Component {
               .map(g => <GeneratorCard
                 key={g.id}
                 item={g}
+                attr={minData.attr || {}}
                 locale={localeDefault}
                 localeDefault={localeDefault}
                 preview={preview}
@@ -186,6 +186,7 @@ class ProfileEditor extends Component {
                   <GeneratorCard
                     key={g.id}
                     item={g}
+                    attr={minData.attr || {}}
                     locale={locale}
                     localeDefault={localeDefault}
                     preview={preview}

--- a/packages/cms/src/profile/TopicEditor.jsx
+++ b/packages/cms/src/profile/TopicEditor.jsx
@@ -284,6 +284,7 @@ class TopicEditor extends Component {
               key={s.id}
               minData={s}
               type="selector"
+              locale={localeDefault}
               onSave={() => this.forceUpdate()}
               onDelete={this.onDelete.bind(this)}
               variables={variables[localeDefault]}

--- a/packages/cms/src/story/StoryBuilder.jsx
+++ b/packages/cms/src/story/StoryBuilder.jsx
@@ -44,7 +44,7 @@ class StoryBuilder extends Component {
   buildNodes(openNode) {
     const {stories} = this.state;
     const {localeDefault} = this.props;
-    const {stripHTML} = this.context.formatters;
+    const {stripHTML} = this.context.formatters[localeDefault];
     const nodes = stories.map(s => {
       const defCon = s.content.find(c => c.lang === localeDefault);
       const title = defCon && defCon.title ? defCon.title : s.slug;
@@ -110,8 +110,8 @@ class StoryBuilder extends Component {
 
   addItem(n, dir) {
     const {nodes} = this.state;
-    const {stripHTML} = this.context.formatters;
     const {localeDefault} = this.props;
+    const {stripHTML} = this.context.formatters[localeDefault];
     n = this.locateNode(n.itemType, n.data.id);
     let parentArray;
     if (n.itemType === "storytopic") {
@@ -222,8 +222,8 @@ class StoryBuilder extends Component {
 
   deleteItem(n) {
     const {nodes} = this.state;
-    const {stripHTML} = this.context.formatters;
     const {localeDefault} = this.props;
+    const {stripHTML} = this.context.formatters[localeDefault];
     n = this.locateNode(n.itemType, n.data.id);
     const nodeToDelete = false;
     // todo: instead of the piecemeal refreshes being done for each of these tiers - is it sufficient to run buildNodes again?
@@ -329,8 +329,8 @@ class StoryBuilder extends Component {
    */
   reportSave(type, id, newValue) {
     const {nodes} = this.state;
-    const {stripHTML} = this.context.formatters;
     const {localeDefault} = this.props;
+    const {stripHTML} = this.context.formatters[localeDefault];
     const node = this.locateNode.bind(this)(type, id);
     // Update the label based on the new value. If this is a section or a topic, this is the only thing needed
     if (node) {

--- a/packages/cms/src/utils/funcifyFormatterByLocale.js
+++ b/packages/cms/src/utils/funcifyFormatterByLocale.js
@@ -1,0 +1,19 @@
+const libs = require("./libs");
+
+/**
+ * Formatters are stored in the database as plaintext logic. Serverside, we use
+ * formatters4eval and FUNC.parse to turn them into "Real Functions." Client-side,
+ * we need to create a lookup object so that different CMS cards in different languages
+ * can view the different results of passing a different locale into the formatter
+ * This function creates a single "instance" of formatters for a given locale, 
+ * which can be added to that lookup object, keyed by its locale.
+ */
+const funcifyFormatterByLocale = (formatters, locale) => 
+  formatters.reduce((acc, d) => {
+    const f = Function("n", "libs", "locale", "formatters", d.logic);
+    const fName = d.name.replace(/^\w/g, chr => chr.toLowerCase());
+    acc[fName] = n => f(n, libs, locale, acc);
+    return acc;
+  }, {});
+
+module.exports = funcifyFormatterByLocale;


### PR DESCRIPTION
This PR closes #494 by:

- adding a search `attr` data object to the front end for use by `urlSwap`, allowing generators to use syntax like `hierarchy=<hierarchy>` (and any other variable from the search table).

- allowing the use of `locale` in formatters.