### PR TITLE
[cms] Updates Migration Script to use Grouping type

### DIFF
--- a/packages/cms/scripts/migration/canon-cms-migrate-0.1.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.1.js
@@ -93,12 +93,12 @@ const migrate = async() => {
     }
 
     // make a topic to replace the profile about/stats/viz
-    let profiletopic = await dbnew.topic.create({ordering: nextTopicLoc, profile_id: newprofile.id, type: "About", slug: "about"}).catch(catcher);
+    let profiletopic = await dbnew.topic.create({ordering: nextTopicLoc, profile_id: newprofile.id, type: "Hero", slug: "hero"}).catch(catcher);
     profiletopic = profiletopic.toJSON();
     // increment the topic head
     nextTopicLoc++;
     // create its associated english language content
-    await dbnew.topic_content.create({title: "About", lang: "en", id: profiletopic.id}).catch(catcher);
+    await dbnew.topic_content.create({title: "Hero", lang: "en", id: profiletopic.id}).catch(catcher);
     for (const list of ["stats"]) {
       for (const entity of oldprofile[list]) {
         // migrate the array of profile entities to the new "profiletopic"
@@ -114,7 +114,7 @@ const migrate = async() => {
     for (const oldsection of oldprofile.sections) {
       // make this section into a new topic, with an ordering of the current "ordering head"
       const {slug, allowed} = oldsection;
-      let sectiontopic = await dbnew.topic.create({ordering: nextTopicLoc, profile_id: newprofile.id, type: "Section", slug, allowed}).catch(catcher);
+      let sectiontopic = await dbnew.topic.create({ordering: nextTopicLoc, profile_id: newprofile.id, type: "Grouping", slug, allowed}).catch(catcher);
       sectiontopic = sectiontopic.toJSON();
       // increment the topic head
       nextTopicLoc++;


### PR DESCRIPTION
Updates migration-0.1 script to use James' new "Grouping" type instead of the now deprecated "Section," so migrated databases will properly make use of Groupings and its DOM compliance.