### PR TITLE
coerces variables to strings before attempting regex

### DIFF
--- a/src/helpers/fixChars.js
+++ b/src/helpers/fixChars.js
@@ -2,7 +2,7 @@
   @desc encodes plus signs and octothorpes
 */
 export function encodeChars(d) {
-  return d
+  return `${d}`
     .replace(/\+/g, "%2B")
     .replace(/\#/g, "%23");
 }
@@ -11,7 +11,7 @@ export function encodeChars(d) {
   @desc turns plus signs and octothorpes back to human-readable
 */
 export function decodeChars(d) {
-  return d
+  return `${d}`
     .replace(/\%2B/g, "+")
     .replace(/\%23/g, "#");
 }


### PR DESCRIPTION
Causing issues in Pantheon when trying to do URL param replacements with integer, since this function expects strings and will explode otherwise.