### PR TITLE
[cms] remote search for Meta Panel

### DIFF
--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -382,6 +382,9 @@ module.exports = function(app) {
   app.get("/api/cms/meta", async(req, res) => {
     let meta = await db.profile_meta.findAll().catch(catcher);
     meta = meta.map(m => m.toJSON());
+    for (const m of meta) {
+      m.top = await db.search.findOne({where: {dimension: m.dimension}, order: [["zvalue", "DESC"]], limit: 1}).catch(catcher);
+    }
     res.json(meta);
   });
 

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -131,14 +131,6 @@ module.exports = function(app) {
     return res.json(payload);
   });
 
-  app.get("/api/search/all", async(req, res) => {
-    let rows = await db.search.findAll({include: [
-      {model: db.image, include: [{association: "content"}]}, {association: "content"}
-    ]}).catch(catcher);
-    rows = rows.map(r => r.toJSON());
-    res.json(rows);
-  });
-
   app.post("/api/image_content/update", async(req, res) => {
     const {id, locale} = req.body;
     const defaults = req.body;

--- a/packages/cms/src/components/Viz/Table.css
+++ b/packages/cms/src/components/Viz/Table.css
@@ -264,12 +264,6 @@ THEMING
     margin-right: 1rem;
   }
 
-  /* hide the page select menu */
-  /* NOTE: only visible when prop `showPageSizeOptions` is false */
-  & .select-wrap {
-    display: none;
-  }
-
   & .-pageInfo {
     display: flex;
     align-items: baseline;

--- a/packages/cms/src/components/interface/Toolbox.css
+++ b/packages/cms/src/components/interface/Toolbox.css
@@ -2,7 +2,7 @@
 
 /* quick and dirty layout */
 @mixin min-lg {
-  .cms-panel:not(:last-child) {
+  .cms-panel:not(:last-child):not(.meta-editor) {
     width: calc(100% - var(--toolbox-width));
     max-width: calc(100% - var(--toolbox-width));
 

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -16,6 +16,7 @@ import Select from "../components/fields/Select";
 import "./MetaEditor.css";
 
 const IMAGES_PER_PAGE = 48;
+const ROWS_PER_PAGE = 10;
 
 class MetaEditor extends Component {
 
@@ -36,8 +37,9 @@ class MetaEditor extends Component {
       isOpen: false,
       currentRow: {},
       loading: false,
+      pageIndex: 0,
+      pageSize: ROWS_PER_PAGE,
       querying: false,
-      rowsPerPage: 10,
       searching: false,
       typingTimeout: null,
       imgIndex: 0,
@@ -533,8 +535,8 @@ class MetaEditor extends Component {
       flickrImages,
       isOpen,
       loading,
-      page,
-      rowsPerPage,
+      pageIndex,
+      pageSize,
       querying,
       searching,
       imgIndex,
@@ -598,15 +600,16 @@ class MetaEditor extends Component {
         <div className="cms-editor cms-meta-table-container">
           <h2 className="u-visually-hidden">Members</h2>
           <ReactTable
-            page={page}
-            onPageChange={page => this.setState({page})}
+            page={pageIndex}
+            onPageChange={pageIndex => this.setState({pageIndex})}
             className="cms-meta-table"
             data={data}
             columns={columns}
-            defaultPageSize={data.length > rowsPerPage ? rowsPerPage : data.length}
+            pageSize={pageSize < data.length ? pageSize : data.length}
+            onPageSizeChange={(pageSize, pageIndex) => this.setState({pageSize, pageIndex})}
             showPageSizeOptions={true}
-            pageSizeOptions={[rowsPerPage, 25, 50, 100]}
-            showPagination={data.length > rowsPerPage}
+            pageSizeOptions={[ROWS_PER_PAGE, 25, 50, 100]}
+            showPagination={data.length > pageSize}
           />
         </div>
 

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -37,8 +37,8 @@ class MetaEditor extends Component {
       currentRow: {},
       loading: false,
       querying: false,
+      rowsPerPage: 10,
       searching: false,
-      typing: false,
       typingTimeout: null,
       imgIndex: 0,
       url: ""
@@ -341,15 +341,6 @@ class MetaEditor extends Component {
           Header: this.renderHeader("preview"),
           accessor: d => this.linkify.bind(this)(d),
           Cell: cell => <ul>{cell.value.map(url => <li key={url}><a href={url}>{url}</a></li>)}</ul>
-          /*
-          Header: this.renderHeader(`${locale} ${prop === "attr" ? "language hints" : prop}`),
-          minWidth: this.columnWidths(prop),
-          accessor: d => {
-            const content = d.content.find(c => c.locale === locale);
-            return content ? content[prop] : null;
-          },
-          Cell: cell => prop !== "name" ? this.renderEditable.bind(this)(cell, prop, locale) : this.renderCell(cell)
-          */
         });
       }
       else if (field === "content") {
@@ -481,7 +472,7 @@ class MetaEditor extends Component {
     // The user may have clicked either a dimension or a hierarchy. Determine which.
     const filterKey = filterBy.includes("hierarchy_") ? "hierarchy" : "dimension";
     filterBy = filterBy.replace("hierarchy_", "").replace("dimension_", "");
-    let url = "/api/search?locale=all&limit=100";
+    let url = "/api/search?locale=all&limit=500";
     if (query) {
       url += `&q=${query}`;
     }
@@ -499,20 +490,6 @@ class MetaEditor extends Component {
       const page = 0;
       this.setState({data, filterKey, page, querying: false});
     });
-    
-    
-    /*
-    const data = sourceData
-      .filter(d => d[filterKey] === filterBy || filterBy === "all")
-      .filter(d =>
-        query === "" ||
-        d.slug && d.slug.includes(query.toLowerCase()) ||
-        d.content.some(c => c.name.toLowerCase().includes(query.toLowerCase())) ||
-        d.content.some(c => c.attr && c.attr.toLowerCase().includes(query.toLowerCase())) ||
-        d.content.some(c => c.keywords && c.keywords.toLowerCase().includes(query.toLowerCase())) ||
-        d.image && d.image.content && d.image.content.some(c => c.meta.toLowerCase().includes(query.toLowerCase()))
-      );
-    */
     
   }
 
@@ -557,9 +534,9 @@ class MetaEditor extends Component {
       isOpen,
       loading,
       page,
+      rowsPerPage,
       querying,
       searching,
-      typing,
       imgIndex,
       url
     } = this.state;
@@ -626,8 +603,10 @@ class MetaEditor extends Component {
             className="cms-meta-table"
             data={data}
             columns={columns}
-            pageSize={data.length > 10 ? 10 : data.length}
-            showPagination={data.length > 10}
+            defaultPageSize={data.length > rowsPerPage ? rowsPerPage : data.length}
+            showPageSizeOptions={true}
+            pageSizeOptions={[rowsPerPage, 25, 50, 100]}
+            showPagination={data.length > rowsPerPage}
           />
         </div>
 

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -36,7 +36,10 @@ class MetaEditor extends Component {
       isOpen: false,
       currentRow: {},
       loading: false,
+      querying: false,
       searching: false,
+      typing: false,
+      typingTimeout: null,
       imgIndex: 0,
       url: ""
     };
@@ -462,11 +465,11 @@ class MetaEditor extends Component {
         url += `&levels=${filterBy}`; 
       }
     }
-    this.setState({loading: true});
+    this.setState({querying: true});
     axios.get(url).then(resp => {
       const data = this.fetchStringifiedSourceData.bind(this)(resp.data);
       const page = 0;
-      this.setState({data, filterKey, page, loading: false});
+      this.setState({data, filterKey, page, querying: false});
     });
     
     
@@ -493,7 +496,17 @@ class MetaEditor extends Component {
   }
 
   onChange(field, e) {
-    this.setState({[field]: e.target.value}, this.processFiltering.bind(this));
+    if (field === "query") {
+      let typingTimeout = null;
+      if (this.state.typingTimeout) {
+        clearTimeout(this.state.typingTimeout);
+      }
+      typingTimeout = setTimeout(this.processFiltering.bind(this), 750);
+      this.setState({typingTimeout, [field]: e.target.value});
+    }
+    else {
+      this.setState({[field]: e.target.value}, this.processFiltering.bind(this));
+    }
   }
 
   closeEditor() {
@@ -516,7 +529,9 @@ class MetaEditor extends Component {
       isOpen,
       loading,
       page,
+      querying,
       searching,
+      typing,
       imgIndex,
       url
     } = this.state;
@@ -736,7 +751,7 @@ class MetaEditor extends Component {
             }
           </div>
         </Dialog>
-        <Status busy="Searching..." done="Complete!" recompiling={loading}/>
+        <Status busy="Searching..." done="Complete!" recompiling={querying}/>
       </div>
     );
   }

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -249,6 +249,17 @@ class MetaEditor extends Component {
     });
   }
 
+  linkify(member) {
+    const {metaData} = this.state;
+    const links = [];
+    const relevantPids = metaData.filter(p => p.dimension === member.dimension).map(d => d.profile_id);
+    relevantPids.forEach(pid => {
+      const relevantProfile = metaData.filter(p => p.profile_id === pid);
+      links.push(`/profile/${relevantProfile.map(p => `${p.slug}/${member.dimension === p.dimension ? member.id : p.top.id}`).join("/")}`);
+    });
+    return links;
+  }
+
   /**
    * Once sourceData has been set, prepare the two variables that react-table needs: data and columns.
    */
@@ -267,12 +278,14 @@ class MetaEditor extends Component {
     const classColumns = [];
     const searchColumns = [];
     const displayColumns = [];
+    const previewColumns = [];
 
     const columns = [
       {Header: "identification",  columns: idColumns},
       {Header: "classification",  columns: classColumns},
       {Header: "search",          columns: searchColumns},
-      {Header: "display",         columns: displayColumns}
+      {Header: "display",         columns: displayColumns},
+      {Header: "preview",         columns: previewColumns}
     ];
 
     fields.forEach(field => {
@@ -323,6 +336,21 @@ class MetaEditor extends Component {
             Cell: cell => cell.original.image ? this.renderEditable.bind(this)(cell, "meta", locale) : this.renderCell(cell)
           });
         }
+        displayColumns.push({
+          id: field,
+          Header: this.renderHeader("preview"),
+          accessor: d => this.linkify.bind(this)(d),
+          Cell: cell => <ul>{cell.value.map(url => <li key={url}><a href={url}>{url}</a></li>)}</ul>
+          /*
+          Header: this.renderHeader(`${locale} ${prop === "attr" ? "language hints" : prop}`),
+          minWidth: this.columnWidths(prop),
+          accessor: d => {
+            const content = d.content.find(c => c.locale === locale);
+            return content ? content[prop] : null;
+          },
+          Cell: cell => prop !== "name" ? this.renderEditable.bind(this)(cell, prop, locale) : this.renderCell(cell)
+          */
+        });
       }
       else if (field === "content") {
         ["name", "attr", "keywords"].forEach(prop => {
@@ -384,7 +412,7 @@ class MetaEditor extends Component {
           dimensions[meta.dimension] = [...new Set([...dimensions[meta.dimension], ...meta.levels])];
         }
       });
-      this.setState({dimensions, sourceData}, this.prepData.bind(this));
+      this.setState({dimensions, sourceData, metaData}, this.prepData.bind(this));
     });
   }
 


### PR DESCRIPTION
The MetaEditor Panel can be quite slow on initial load, because I was loading ALL search members and then filtering with javascript.

This PR moves the querying to the server using limiting, which results in a much quicker experience for navigating large member tables.