### PR TITLE
table viz pagination style

### DIFF
--- a/packages/cms/src/components/Viz/Table.css
+++ b/packages/cms/src/components/Viz/Table.css
@@ -2,6 +2,10 @@
 
 .cp-table-viz-container .cp-viz-figure {
   height: auto !important;
+
+  & .rt-table {
+    @mixin overflow-container;
+  }
 }
 
 /* -----------------------------

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -15,6 +15,9 @@ class Table extends Component {
     this.state = {
       config: null
     };
+    this.props = {
+      minRowsForPagination: 15
+    };
 
     this.viz = React.createRef();
   }
@@ -25,7 +28,7 @@ class Table extends Component {
 
   buildConfig() {
     const propConfig = this.props.config;
-    const {dataFormat} = this.props;
+    const {dataFormat, minRowsForPagination} = this.props;
 
     const paginationButtonProps = {
       className: "cp-table-pagination-button",
@@ -57,11 +60,13 @@ class Table extends Component {
     if (typeof config.data === "string") {
       axios.get(config.data).then(resp => {
         config.data = dataFormat(resp.data);
+        if (config.data && config.data.length >= minRowsForPagination) config.showPagination = true;
         this.setState({config});
       });
     }
     else {
       config.data = dataFormat(config.data);
+      if (config.data && config.data.length >= minRowsForPagination) config.showPagination = true;
       this.setState({config});
     }
   }

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -5,6 +5,8 @@ import abbreviate from "../../utils/formatters/abbreviate";
 import {Icon} from "@blueprintjs/core";
 import ReactTable from "react-table";
 
+import Button from "../fields/Button";
+import TextInput from "../fields/TextInput";
 import "./Table.css";
 
 class Table extends Component {
@@ -25,12 +27,28 @@ class Table extends Component {
     const propConfig = this.props.config;
     const {dataFormat} = this.props;
 
+    const paginationButtonProps = {
+      className: "cp-table-pagination-button",
+      fontSize: "xxs",
+      iconOnly: true
+    };
+
     const defaults = {
       cellFormat: (key, val) =>
         isNaN(val) ? val : abbreviate(val),
       headerFormat: val => val,
       minRows: 0,
-      showPagination: false
+      showPagination: false,
+      showPageSizeOptions: false, // good luck
+      // custom next/prev buttons when they've been enabled
+      PreviousComponent: props =>
+        <Button icon="arrow-left" {...paginationButtonProps} {...props}>
+          Go to previous page in table
+        </Button>,
+      NextComponent: props =>
+        <Button icon="arrow-right" {...paginationButtonProps} {...props}>
+          Go to next page in table
+        </Button>
     };
 
     const config = Object.assign({}, defaults, propConfig);

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -15,9 +15,6 @@ class Table extends Component {
     this.state = {
       config: null
     };
-    this.props = {
-      minRowsForPagination: 15
-    };
 
     this.viz = React.createRef();
   }
@@ -169,5 +166,9 @@ class Table extends Component {
     );
   }
 }
+
+Table.defaultProps = {
+  minRowsForPagination: 15
+};
 
 export default Table;

--- a/packages/cms/src/components/cards/VisualizationCard.css
+++ b/packages/cms/src/components/cards/VisualizationCard.css
@@ -1,5 +1,9 @@
 @import "../../css/mixins.css";
 
+.cms-visualization-card .rt-table {
+  @mixin overflow-container;
+}
+
 /* keep visualizations from breaking out of the container */
 .cms-visualization-card .visualization {
   max-width: 100%;

--- a/packages/cms/src/components/fields/Button.css
+++ b/packages/cms/src/components/fields/Button.css
@@ -99,4 +99,9 @@
     border-color: var(--button-hover-border-color);
     color: var(--button-hover-color);
   }
+
+  /* make disabled non-cms buttons visually disabled */
+  &[disabled] {
+    opacity: 0.5;
+  }
 }

--- a/packages/cms/src/member/MetaEditor.css
+++ b/packages/cms/src/member/MetaEditor.css
@@ -134,9 +134,6 @@
   /* theming */
   & .rt-tbody .rt-tr.-even .rt-td { background-color: color(var(--white) a(0.5)); }
   & .rt-tbody                     { @mixin font-xxs; }
-  & .-btn                         { @mixin cms-button-style;
-    &[disabled]                   { @mixin disabled-button; @mixin cms-disabled-button-style; }
-  }
   & .-pageJump > input            { @mixin cms-text-input-style; }
   & .-pageJump > *                { margin: 0 0.125em; }
   & .-pagination                  { background-color: var(--light-1); }

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -556,6 +556,22 @@ class MetaEditor extends Component {
       url
     } = this.state;
 
+    // custom pagination buttons
+    const paginationButtonProps = {
+      className: "cms-meta-pagination-button",
+      fontSize: "xxs",
+      iconOnly: true,
+      namespace: "cms"
+    };
+    const PreviousComponent = props =>
+      <Button icon="arrow-left" {...paginationButtonProps} {...props}>
+        Go to previous page in table
+      </Button>;
+    const NextComponent = props =>
+      <Button icon="arrow-right" {...paginationButtonProps} {...props}>
+        Go to next page in table
+      </Button>;
+
     return (
       <div className="cms-panel meta-editor">
         <div className="cms-sidebar cms-meta-header">
@@ -632,6 +648,8 @@ class MetaEditor extends Component {
             pageSize={pageSize < data.length ? pageSize : data.length}
             onPageSizeChange={(pageSize, pageIndex) => this.setState({pageSize, pageIndex})}
             showPagination={data.length > pageSize}
+            PreviousComponent={PreviousComponent}
+            NextComponent={NextComponent}
             showPageSizeOptions={false}
           />
         </div>


### PR DESCRIPTION
Found out you can replace react-table's pagination controls with your own, so I replaced them with canon `Button`s (and did the same for the Meta table while I was at it). 

Tested and made sure the controls are in fact appearing when `showPagination` is set to `true` in viz config.

closes #783