### PR TITLE
hide visualization titles

### DIFF
--- a/packages/cms/src/components/Viz/Viz.css
+++ b/packages/cms/src/components/Viz/Viz.css
@@ -62,6 +62,11 @@
 
     & > .Options {
       flex-shrink: 0;
+
+      /* keep right aligned if no title */
+      &:first-child {
+        margin-left: auto;
+      }
     }
 
     /* header exists; make room for it */

--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -116,7 +116,6 @@ Viz.defaultProps = {
   configOverride: {},
   context: "cp",
   options: true,
-  title: undefined,
   showTitle: true,
   headingLevel: "h3"
 };

--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -55,7 +55,7 @@ class Viz extends Component {
       return <div>{`${type} is not a valid Visualization Type`}</div>;
     }
 
-    const title = vizProps.config.title || this.props.title || config.title || slug || "";
+    const title = vizProps.config.title;
     delete vizProps.config.title;
 
     const vizConfig = Object.assign({}, defaultConfig, {locale}, vizProps.config);
@@ -66,7 +66,7 @@ class Viz extends Component {
       }${
         type ? ` ${context}-${toKebabCase(type)}-viz-container` : ""
       }`}>
-        {showTitle || options
+        {title && showTitle || options
           ? <div className={`${context}-viz-header`}>
             {title && showTitle
               ? <Parse El={headingLevel} className={`${context}-viz-title u-margin-top-off u-margin-bottom-off u-font-xs`}>

--- a/packages/cms/src/components/sections/Default.jsx
+++ b/packages/cms/src/components/sections/Default.jsx
@@ -4,7 +4,7 @@ import "./Default.css";
 
 export default class Default extends Component {
   render() {
-    const {slug, title, heading, paragraphs, loading, filters, stats, sources, visualizations, vizHeadingLevel} = this.props;
+    const {slug, heading, paragraphs, loading, filters, stats, sources, visualizations, vizHeadingLevel} = this.props;
 
     return (
       <div
@@ -23,7 +23,7 @@ export default class Default extends Component {
         {/* caption */}
         <div className={`cp-default-section-figure${visualizations.length > 1 ? " cp-multicolumn-default-section-figure" : ""}`}>
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} title={title} headingLevel={vizHeadingLevel} slug={`${slug}-${ii}`} key={ii} />
+            <Viz section={this} config={visualization} headingLevel={vizHeadingLevel} slug={`${slug}-${ii}`} key={ii} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/Grouping.jsx
+++ b/packages/cms/src/components/sections/Grouping.jsx
@@ -23,7 +23,7 @@ export default class Grouping extends Component {
         {/* caption */}
         <div className={`cp-grouping-section-figure${visualizations.length > 1 ? " cp-multicolumn-grouping-section-figure" : ""}`}>
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} title={title} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={ii} />
+            <Viz section={this} config={visualization} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={ii} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -99,7 +99,7 @@ class Hero extends Component {
           {contents && contents.visualizations && contents.visualizations.length
             ? <div className="cp-hero-figure">
               {contents.visualizations.map((visualization, ii) => ii === 0
-                ? <Viz section={this} config={visualization} showTitle={false} options={false} title={title} slug={`${contents.slug}-${ii}`} key={ii} />
+                ? <Viz section={this} config={visualization} showTitle={false} options={false} slug={`${contents.slug}-${ii}`} key={ii} />
                 : ""
               )}
             </div> : ""

--- a/packages/cms/src/components/sections/InfoCard.jsx
+++ b/packages/cms/src/components/sections/InfoCard.jsx
@@ -40,7 +40,7 @@ export default class InfoCard extends Component {
           {visualizations && visualizations.length
             ? <div className="cp-section-content cp-info-card-section-viz">
               {visualizations.map((visualization, ii) => ii === 0
-                ? <Viz section={this} config={visualization} options={false} title={title} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} /> : ""
+                ? <Viz section={this} config={visualization} options={false} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} /> : ""
               )}
             </div> : ""
           }

--- a/packages/cms/src/components/sections/MultiColumn.jsx
+++ b/packages/cms/src/components/sections/MultiColumn.jsx
@@ -21,7 +21,7 @@ export default class MultiColumn extends Component {
           {paragraphs}
           {sources}
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} title={title} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} />
+            <Viz section={this} config={visualization} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/SingleColumn.jsx
+++ b/packages/cms/src/components/sections/SingleColumn.jsx
@@ -23,7 +23,7 @@ export default class SingleColumn extends Component {
           {paragraphs}
           {sources}
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} title={title} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} />
+            <Viz section={this} config={visualization} slug={`${slug}-${ii}`} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/Tabs.jsx
+++ b/packages/cms/src/components/sections/Tabs.jsx
@@ -98,7 +98,7 @@ export default class Tabs extends Component {
       </div>
 
       <div className="cp-tabs-section-figure">
-        <Viz section={this} config={visualization} key={tabIndex} title={title} slug={`${slug}_${tabIndex}`} headingLevel={vizHeadingLevel} />
+        <Viz section={this} config={visualization} key={tabIndex} slug={`${slug}_${tabIndex}`} headingLevel={vizHeadingLevel} />
         {tabSelectors.length > 0 && <div className="cp-section-selectors">
           {tabSelectors && tabSelectors.map(selector => <Selector key={selector.id} {...selector} loading={loading} />)}
         </div>}


### PR DESCRIPTION
Hides visualization titles unless a `title` is explicitly defined in the viz config; closes #619