### PR TITLE
adds ability to search for parents in images

### DIFF
--- a/packages/cms/src/api/imageRoute.js
+++ b/packages/cms/src/api/imageRoute.js
@@ -4,12 +4,37 @@ const yn = require("yn");
 
 const verbose = yn(process.env.CANON_CMS_LOGGING);
 const envLoc = process.env.CANON_LANGUAGE_DEFAULT || "en";
+let cubeRoot = process.env.CANON_CMS_CUBES;
+if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 
 const catcher = e => {
   if (verbose) {
-    console.error("Error in searchRoute: ", e);
+    console.error("Error in imageRoute: ", e);
   }
   return [];
+};
+
+const getParentMemberWithImage = async(db, member, meta) => {
+  const {id, hierarchy} = member;
+  const {dimension, cubeName} = meta;
+  if (cubeName) {
+    const resp = await axios.get(`${cubeRoot}/relations.jsonrecords?cube=${cubeName}&${hierarchy}=${id}:parents`).catch(() => {
+      if (verbose) console.log("Warning: Parent endpoint misconfigured or not available");
+      return [];
+    });
+    if (resp.data && resp.data.data && resp.data.data.length > 0) {
+      const parents = resp.data.data.reverse();
+      for (const parent of parents) {
+        let parentMember = await db.search.findOne({
+          where: {dimension, id: parent.value},
+          include: {model: db.image, include: [{association: "content"}]}
+        }).catch(catcher);
+        parentMember = parentMember.toJSON();
+        if (parentMember.image) return parentMember;
+      }
+    }
+  }
+  return null;
 };
 
 module.exports = function(app) {
@@ -18,16 +43,13 @@ module.exports = function(app) {
   
   app.get("/api/image", async(req, res) => {
     const {slug, id, type, t} = req.query;
-    let {dimension} = req.query;
     const size = req.query.size || "splash";
     const locale = req.query.locale || envLoc;
     const jsonError = () => res.json({error: "Not Found"});
     const imageError = () => res.sendFile(`${process.cwd()}/static/images/transparent.png`);
-    if (!dimension) {
-      const meta = await db.profile_meta.findOne({where: {slug}}).catch(catcher);
-      if (!meta) return type === "json" ? jsonError() : imageError();  
-      dimension = meta.dimension;
-    }
+    const meta = await db.profile_meta.findOne({where: {slug}}).catch(catcher);
+    if (!meta) return type === "json" ? jsonError() : imageError();  
+    const {dimension} = meta;
     let member = await db.search.findOne({
       where: {dimension, [sequelize.Op.or]: {id, slug: id}},
       include: {model: db.image, include: [{association: "content"}]}
@@ -35,6 +57,11 @@ module.exports = function(app) {
     if (!member) return type === "json" ? jsonError() : imageError();
     member = member.toJSON();
     if (type === "json") {
+      // If this member didn't have an image, attempt to find a parent image instead.
+      if (!member.image) {
+        const parentMember = await getParentMemberWithImage(db, member, meta);
+        if (parentMember) member.image = parentMember.image;
+      }
       if (member.image && member.image.content) {
         const content = member.image.content.find(d => d.locale === locale);
         if (content) {
@@ -45,14 +72,23 @@ module.exports = function(app) {
       return res.json(member);
     }
     else {
-      const {imageId} = member;
+      let {imageId} = member;
       const bucket = process.env.CANON_CONST_STORAGE_BUCKET;
-      if (imageId && bucket && ["splash", "thumb"].includes(size)) {
-        let url = `https://storage.googleapis.com/${bucket}/${size}/${imageId}.jpg`;
-        if (t) url += `?t=${t}`;
-        const imgData = await axios.get(url, {responseType: "arraybuffer"}).then(resp => resp.data).catch(catcher);
-        res.writeHead(200,  {"Content-Type": "image/jpeg"});
-        return res.end(imgData, "binary");
+      if (bucket && ["splash", "thumb"].includes(size)) {
+        if (!imageId) {
+          const parentMember = await getParentMemberWithImage(db, member, meta);
+          if (parentMember) imageId = parentMember.imageId;
+        }
+        if (imageId) {
+          let url = `https://storage.googleapis.com/${bucket}/${size}/${imageId}.jpg`;
+          if (t) url += `?t=${t}`;
+          const imgData = await axios.get(url, {responseType: "arraybuffer"}).then(resp => resp.data).catch(catcher);
+          res.writeHead(200,  {"Content-Type": "image/jpeg"});
+          return res.end(imgData, "binary");  
+        }
+        else {
+          return imageError();
+        }
       }
       else {
         return imageError();


### PR DESCRIPTION
closes #798

Image lookups will now attempt to find parents, if the `:parents` endpoint has been configured in tesseract.  Fails gracefully if it has not.