### PR TITLE
adds str conversion to striphtml

### DIFF
--- a/packages/cms/src/utils/formatters/stripHTML.js
+++ b/packages/cms/src/utils/formatters/stripHTML.js
@@ -2,7 +2,7 @@
 * Converts html tags to spaces, then removes redundant spaces
 */
 function stripHTML(n) {
-  return n.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  return String(n).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
 }
 
 module.exports = stripHTML;


### PR DESCRIPTION
the striphtml function does not work if a number is passed to it (or anything non-string, for that matter).

Cast the input to string before running `.replace`.