### PR TITLE
hotfixes bug when cube is changed underneath meta

### DIFF
--- a/packages/cms/src/components/editors/DimensionEditor.jsx
+++ b/packages/cms/src/components/editors/DimensionEditor.jsx
@@ -35,8 +35,8 @@ class DimensionEditor extends Component {
         slug: meta.slug,
         cubeName: meta.cubeName,
         dimName: meta.dimension,
-        dimension: selectedDimension.name,
-        hierarchies: selectedDimension.hierarchies,
+        dimension: selectedDimension ? selectedDimension.name : "",
+        hierarchies: selectedDimension ? selectedDimension.hierarchies : "",
         levels: meta.levels,
         measure: meta.measure
       };
@@ -150,7 +150,7 @@ class DimensionEditor extends Component {
           value={profileData.dimension}
           onChange={this.chooseDimension.bind(this)}
         >
-          <option value="default">Choose a selector</option>
+          <option value="default">Choose a Dimension</option>
           {dimOptions}
         </Select>
 


### PR DESCRIPTION
Handles the case where a cube has been changed beneath an existing configuration, so the user can successfully open and modify a dimension without crashing.