### PR TITLE
makes search population blocking for #821

### DIFF
--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -45,6 +45,7 @@ export function swapEntity(type, id) {
 /** */
 export function modifyDimension(payload) { 
   return function(dispatch, getStore) {
+    dispatch({type: "SEARCH_LOADING"});
     const diffCounter = getStore().cms.status.diffCounter + 1;
     return axios.post("/api/cms/profile/upsertDimension", payload)
       .then(({data}) => {

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -559,7 +559,7 @@ module.exports = function(app) {
       const ordering = typeof maxFetch[0].max === "number" ? maxFetch[0].max + 1 : 0;
       profileData.ordering = ordering;
       await db.profile_meta.create(profileData);
-      populateSearch(profileData, db);
+      await populateSearch(profileData, db);
     }
     // Updates are more complex - the user may have changed levels, or even modified the dimension
     // entirely. We have to prune the search before repopulating it.
@@ -567,7 +567,7 @@ module.exports = function(app) {
       await db.profile_meta.update(profileData, {where: {id: profileData.id}});
       if (oldmeta.dimension !== profileData.dimension || oldmeta.levels.join() !== profileData.levels.join()) {
         pruneSearch(oldmeta.dimension, oldmeta.levels, db);
-        populateSearch(profileData, db);
+        await populateSearch(profileData, db);
       }
     }
     const reqObj = Object.assign({}, profileReqFull, {where: {id: profile_id}});

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -48,12 +48,20 @@ class ProfileBuilder extends Component {
   render() {
 
     const {toolboxVisible} = this.state;
-    const {currentPid, gensLoaded, gensTotal, genLang, pathObj, previews, profilesLoaded} = this.props.status;
+    const {currentPid, gensLoaded, gensTotal, genLang, pathObj, previews, profilesLoaded, searchLoading} = this.props.status;
 
     const type = pathObj.section ? "section" : pathObj.profile ? "profile" : null;
     const editorTypes = {profile: ProfileEditor, section: SectionEditor};
     const Editor = editorTypes[type];
     const id = pathObj.section ? Number(pathObj.section) : pathObj.profile ? Number(pathObj.profile) : null;
+
+    const gensRecompiling = gensLoaded !== gensTotal;
+    const gensBusy = `${gensLoaded} of ${gensTotal} Generators Loaded (${genLang})`;
+    const gensDone = "Variables Loaded";
+
+    const searchRecompiling = searchLoading;
+    const searchBusy = "Loading Search Members, please wait.";
+    const searchDone = "Members Loaded.";
 
     if (!profilesLoaded) return null;
 
@@ -88,9 +96,9 @@ class ProfileBuilder extends Component {
             </Toolbox>
 
             <Status
-              recompiling={gensLoaded !== gensTotal}
-              busy={`${gensLoaded} of ${gensTotal} Generators Loaded (${genLang})`}
-              done="Variables Loaded"
+              recompiling={gensRecompiling || searchRecompiling}
+              busy={gensRecompiling ? gensBusy : searchBusy}
+              done={gensRecompiling ? gensDone : searchDone}
             />
           </div>
         </div>

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -77,8 +77,10 @@ export default (status = {}, action) => {
       return Object.assign({}, status, newStatus);
     case "SECTION_UPDATE": 
       return Object.assign({}, status, {diffCounter: action.diffCounter});
+    case "SEARCH_LOADING": 
+      return Object.assign({}, status, {searchLoading: true});
     case "DIMENSION_MODIFY": 
-      return Object.assign({}, status, {diffCounter: action.diffCounter});
+      return Object.assign({}, status, {diffCounter: action.diffCounter, searchLoading: false});
     case "DIMENSION_DELETE": 
       return Object.assign({}, status, {diffCounter: action.diffCounter});
     // Deleting a profile requires resetting currentNode/Pid. It will be reset when the jsx picks a new node automatically


### PR DESCRIPTION
Closes #821 

@davelandry The reason for the above issue was that I was populating the search table asynchronously. Therefore, the Profile came back as created before any search rows were inserted, and no preview was being auto-selected.  This caused the preview to be empty, and `<id>` to not work in our first generator.

There are a few ways to think of how to address this:

1) You need to click your own preview AFTER adding a dimension. This is what people usually do, they search for a sample member in the search, and by the time they do this, the search has populated (partially, at least).

2) We could switch to the "I only ever fetch variables if you press a manual button" school of thought.  This would refuse to run if you hadn't picked a preview, which would prevent the behavior above.

3) I can block on profile creation, and wait for the members to populate, then auto-select one as normal.

I have chosen #3 for this PR. When a user adds a dimension, a Status bar asks that the user wait while the search members populate.  Once this is complete, the highest z-index is chosen automatically as usual. Though this can be a pain to wait, I can't pick a member until I'm done inserting search members, after all, that's the cause of the bug in the first place.

It's worth remembering that this interaction (adding dimensions) only happens a handful of times, early in CMS usage. 

If you want behavior #3, please review this PR. If not, let's chat more on how to handle this.