### PR TITLE
fixes bug where duplicate apis only executed a single generator

### DIFF
--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -290,7 +290,7 @@ module.exports = function(app) {
         // genStatus is used to track the status of each individual generator
         genStatus[g.id] = evalResults.error ? {error: evalResults.error} : evalResults.vars;
         // Fold the generated variables into the accumulating returnVariables
-        return {...returnVariables, ...vars};
+        return {...acc, ...vars};
       }, returnVariables);
     });
     returnVariables._genStatus = genStatus;


### PR DESCRIPTION
@cnavarreteliz Found a bug while working on OEC where generators that share an API only executed one of the generators. This was due to a bug in my de-duplication reducer logic, fixed in this PR.