### PR TITLE
Add tesseract client

### DIFF
--- a/packages/cms/package-lock.json
+++ b/packages/cms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawheel/canon-cms",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -230,9 +230,9 @@
       "dev": true
     },
     "@datawheel/canon-core": {
-      "version": "0.17.26",
-      "resolved": "https://registry.npmjs.org/@datawheel/canon-core/-/canon-core-0.17.26.tgz",
-      "integrity": "sha512-Z0d7G0GbLw8dxjjkpIa6vIiiTdwlhnLxV8zz+JNslod+/fwdER5gN4mvhiadp6/z7TrLrtUsR6iuz26hISeVeA==",
+      "version": "0.17.27",
+      "resolved": "https://registry.npmjs.org/@datawheel/canon-core/-/canon-core-0.17.27.tgz",
+      "integrity": "sha512-qqZByePhnlkVFUc3Bp6PntgRM/OUTzAdwsQryUN70G1+SzyYUe47zGb0bYmSga4xjpCdS55uNdn1J9p1HJC0dQ==",
       "dev": true,
       "requires": {
         "@blueprintjs/core": "^3.10.0",
@@ -349,9 +349,9 @@
       }
     },
     "@datawheel/canon-logiclayer": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@datawheel/canon-logiclayer/-/canon-logiclayer-0.3.18.tgz",
-      "integrity": "sha512-SaUfHGfSrciC8A3MWxGHnCUfIc3cjCjwxsdd3WOIRpuC5Dt8cY3/D89BO7ey/2Va9s5wddgt0BzhkB+ST90rtg==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@datawheel/canon-logiclayer/-/canon-logiclayer-0.3.20.tgz",
+      "integrity": "sha512-jRomZoop9pxyEXRAtiJPdDDGyHI/ttFpPIqoEDyutWSDyR4J6i6t+M2OQEuIfXxbmcSI1ORiIdxsL19tJgW0Yw==",
       "dev": true,
       "requires": {
         "d3-array": "^1.2.1",
@@ -401,9 +401,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
-      "integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
+      "version": "8.10.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
+      "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
       "dev": true
     },
     "@types/prop-types": {
@@ -1970,9 +1970,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
-          "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -2130,9 +2130,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
-          "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
           "dev": true
         }
       }
@@ -2148,9 +2148,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
-          "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -2702,15 +2702,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000971",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000971.tgz",
-      "integrity": "sha512-ubSZfYXO2KMYtCVmDez82mjodeZa+mBYWAnBMAmFBPAn4C2PY4SD0eC/diYQD4Rj1K+WNdp0vr0JDtm0SQ6GNg==",
+      "version": "1.0.30000973",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000973.tgz",
+      "integrity": "sha512-leylQOpbgiYSm4G3NT8kq/KkKhKHlOLIBugpr6QsmjrYWgIR+S/iTDjM/5uM6FVqJg4YiD0en3P1udVvnRmrWA==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000971",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-      "integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
+      "version": "1.0.30000973",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+      "integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
       "dev": true
     },
     "canvas-toBlob": {
@@ -2806,9 +2806,9 @@
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -2982,9 +2982,9 @@
       "dev": true
     },
     "cloneable-readable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4032,25 +4032,25 @@
       }
     },
     "d3plus-axis": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-0.4.7.tgz",
-      "integrity": "sha512-dcNyEL7KbDTL4GZZ1Vbhb/48daeGS8usV+72J5EZ+ME6t9sfaQHmKzBOXhwUbUFL/IEdeZtdT79hceXMtATC1A==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-0.4.8.tgz",
+      "integrity": "sha512-kCWJDxqol+He3erGmm2Kgoy9r5PRBbWksdN+BM1HGPZVdWD1uUWgvwWGpCs/1iXCOV61Grrp1ICLYfgIqyqzow==",
       "dev": true,
       "requires": {
         "d3-array": "^1.2.4",
         "d3-scale": "^2.1.2",
         "d3-selection": "^1.3.2",
         "d3-transition": "^1.1.3",
-        "d3plus-common": "^0.6.45",
+        "d3plus-common": "^0.6.48",
         "d3plus-format": "^0.1.9",
-        "d3plus-shape": "^0.16.7",
+        "d3plus-shape": "^0.16.8",
         "d3plus-text": "^0.9.43"
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4073,9 +4073,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4147,9 +4147,9 @@
       }
     },
     "d3plus-hierarchy": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/d3plus-hierarchy/-/d3plus-hierarchy-0.8.3.tgz",
