### PR TITLE
fixes bug with search attr not properly replacing in urlswap

### DIFF
--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -240,7 +240,7 @@ module.exports = function(app) {
     const formatterFunctions = formatters4eval(formatters, locale);
     // Deduplicate generators that share an API endpoint
     const requests = Array.from(new Set(generators.map(g => g.api)));
-    const fetches = requests.map(r => throttle.add(createGeneratorFetch.bind(this, r, attr)));
+    const fetches = requests.map(r => throttle.add(createGeneratorFetch.bind(this, r, attr.toJSON())));
     const results = await Promise.all(fetches).catch(catcher);
     // Given a profile id, its generators, their API endpoints, and the responses of those endpoints,
     // start to build a returnVariables object by executing the javascript of each generator on its data


### PR DESCRIPTION
The `attr` object that is fetched from the search table is not a db row - it's a big giant sequelize response object. This was messing up the `urlSwap` function and causing it to use lots of unnecessary and broken key/values, which, among other problems, was failing to swap the `hierarchy` key for estonia.

Fix: Convert the attr response to raw json before passing it to the swap object.