### PR TITLE
[canon] increases json limit for post objects

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -200,7 +200,7 @@ async function start() {
   app.set("port", PORT);
   app.set("trust proxy", "loopback");
   app.use(cookieParser());
-  app.use(bodyParser.json());
+  app.use(bodyParser.json({limit: "50mb"}));
   app.use(bodyParser.urlencoded({extended: true, limit: "50mb"}));
   app.use(express.static(staticPath));
   app.use(i18nMiddleware.handle(i18n));


### PR DESCRIPTION
We recently updated `canon-cms` to be able to accept the `variables` object as a `POST` payload - This allows pages to be re-rendered WITHOUT re-running generators.

However, the default limit in express for posting json is 100kb.  This PR bumps that up to 50mb (note to @davelandry - this is needed for CDC, and likely datausa too).

Let me know if you would prefer this be a CANON var - I didn't want to overload the number of configuration variables.