### PR TITLE
fixes bug in viz assign

### DIFF
--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -57,8 +57,7 @@ class Viz extends Component {
     const title = vizProps.config.title || this.props.title || config.title || slug || "";
     delete vizProps.config.title;
 
-    const vizConfig = Object.assign(defaultConfig, {locale}, vizProps.config);
-    console.log(vizConfig);
+    const vizConfig = Object.assign({}, defaultConfig, {locale}, vizProps.config);
 
     return <SizeMe render={({size}) =>
       <div className={ `${context}-viz-container${


### PR DESCRIPTION
A bug in config assignment breaks when multiple vizes are on a page, overloading the `defaultConfig` object and breaking vizes.  Assigning it to an empty object fixes this.