### PR TITLE
prunes data for nulls in percbar

### DIFF
--- a/packages/cms/src/components/Viz/PercentageBar.jsx
+++ b/packages/cms/src/components/Viz/PercentageBar.jsx
@@ -72,7 +72,7 @@ class PercentageBar extends Component {
     return (
       <div className="percentage-bar-wrapper">
         <ul className="percentage-bar-list">
-          {displayData.map((d, i) => {
+          {displayData.filter(d => d).map((d, i) => {
             const percent = d[value] / total * 100;
             const label = d[groupBy];
             return (


### PR DESCRIPTION
In certain situations (usually a bad `dataFormat` function) a user could pass `undefined` values into the data array for PercentageBar.  Attempts to access properties of these values results in a red screen, both on the CMS and front end. 

This PR adds a filter to the viz that ensures a given data value exists before attempting to graph it.

This is a followup to https://github.com/DeloitteGeospatial/cdc-pha/issues/955
