### PR TITLE
fixes bug in varSwapRecursive that caused levels to improperly turn into objects

### DIFF
--- a/packages/cms/src/utils/varSwapRecursive.js
+++ b/packages/cms/src/utils/varSwapRecursive.js
@@ -2,6 +2,28 @@ const selSwap = require("./selSwap");
 const varSwap = require("./varSwap");
 const buble = require("buble");
 
+const strSwap = (str, formatterFunctions, variables, selectors, isLogic) => {
+  // First, do a selector replace of the pattern [[Selector]]
+  str = selSwap(str, selectors);
+  // Replace all instances of the following pattern:  FormatterName{{VarToReplace}}
+  str = varSwap(str, formatterFunctions, variables);
+  // If the key is named logic, this is javascript. Transpile it for IE.
+  if (isLogic) {
+    try {
+      let code = buble.transform(str).code; 
+      if (code.startsWith("!")) code = code.slice(1);
+      str = code;
+    }
+    catch (e) {
+      console.log("Error in ES5 transpiling in varSwapRecursive");
+      // Note: There is no need to do anything special here. In Viz/index.jsx, we will eventually run propify.
+      // Propify handles malformed js and sets an error instead of attempting to render the viz, so we can simply
+      // leave the key as malformed es6, let propify catch it later, and pass the error to the front-end.
+    }
+  }
+  return str;
+};
+
 /* Given an object, a hashtable of formatting functions, and a lookup object full of variables
  * Replace every instance of {{var}} with its true value from the lookup object, and
  * apply the appropriate formatter
@@ -34,28 +56,22 @@ const varSwapRecursive = (sourceObj, formatterFunctions, variables, query = {}, 
     if (obj.hasOwnProperty(skey)) {
       // If this property is a string, replace all the vars
       if (typeof obj[skey] === "string") {
-        // First, do a selector replace of the pattern [[Selector]]
-        obj[skey] = selSwap(obj[skey], selectors);
-        // Replace all instances of the following pattern:  FormatterName{{VarToReplace}}
-        obj[skey] = varSwap(obj[skey], formatterFunctions, variables);
-        // If the key is named logic, this is javascript. Transpile it for IE.
-        if (skey === "logic") {
-          try {
-            let code = buble.transform(obj[skey]).code; 
-            if (code.startsWith("!")) code = code.slice(1);
-            obj[skey] = code;
-          }
-          catch (e) {
-            console.log("Error in ES5 transpiling in varSwapRecursive");
-            // Note: There is no need to do anything special here. In Viz/index.jsx, we will eventually run propify.
-            // Propify handles malformed js and sets an error instead of attempting to render the viz, so we can simply
-            // leave the key as malformed es6, let propify catch it later, and pass the error to the front-end.
-          }
-        }
+        obj[skey] = strSwap(obj[skey], formatterFunctions, variables, selectors, skey === "logic");
       }
       // If this property is an array, recursively swap all elements
       else if (Array.isArray(obj[skey])) {
-        obj[skey] = obj[skey].filter(allowed).map(o => varSwapRecursive(o, formatterFunctions, variables, query, selectors));
+        obj[skey] = obj[skey].filter(allowed).map(o => {
+          if (typeof o === "object") {
+            return varSwapRecursive(o, formatterFunctions, variables, query, selectors);
+          }
+          // If this is a string, we've "hit bottom" and can swap it out with strSwap
+          else if (typeof o === "string") {
+            return strSwap(o, formatterFunctions, variables, selectors, false);
+          }
+          else {
+            return o;
+          }
+        });
       }
       // If this property is an object, recursively do another swap
       // For some reason, postgres "DATE" props come through as objects. Exclude them from this object swap.


### PR DESCRIPTION
in varSwapRecursive, I was making the assumption that if the object i've encountered is an array, it is sufficient to recursively run varSwapRecursive on it again.

However, profiles now have `levels`, which is simply an array of strings. Therefore, I was trying to run varSwapRecursive on a __string__, which was casting it to an object and breaking the datatype.

I added a case into the "array" part of the function.  As it fans over the array, if it is an object, we use varSwapRecursive, but if it's a string, we have "hit bottom" and can use the new `strSwap`.

Fixes a bug that @cnavarreteliz discovered in Estonia with hierarchies.