-      "integrity": "sha512-ItsXp+SWzKC4kV1PNycyf/8a793dU48+D6ljvQPy7+WtXdaZJh5vlGzMS8ewR9yPgGhN3SXrzKZPbX2B0aN/Hg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/d3plus-hierarchy/-/d3plus-hierarchy-0.8.5.tgz",
+      "integrity": "sha512-0U9Erehp/mniRtiXg8EcIgW6mr5SWL0HHHsGf99K7CFprqC1EzdiJ/x7MYzCLaKUEi+TZ2zsg1XrvmiRXLZ0Jg==",
       "dev": true,
       "requires": {
         "d3-array": "^1.2.4",
@@ -4157,15 +4157,15 @@
         "d3-hierarchy": "^1.1.8",
         "d3-scale": "^2.2.2",
         "d3-shape": "^1.3.5",
-        "d3plus-common": "^0.6.47",
-        "d3plus-shape": "^0.16.7",
-        "d3plus-viz": "^0.12.25"
+        "d3plus-common": "^0.6.49",
+        "d3plus-shape": "^0.16.8",
+        "d3plus-viz": "^0.12.32"
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4193,9 +4193,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4207,9 +4207,9 @@
       }
     },
     "d3plus-network": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/d3plus-network/-/d3plus-network-0.5.5.tgz",
-      "integrity": "sha512-AC8YlmFJRjnCdzIrjCA9GKCi0Nc2Vm7WCfjIwt8ADEoqmLG5u0eJzxgJRFnK/IyVWMiFTfBntFNldHewVHIt+g==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/d3plus-network/-/d3plus-network-0.5.6.tgz",
+      "integrity": "sha512-J0xKyRi/RdjKMBtPOzMqp+OMq6vEYDnrDIzMGnod7I4BId3VrapqJsxdN45uAHRkY88zoQAbW+N4GX1U3F9OnA==",
       "dev": true,
       "requires": {
         "d3-array": "^1.2.4",
@@ -4222,9 +4222,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4254,9 +4254,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4283,9 +4283,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4314,9 +4314,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4360,9 +4360,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4386,9 +4386,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4412,9 +4412,9 @@
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4426,20 +4426,20 @@
       }
     },
     "d3plus-tooltip": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/d3plus-tooltip/-/d3plus-tooltip-0.3.7.tgz",
