### PR TITLE
passes section title to Options.jsx & restores filename fallbacks

### DIFF
--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -21,6 +21,7 @@ class Viz extends Component {
   }
 
   render() {
+    const {sectionTitle} = this.props;
     const variables = this.props.variables || this.context.variables;
     const locale = this.props.locale || this.context.locale;
 
@@ -80,7 +81,7 @@ class Viz extends Component {
                 data={ vizConfig.data }
                 dataFormat={ vizProps.dataFormat }
                 slug={ slug }
-                title={ title }
+                title={ title || sectionTitle || slug }
                 iconOnly={size && size.width < 320 ? true : false}
               /> : ""
             }

--- a/packages/cms/src/components/sections/Default.jsx
+++ b/packages/cms/src/components/sections/Default.jsx
@@ -4,7 +4,7 @@ import "./Default.css";
 
 export default class Default extends Component {
   render() {
-    const {slug, heading, paragraphs, loading, filters, stats, sources, visualizations, vizHeadingLevel} = this.props;
+    const {slug, heading, title, paragraphs, loading, filters, stats, sources, visualizations, vizHeadingLevel} = this.props;
 
     return (
       <div
@@ -23,7 +23,7 @@ export default class Default extends Component {
         {/* caption */}
         <div className={`cp-default-section-figure${visualizations.length > 1 ? " cp-multicolumn-default-section-figure" : ""}`}>
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} headingLevel={vizHeadingLevel} slug={slug} key={ii} />
+            <Viz section={this} config={visualization} headingLevel={vizHeadingLevel} sectionTitle={title} slug={slug} key={ii} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/Grouping.jsx
+++ b/packages/cms/src/components/sections/Grouping.jsx
@@ -23,7 +23,7 @@ export default class Grouping extends Component {
         {/* caption */}
         <div className={`cp-grouping-section-figure${visualizations.length > 1 ? " cp-multicolumn-grouping-section-figure" : ""}`}>
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} slug={slug} headingLevel={vizHeadingLevel} key={ii} />
+            <Viz section={this} config={visualization} slug={slug} headingLevel={vizHeadingLevel} sectionTitle={title} key={ii} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -99,7 +99,7 @@ class Hero extends Component {
           {contents && contents.visualizations && contents.visualizations.length
             ? <div className="cp-hero-figure">
               {contents.visualizations.map((visualization, ii) => ii === 0
-                ? <Viz section={this} config={visualization} showTitle={false} options={false} slug={contents.slug} key={ii} />
+                ? <Viz section={this} config={visualization} showTitle={false} sectionTitle={title} options={false} slug={contents.slug} key={ii} />
                 : ""
               )}
             </div> : ""

--- a/packages/cms/src/components/sections/InfoCard.jsx
+++ b/packages/cms/src/components/sections/InfoCard.jsx
@@ -40,7 +40,7 @@ export default class InfoCard extends Component {
           {visualizations && visualizations.length
             ? <div className="cp-section-content cp-info-card-section-viz">
               {visualizations.map((visualization, ii) => ii === 0
-                ? <Viz section={this} config={visualization} options={false} slug={slug} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} /> : ""
+                ? <Viz section={this} config={visualization} options={false} slug={slug} headingLevel={vizHeadingLevel} sectionTitle={title} key={`${slug}-${ii}`} /> : ""
               )}
             </div> : ""
           }

--- a/packages/cms/src/components/sections/MultiColumn.jsx
+++ b/packages/cms/src/components/sections/MultiColumn.jsx
@@ -21,7 +21,7 @@ export default class MultiColumn extends Component {
           {paragraphs}
           {sources}
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} slug={slug} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} />
+            <Viz section={this} config={visualization} slug={slug} headingLevel={vizHeadingLevel} sectionTitle={title} key={`${slug}-${ii}`} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/SingleColumn.jsx
+++ b/packages/cms/src/components/sections/SingleColumn.jsx
@@ -23,7 +23,7 @@ export default class SingleColumn extends Component {
           {paragraphs}
           {sources}
           {visualizations.map((visualization, ii) =>
-            <Viz section={this} config={visualization} slug={slug} headingLevel={vizHeadingLevel} key={`${slug}-${ii}`} />
+            <Viz section={this} config={visualization} slug={slug} headingLevel={vizHeadingLevel} sectionTitle={title} key={`${slug}-${ii}`} />
           )}
         </div>
       </div>

--- a/packages/cms/src/components/sections/Tabs.jsx
+++ b/packages/cms/src/components/sections/Tabs.jsx
@@ -98,7 +98,7 @@ export default class Tabs extends Component {
       </div>
 
       <div className="cp-tabs-section-figure">
-        <Viz section={this} config={visualization} key={tabIndex} slug={slug} headingLevel={vizHeadingLevel} />
+        <Viz section={this} config={visualization} key={tabIndex} slug={slug} headingLevel={vizHeadingLevel} sectionTitle={title}  />
         {tabSelectors.length > 0 && <div className="cp-section-selectors">
           {tabSelectors && tabSelectors.map(selector => <Selector key={selector.id} {...selector} loading={loading} />)}
         </div>}


### PR DESCRIPTION
closes #692 

[related issue](https://github.com/Datawheel/canon/blob/feature-multisearch/packages/cms/src/components/Viz/Options.jsx#L26-L28)