### PR TITLE
bumps default page size up from 10 to 20

### DIFF
--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -559,7 +559,8 @@ class MetaEditor extends Component {
             className="cms-meta-table"
             data={data}
             columns={columns}
-            pageSize={data.length > 10 ? 10 : data.length}
+            defaultPageSize={data.length > 20 ? 20 : data.length}
+            showPageSizeOptions={true}
             showPagination={data.length > 10}
           />
         </div>


### PR DESCRIPTION
Here is what my meta tab looks like:

<img width="2075" alt="Screen Shot 2019-10-09 at 6 16 20 PM" src="https://user-images.githubusercontent.com/252276/66524627-ee0d9a00-eac0-11e9-999f-048c64b87acf.png">

it would help my workflow a lot to see more results here by default and also allow the user to change the pagesize.