### PR TITLE
Fix busted generator assign

### DIFF
--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -555,6 +555,14 @@ class ProfileBuilder extends Component {
               }
             });
           }
+          // Further, for any given _genStatus or _matStatus that is incoming, 
+          // if the incoming version has no error, we must CLEAR the error from
+          // the current state of the variables.
+          const incGens = defObj[localeDefault]._genStatus;
+          const curGens = variablesHash[currentPid][localeDefault]._genStatus;
+          Object.keys(incGens).forEach(id => {
+            if (!incGens[id].error) delete curGens[id].error;
+          });
           variablesHash[currentPid] = nestedObjectAssign(variablesHash[currentPid], defObj);
         }
         if (locale) {
@@ -580,6 +588,11 @@ class ProfileBuilder extends Component {
                 }
               });
             }
+            const incGens = locObj[locale]._genStatus;
+            const curGens = variablesHash[currentPid][locale]._genStatus;
+            Object.keys(incGens).forEach(id => {
+              if (!incGens[id].error) delete curGens[id].error;
+            });
             variablesHash[currentPid] = nestedObjectAssign(variablesHash[currentPid], locObj);
             this.setState({variablesHash}, maybeCallback);
           });

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -558,11 +558,15 @@ class ProfileBuilder extends Component {
           // Further, for any given _genStatus or _matStatus that is incoming, 
           // if the incoming version has no error, we must CLEAR the error from
           // the current state of the variables.
-          const incGens = defObj[localeDefault]._genStatus;
-          const curGens = variablesHash[currentPid][localeDefault]._genStatus;
-          Object.keys(incGens).forEach(id => {
-            if (!incGens[id].error) delete curGens[id].error;
-          });
+          if (variablesHash[currentPid][localeDefault]) {
+            ["_genStatus", "_matStatus"].forEach(status => {
+              const incGens = defObj[localeDefault][status];
+              const curGens = variablesHash[currentPid][localeDefault][status];
+              Object.keys(incGens).forEach(id => {
+                if (!incGens[id].error) delete curGens[id].error;
+              });
+            });
+          }
           variablesHash[currentPid] = nestedObjectAssign(variablesHash[currentPid], defObj);
         }
         if (locale) {
@@ -588,11 +592,15 @@ class ProfileBuilder extends Component {
                 }
               });
             }
-            const incGens = locObj[locale]._genStatus;
-            const curGens = variablesHash[currentPid][locale]._genStatus;
-            Object.keys(incGens).forEach(id => {
-              if (!incGens[id].error) delete curGens[id].error;
-            });
+            if (variablesHash[currentPid][locale]) {
+              ["_genStatus", "_matStatus"].forEach(status => {
+                const incGens = locObj[locale][status];
+                const curGens = variablesHash[currentPid][locale][status];
+                Object.keys(incGens).forEach(id => {
+                  if (!incGens[id].error) delete curGens[id].error;
+                });
+              });
+            }
             variablesHash[currentPid] = nestedObjectAssign(variablesHash[currentPid], locObj);
             this.setState({variablesHash}, maybeCallback);
           });


### PR DESCRIPTION
@davelandry this is the bug observed in the CDC Demo that required a "jiggering" of the generator to clear the error state.

When I added "piecemeal updating" to generators, the `Object.assign` that I used for incoming new variables was failing to clear the `error` key that existed in state, therefore generators still appeared to be in error, even when the Preview id was updated.