### PR TITLE
adds proper catch to cubeData population and supports empty case for …

### DIFF
--- a/packages/cms/src/cache/cubeData.js
+++ b/packages/cms/src/cache/cubeData.js
@@ -1,5 +1,8 @@
 const d3Array = require("d3-array");
 const axios = require("axios");
+const yn = require("yn");
+
+const verbose = yn(process.env.CANON_CMS_LOGGING);
 
 // Older version of CANON_CMS_CUBES had a full path to the cube (path.com/cubes)
 // CANON_CMS_CUBES was changed to be root only, so fix it here so we can handle
@@ -13,10 +16,17 @@ const s = (a, b) => {
   return ta < tb ? -1 : ta > tb ? 1 : 0;
 };
 
+const catcher = e => {
+  if (verbose) {
+    console.error("Error in cubeData.js: ", e);
+  }
+  return [];
+};
+
 module.exports = async function() {
 
 
-  const resp = await axios.get(url).then(resp => resp.data);
+  const resp = await axios.get(url).then(resp => resp.data).catch(catcher);
   const cubes = resp.cubes || [];
 
   const dimensions = [];

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -272,9 +272,9 @@ class MetaEditor extends Component {
     let skip = ["stem", "imageId", "contentId"];
     if (!imageEnabled) skip = skip.concat("image");
     const keySort = ["id", "slug", "content", "zvalue", "dimension", "hierarchy", "image"];
-    const fields = Object.keys(data[0])
+    const fields = data[0] ? Object.keys(data[0])
       .filter(d => !skip.includes(d))
-      .sort((a, b) => keySort.indexOf(a) - keySort.indexOf(b));
+      .sort((a, b) => keySort.indexOf(a) - keySort.indexOf(b)) : [];
 
     const idColumns = [];
     const classColumns = [];


### PR DESCRIPTION
Two quick bug fixes:

The cubeData cache element can crash with an improper `CANON_CMS_CUBES` var. Adds a catch for that.

The MetaData table crashes if the user has no member data yet. Fixed.