### PR TITLE
Fix cms permalink routing

### DIFF
--- a/packages/cms/package-lock.json
+++ b/packages/cms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawheel/canon-cms",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -338,18 +338,6 @@
           "integrity": "sha1-q/sd2CRwZ04DIrU86xqvQSk45L8=",
           "dev": true
         }
-      }
-    },
-    "@datawheel/canon-logiclayer": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@datawheel/canon-logiclayer/-/canon-logiclayer-0.3.20.tgz",
-      "integrity": "sha512-jRomZoop9pxyEXRAtiJPdDDGyHI/ttFpPIqoEDyutWSDyR4J6i6t+M2OQEuIfXxbmcSI1ORiIdxsL19tJgW0Yw==",
-      "dev": true,
-      "requires": {
-        "d3-array": "^1.2.1",
-        "d3-collection": "^1.0.4",
-        "mondrian-rest-client": "^1.1.3",
-        "promise-throttle": "^1.0.0"
       }
     },
     "@datawheel/tesseract-client": {
@@ -8864,7 +8852,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/mondrian-rest-client/-/mondrian-rest-client-1.1.3.tgz",
       "integrity": "sha512-fMOyOZ+gnI2PSHcXdlM6Vu07d4IkItEK4sOE3RuVFB3yWtQGjoi3L5aVn+gNtdxXgrydeG0DD5N+fdyRQ4K3Jg==",
-      "dev": true,
       "requires": {
         "axios": "^0.18.0",
         "form-urlencoded": "1.4.1",
@@ -8875,14 +8862,12 @@
         "form-urlencoded": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-1.4.1.tgz",
-          "integrity": "sha1-DFQD7xTNdhjZCKF7jh4gpvUKJKY=",
-          "dev": true
+          "integrity": "sha1-DFQD7xTNdhjZCKF7jh4gpvUKJKY="
         },
         "url-join": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
-          "dev": true
+          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
         }
       }
     },
@@ -13477,8 +13462,7 @@
     "shorthash": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