-      "integrity": "sha512-vP9zkcaRbFf46/CB0zSClCfgkRqBBwSwKK3dsApE1NmIy3oYxDlXUOP5+19S8SCEyGFb+Ksxu9IdOqS8lphGnQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/d3plus-tooltip/-/d3plus-tooltip-0.3.8.tgz",
+      "integrity": "sha512-CGYGSg7pT+QfY9A2heiFnqzuKWSmzTXgaRY0ryMkJSUglswEzeZhgOPKMFMs+onjuYZ3YqwL2nq0avdR1gVbKA==",
       "dev": true,
       "requires": {
         "d3-selection": "^1.4.0",
-        "d3plus-common": "^0.6.45",
+        "d3plus-common": "^0.6.48",
         "popper.js": "^1.15.0"
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4457,9 +4457,9 @@
       }
     },
     "d3plus-viz": {
-      "version": "0.12.28",
-      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-0.12.28.tgz",
-      "integrity": "sha512-zaIhyPVw0jyILWPnrioy/Xm9HfxffCSJgkwxnrNd6uFCb9x52qZ2kWZmtIP0Er6UVtz+AZ+EvZmgs3ucXaOk3w==",
+      "version": "0.12.32",
+      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-0.12.32.tgz",
+      "integrity": "sha512-IOX0tNrGqQ3esRcnTpc524UkDvmy66LLoWpAOHY+c6Xa8yBuq9+5cbN37Dcgc3etmLYsA+PjQ/OLjIMVUytmQw==",
       "dev": true,
       "requires": {
         "d3-array": "^1.2.4",
@@ -4471,23 +4471,23 @@
         "d3-selection": "^1.4.0",
         "d3-transition": "^1.2.0",
         "d3-zoom": "^1.7.3",
-        "d3plus-axis": "^0.4.5",
+        "d3plus-axis": "^0.4.8",
         "d3plus-color": "^0.6.4",
-        "d3plus-common": "^0.6.45",
-        "d3plus-export": "^0.3.13",
+        "d3plus-common": "^0.6.48",
+        "d3plus-export": "^0.3.14",
         "d3plus-form": "^0.2.6",
         "d3plus-format": "^0.1.9",
         "d3plus-legend": "^0.8.22",
         "d3plus-text": "^0.9.43",
         "d3plus-timeline": "^0.4.11",
-        "d3plus-tooltip": "^0.3.7",
+        "d3plus-tooltip": "^0.3.8",
         "lrucache": "^1.0.3"
       },
       "dependencies": {
         "d3plus-common": {
-          "version": "0.6.47",
-          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.47.tgz",
-          "integrity": "sha512-zzcAcydeokpXTUQmGcWDSEu46XH8POx0Ow5QWF8MsCE0Xtsp/fnUmwloSTHVhVMLba3nhw8QqajHif6OySRLGQ==",
+          "version": "0.6.49",
+          "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.49.tgz",
+          "integrity": "sha512-cYJ7WRj8Y7Bfj9tnqBH/qDjAPjrAU8m+gUSM5I2cAwNmmah8iZQIDrFZG0jMq5ahJvkgpO4K6Lz2F/BNTSZziA==",
           "dev": true,
           "requires": {
             "d3-array": "^1.2.4",
@@ -4868,9 +4868,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
-      "integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
+      "version": "1.3.144",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.144.tgz",
+      "integrity": "sha512-jNRFJpfNrYm5uJ4x0q9oYMOfbL0JPOlkNli8GS/5zEmCjnE5jAtoCo4BYajHiqSPqEeAjtTdItL4p7EZw+jSfg==",
       "dev": true
     },
     "elliptic": {
@@ -5411,9 +5411,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.0.tgz",
-      "integrity": "sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.7",
@@ -6561,9 +6561,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -9091,9 +9091,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
-      "integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.22.tgz",
+      "integrity": "sha512-O6XpteBuntW1j86mw6LlovBIwTe+sO2+7vi9avQffNeIW4upgnaCVm6xrBWH+KATz7mNNRNNeEpuWB7dT6Cr3w==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -9126,9 +9126,9 @@
       }
     },
     "nodemon": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.0.tgz",
-      "integrity": "sha512-NHKpb/Je0Urmwi3QPDHlYuFY9m1vaVfTsRZG5X73rY46xPj0JpNe8WhUGQdkDXQDOxrBNIU3JrcflE9Y44EcuA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.1.tgz",
+      "integrity": "sha512-/DXLzd/GhiaDXXbGId5BzxP1GlsqtMGM9zTmkWrgXtSqjKmGSbLicM/oAy4FR0YWm14jCHRwnR31AHS2dYFHrg==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.5",
@@ -11794,28 +11794,29 @@
       },
       "dependencies": {
         "autoprefixer": {
-          "version": "9.5.1",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
-          "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
+          "integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
           "dev": true,
           "requires": {
-            "browserslist": "^4.5.4",
-            "caniuse-lite": "^1.0.30000957",
+            "browserslist": "^4.6.1",
+            "caniuse-lite": "^1.0.30000971",
+            "chalk": "^2.4.2",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
-            "postcss": "^7.0.14",
+            "postcss": "^7.0.16",
             "postcss-value-parser": "^3.3.1"
           }
         },
         "browserslist": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz",
-          "integrity": "sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==",
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+          "integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000967",
-            "electron-to-chromium": "^1.3.133",
-            "node-releases": "^1.1.19"
+            "caniuse-lite": "^1.0.30000971",
+            "electron-to-chromium": "^1.3.137",
+            "node-releases": "^1.1.21"
           }
         },
         "postcss": {
@@ -12371,9 +12372,9 @@
       "dev": true
     },
     "pstree.remy": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
-      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
+      "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
       "dev": true
     },
     "public-encrypt": {
@@ -13085,9 +13086,9 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"

--- a/packages/cms/package-lock.json
+++ b/packages/cms/package-lock.json
@@ -361,11 +361,47 @@
       }
     },
     "@datawheel/tesseract-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@datawheel/tesseract-client/-/tesseract-client-0.1.0.tgz",
