### PR TITLE
updates multiselect to bp3, was missed in canon upgrade

### DIFF
--- a/packages/cms/src/components/sections/components/Selector.jsx
+++ b/packages/cms/src/components/sections/components/Selector.jsx
@@ -33,7 +33,7 @@ class Selector extends Component {
     onSelector(name, filteredComparison);
   }
 
-  renderItem({handleClick, item}) {
+  renderItem(item, {handleClick}) {
     const {comparisons} = this.state;
     const {variables} = this.context;
     const selected = comparisons.find(comparison => comparison === item);


### PR DESCRIPTION
Blueprint 3 changed the way `renderItem` worked, but this missed (by me!) for the bp3 upgrade, resulting in blanks in multiselect dropdowns.  This fixes that bug.