-      "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs=",
-      "dev": true
+      "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
     },
     "sigmund": {
       "version": "1.0.1",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -26,6 +26,7 @@
     "iso-639-1": "^2.0.3",
     "jszip": "^3.1.5",
     "localforage": "^1.7.2",
+    "mondrian-rest-client": "^1.1.3",
     "node-yaml": "^3.1.1",
     "promise-throttle": "^1.0.0",
     "react-ace": "^6.2.0",
@@ -33,11 +34,10 @@
     "react-quill": "^1.3.1"
   },
   "devDependencies": {
-    "@datawheel/canon-core": "^0.17.27",
-    "@datawheel/canon-logiclayer": "^0.3.20"
+    "@datawheel/canon-core": "^0.17.27"
   },
   "peerDependencies": {
-    "@datawheel/canon-core": "^0.17.26"
+    "@datawheel/canon-core": "^0.17.27"
   },
   "repository": {
     "type": "git",

--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -29,7 +29,8 @@ class Builder extends Component {
   }
 
   componentDidMount() {
-    const {isEnabled, env, location} = this.props;
+    const {isEnabled, env} = this.props;
+    const {location} = this.props.router;
     const {profile, section, previews} = location.query;
     // The CMS is only accessible on localhost/dev. Redirect the user to root otherwise.
     if (!isEnabled && typeof window !== "undefined" && window.location.pathname !== "/") window.location = "/";
@@ -81,8 +82,8 @@ class Builder extends Component {
     const diffProfile = String(pathObj.profile) !== String(this.state.pathObj.profile);
     const diffSection = String(pathObj.section) !== String(this.state.pathObj.section);
     if (diffProfile || diffSection) {
-      const {router, location} = this.props;
-      const {pathname} = location;
+      const {router} = this.props;
+      const {pathname} = router.location;
       let url = pathname === "/" ? "" : "/";
       url += `${pathname}?profile=${pathObj.profile}`;
       if (pathObj.section) url += `&section=${pathObj.section}`;

--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -81,9 +81,10 @@ class Builder extends Component {
     const diffProfile = String(pathObj.profile) !== String(this.state.pathObj.profile);
     const diffSection = String(pathObj.section) !== String(this.state.pathObj.section);
     if (diffProfile || diffSection) {
-      const {router, cmsPath} = this.props;
-      let url = cmsPath === "/" ? "" : "/";
-      url += `${cmsPath}?profile=${pathObj.profile}`;
+      const {router, location} = this.props;
+      const {pathname} = location;
+      let url = pathname === "/" ? "" : "/";
+      url += `${pathname}?profile=${pathObj.profile}`;
       if (pathObj.section) url += `&section=${pathObj.section}`;
       // if (pathObj.previews) url += `&previews=${pathObj.previews}`;
       router.replace(url);
@@ -180,6 +181,5 @@ Builder.need = [
 export default connect(state => ({
   formatters: state.data.formatters,
   env: state.env,
-  isEnabled: state.data.isEnabled,
-  cmsPath: state.routing.locationBeforeTransitions ? state.routing.locationBeforeTransitions.pathname : state.location.pathname.substring(1)
+  isEnabled: state.data.isEnabled
 }))(Builder);

--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -81,8 +81,9 @@ class Builder extends Component {
     const diffProfile = String(pathObj.profile) !== String(this.state.pathObj.profile);
     const diffSection = String(pathObj.section) !== String(this.state.pathObj.section);
     if (diffProfile || diffSection) {
-      const {router} = this.props;
-      let url = `?profile=${pathObj.profile}`;
+      const {router, cmsPath} = this.props;
+      let url = cmsPath === "/" ? "" : "/";
+      url += `${cmsPath}?profile=${pathObj.profile}`;
       if (pathObj.section) url += `&section=${pathObj.section}`;
       // if (pathObj.previews) url += `&previews=${pathObj.previews}`;
       router.replace(url);
@@ -179,5 +180,6 @@ Builder.need = [
 export default connect(state => ({
   formatters: state.data.formatters,
   env: state.env,
-  isEnabled: state.data.isEnabled
+  isEnabled: state.data.isEnabled,
+  cmsPath: state.routing.locationBeforeTransitions ? state.routing.locationBeforeTransitions.pathname : state.location.pathname.substring(1)
 }))(Builder);

--- a/packages/cms/src/cache/cubeData.js
+++ b/packages/cms/src/cache/cubeData.js
@@ -1,15 +1,11 @@
 const d3Array = require("d3-array");
 const axios = require("axios");
 
-let url = process.env.CANON_CMS_CUBES;
-
 // Older version of CANON_CMS_CUBES had a full path to the cube (path.com/cubes)
 // CANON_CMS_CUBES was changed to be root only, so fix it here so we can handle
 // both the new style and the old style
-url = url.replace("/cubes/", "");
-url = url.replace("/cubes", "");
-if (url.substr(-1) === "/") url = url.slice(0, -1);
-url = `${url}/cubes`;
+const url = process.env.CANON_CMS_CUBES
+  .replace(/[\/]{0,}[cubes]{0,}[\/]{0,}$/, "/cubes");
 
 const s = (a, b) => {
   const ta = a.name.toUpperCase();
@@ -19,10 +15,9 @@ const s = (a, b) => {
 
 module.exports = async function() {
 
-  
-  const client = axios.get(url);
-  const resp = await client;
-  const cubes = resp.data.cubes;
+
+  const resp = await axios.get(url).then(resp => resp.data);
+  const cubes = resp.cubes || [];
 
   const dimensions = [];
 


### PR DESCRIPTION
@cnavarreteliz Pointed out a bug in the cms path routing - if the Builder is put on a non-index route (as it almost always is, at `/admin` or `/builder`), then the pathing for permalinks was not being created correctly, and clicking profiles kicked you out to the IndexRoute.

This fix uses `props.location` to build a proper url for cms permalinks.