-      "integrity": "sha512-/ruVUm1ES7tZGkBL9XsgyLLCllwPd+DXq8ybtON6U3dChcgf/wqXuYaHNcHLanHX/pv3JBlIc6B4cFcjfLyi8Q==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@datawheel/tesseract-client/-/tesseract-client-0.1.1.tgz",
+      "integrity": "sha512-Er2ysXaTgswwA2Zm7Ox9R5WZ2Mi8DJg2AOtGENeVz9DcXUYI+U36Rp5kLGvlU1JtkkZOazZUcwN+5urtyEtloA==",
       "requires": {
-        "axios": "^0.18.0"
+        "axios": "^0.19.0",
+        "form-urlencoded": "^3.0.0",
+        "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "form-urlencoded": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-3.0.0.tgz",
+          "integrity": "sha512-zSgBjyO5Yo3TCfElJKqlSBGOEq8lZjltZAYqew4X5trf4AbH4sZhBesvywy7IpD1mfbu8JS6733V3zv3YdIW1g=="
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "url-join": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
+        }
       }
     },
     "@mrmlnc/readdir-enhanced": {

--- a/packages/cms/package-lock.json
+++ b/packages/cms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawheel/canon-cms",
-  "version": "0.4.14",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -358,6 +358,14 @@
         "d3-collection": "^1.0.4",
         "mondrian-rest-client": "^1.1.3",
         "promise-throttle": "^1.0.0"
+      }
+    },
+    "@datawheel/tesseract-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@datawheel/tesseract-client/-/tesseract-client-0.1.0.tgz",
+      "integrity": "sha512-/ruVUm1ES7tZGkBL9XsgyLLCllwPd+DXq8ybtON6U3dChcgf/wqXuYaHNcHLanHX/pv3JBlIc6B4cFcjfLyi8Q==",
+      "requires": {
+        "axios": "^0.18.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -32,8 +32,8 @@
     "react-quill": "^1.3.1"
   },
   "devDependencies": {
-    "@datawheel/canon-core": "^0.17.26",
-    "@datawheel/canon-logiclayer": "^0.3.18"
+    "@datawheel/canon-core": "^0.17.27",
+    "@datawheel/canon-logiclayer": "^0.3.20"
   },
   "peerDependencies": {
     "@datawheel/canon-core": "^0.17.26"

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -16,6 +16,7 @@
     "@blueprintjs/datetime": "^3.7.1",
     "@blueprintjs/select": "^3.6.1",
     "@blueprintjs/table": "^3.4.1",
+    "@datawheel/tesseract-client": "^0.1.0",
     "axios": "^0.18.0",
     "buble": "^0.19.3",
     "d3-selection": "^1.3.2",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -16,7 +16,7 @@
     "@blueprintjs/datetime": "^3.7.1",
     "@blueprintjs/select": "^3.6.1",
     "@blueprintjs/table": "^3.4.1",
-    "@datawheel/tesseract-client": "^0.1.0",
+    "@datawheel/tesseract-client": "^0.1.1",
     "axios": "^0.18.0",
     "buble": "^0.19.3",
     "d3-selection": "^1.3.2",

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -218,7 +218,7 @@ const formatter = (members, data, dimension, level) => {
     const obj = {};
     obj.id = `${d.key}`;
     obj.name = d.name;
-    obj.display = d.caption;
+    obj.display = d.caption || d.name;
     obj.zvalue = data[obj.id] || 0;
     obj.dimension = dimension;
     obj.hierarchy = level;
@@ -274,7 +274,7 @@ const populateSearch = async(profileData, db) => {
         .addMeasure(measure), "jsonrecords")
         .then(resp => resp.data)
         .then(data => data.reduce((obj, d) => {
-          obj[d[`ID ${level.name}`]] = d[measure];
+          obj[d[`${level.name} ID`]] = d[measure];
           return obj;
         }, {})).catch(catcher);
     }
@@ -288,8 +288,6 @@ const populateSearch = async(profileData, db) => {
           return obj;
         }, {})).catch(catcher);
     }
-
-    
 
     fullList = fullList.concat(formatter(members, data, dimension, level.name));
 

--- a/packages/cms/src/cache/cubeData.js
+++ b/packages/cms/src/cache/cubeData.js
@@ -1,7 +1,15 @@
 const d3Array = require("d3-array");
 const axios = require("axios");
 
-const {CANON_CMS_CUBES} = process.env;
+let url = process.env.CANON_CMS_CUBES;
+
+// Older version of CANON_CMS_CUBES had a full path to the cube (path.com/cubes)
+// CANON_CMS_CUBES was changed to be root only, so fix it here so we can handle
+// both the new style and the old style
+url = url.replace("/cubes/", "");
+url = url.replace("/cubes", "");
+if (url.substr(-1) === "/") url = url.slice(0, -1);
+url = `${url}/cubes`;
 
 const s = (a, b) => {
   const ta = a.name.toUpperCase();
@@ -11,7 +19,8 @@ const s = (a, b) => {
 
 module.exports = async function() {
 
-  const client = axios.get(CANON_CMS_CUBES);
+  
+  const client = axios.get(url);
   const resp = await client;
   const cubes = resp.data.cubes;
 


### PR DESCRIPTION
Adds support for tesseract-client to Canon CMS.

In this PR, the cms no longer improperly borrows `CANON_LOGICLAYER_CUBE` as a way to designate where mondrian lives.  Users should now use `CANON_CMS_CUBES` to designate a mondrian or tesseract endpoint.

NOTE: `CANON_CMS_CUBES` originally expected a path like `path.com/cubes`, because it was used for fetching cube metadata.  From now on, `CANON_CMS_CUBES` should be set only to the actual path for mondrian or tesseract, (`path.com`), because I add the `/cubes` to fetch metadata in the appropriate place.