### PR TITLE
fixes bug in SMR calculation port from SAS

### DIFF
--- a/packages/cms/src/utils/stats.js
+++ b/packages/cms/src/utils/stats.js
@@ -172,14 +172,6 @@ function smr(observedVal, expectedVal) {
   let vx = observedVal;
   const vN = expectedVal;
 
-  // Byar method approximation;
-  if (vx > vN) {
-    vx = vx;
-  }
-  else {
-    vx += 1;
-  }
-
   // Fisher's exact test for poisson distribution ;
   const Obs = vx;
   const Exp = vN;


### PR DESCRIPTION
While porting code for the standard morbidity ratio from the original SAS a few extra lines were included that aren't related to the actual SMR calculation and end up throwing off the calculation.