### PR TITLE
Issue 825

### DIFF
--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -86,6 +86,10 @@ class Builder extends Component {
     }
   }
 
+  /**
+   * Almost every child of Builder makes use of redux "resources" to access formatters. However, Viz.jsx
+   * misbehaves when wrapped in redux-connect, so for Viz.jsx ONLY, we pass it down via context.
+   */
   getChildContext() {
     const {formatters} = this.state;
     return {

--- a/packages/cms/src/actions/formatters.js
+++ b/packages/cms/src/actions/formatters.js
@@ -1,11 +1,5 @@
 import axios from "axios";
-
-const getLocales = env => {
-  const localeDefault = env.CANON_LANGUAGE_DEFAULT || "en";
-  const locales = env.CANON_LANGUAGES ? env.CANON_LANGUAGES.split(",") : [localeDefault];
-  if (!locales.includes(localeDefault)) locales.push(localeDefault);
-  return locales;
-};
+import getLocales from "../utils/getLocales";
 
 /** */
 export function getFormatters() { 
@@ -17,34 +11,3 @@ export function getFormatters() {
       });
   };
 }
-
-/** */
-export function newFormatter(payload) { 
-  return function(dispatch, getStore) {
-    return axios.post(`${getStore().env.CANON_API}/api/cms/formatter/new`, payload)
-      .then(({data}) => {
-        dispatch({type: "FORMATTER_NEW", data});
-      });
-  };
-}
-
-/** */
-export function updateFormatter(payload) { 
-  return function(dispatch, getStore) {
-    return axios.post(`${getStore().env.CANON_API}/api/cms/formatter/update`, payload)
-      .then(({data}) => {
-        dispatch({type: "FORMATTER_UPDATE", data});
-      });
-  };
-}
-
-/** */
-export function deleteFormatter(id) { 
-  return function(dispatch, getStore) {
-    axios.delete(`${getStore().env.CANON_API}/api/cms/formatter/delete`, {params: {id}})
-      .then(({data}) => {
-        dispatch({type: "FORMATTER_DELETE", data});
-      });
-  };
-}
-

--- a/packages/cms/src/actions/formatters.js
+++ b/packages/cms/src/actions/formatters.js
@@ -1,11 +1,19 @@
 import axios from "axios";
 
+const getLocales = env => {
+  const localeDefault = env.CANON_LANGUAGE_DEFAULT || "en";
+  const locales = env.CANON_LANGUAGES ? env.CANON_LANGUAGES.split(",") : [localeDefault];
+  if (!locales.includes(localeDefault)) locales.push(localeDefault);
+  return locales;
+};
+
 /** */
 export function getFormatters() { 
   return function(dispatch, getStore) {
+    const locales = getLocales(getStore().env);
     return axios.get(`${getStore().env.CANON_API}/api/cms/formatter`)
       .then(({data}) => {
-        dispatch({type: "FORMATTER_GET", data});
+        dispatch({type: "FORMATTER_GET", data, locales});
       });
   };
 }

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import {assign} from "d3plus-common";
 import deepClone from "../utils/deepClone";
+import getLocales from "../utils/getLocales";
 
 /** */
 export function getProfiles() {
@@ -78,10 +79,13 @@ export function newEntity(type, payload) {
 /** */
 export function updateEntity(type, payload) { 
   return function(dispatch, getStore) {
+    // Updates might need to trigger re-running certain displays. Use diffcounter to track changes
     const diffCounter = getStore().cms.status.diffCounter + 1;
+    // Formatters require locales in the payload to know what languages to compile for
+    const locales = getLocales(getStore().env);
     return axios.post(`${getStore().env.CANON_API}/api/cms/${type}/update`, payload)
       .then(({data}) => {
-        dispatch({type: `${type.toUpperCase()}_UPDATE`, data, diffCounter});
+        dispatch({type: `${type.toUpperCase()}_UPDATE`, data, diffCounter, locales});
       });
   };
 }

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -79,7 +79,7 @@ export function newEntity(type, payload) {
 /** */
 export function updateEntity(type, payload) { 
   return function(dispatch, getStore) {
-    // Updates might need to trigger re-running certain displays. Use diffcounter to track changes
+    // Updates might need to trigger re-running certain displays. Use diffCounter to track changes
     const diffCounter = getStore().cms.status.diffCounter + 1;
     // Formatters require locales in the payload to know what languages to compile for
     const locales = getLocales(getStore().env);
@@ -93,9 +93,13 @@ export function updateEntity(type, payload) {
 /** */
 export function deleteEntity(type, payload) { 
   return function(dispatch, getStore) {
+    // Deletes might need to trigger re-running certain displays. Use diffCounter to track changes
+    const diffCounter = getStore().cms.status.diffCounter + 1;
+    // Formatters require locales in the payload to know what languages to compile for
+    const locales = getLocales(getStore().env);
     axios.delete(`${getStore().env.CANON_API}/api/cms/${type}/delete`, {params: payload})
       .then(({data}) => {
-        dispatch({type: `${type.toUpperCase()}_DELETE`, data});
+        dispatch({type: `${type.toUpperCase()}_DELETE`, data, diffCounter, locales});
       });
   };
 }

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -600,13 +600,20 @@ module.exports = function(app) {
           await db[`${ref}_content`].upsert(content, {where: {id, locale: content.locale}}).catch(catcher);
         }
       }
-      if (contentTables.includes(ref)) {
-        const u = await db[ref].findOne({where: {id}, include: {association: "content"}}).catch(catcher);
-        return res.json(u);
+      // Formatters are a special update case - return the whole list on update (necessary for recompiling them)
+      if (ref === "formatter") {
+        const rows = await db.formatter.findAll().catch(catcher);
+        return res.json(rows);
       }
       else {
-        const u = await db[ref].findOne({where: {id}}).catch(catcher);
-        return res.json(u);
+        if (contentTables.includes(ref)) {
+          const u = await db[ref].findOne({where: {id}, include: {association: "content"}}).catch(catcher);
+          return res.json(u);
+        }
+        else {
+          const u = await db[ref].findOne({where: {id}}).catch(catcher);
+          return res.json(u);
+        }
       }
     });
   });

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -11,7 +11,6 @@ import PlainTextEditor from "../editors/PlainTextEditor";
 import deepClone from "../../utils/deepClone";
 import stripHTML from "../../utils/formatters/stripHTML";
 import formatFieldName from "../../utils/formatters/formatFieldName";
-import PropTypes from "prop-types";
 import LocaleName from "./components/LocaleName";
 import Card from "./Card";
 
@@ -106,6 +105,7 @@ class TextCard extends Component {
   formatDisplay() {
     const {selectors} = this.props;
     const {localeDefault, localeSecondary, query} = this.props.status;
+    const {formatterFunctions} = this.props.resources;
     // Stories use TextCards, but don't need variables.
     const variables = this.props.status.variables[localeDefault] ? this.props.status.variables[localeDefault] : {};
 
@@ -120,7 +120,7 @@ class TextCard extends Component {
     // polluting the object itself
     minData.selectors = selectors;
 
-    const thisFormatters = this.context.formatters[localeDefault];
+    const thisFormatters = formatterFunctions[localeDefault];
     // Swap vars, and extract the actual (multilingual) content
     const content = varSwapRecursive(minData, thisFormatters, variables, query).content;
     const thisLang = content.find(c => c.locale === localeDefault);
@@ -136,7 +136,7 @@ class TextCard extends Component {
 
     if (localeSecondary) {
       thatDisplayData = {};
-      const thatFormatters = this.context.formatters[localeSecondary];
+      const thatFormatters = formatterFunctions[localeSecondary];
       const content = varSwapRecursive(minData, thatFormatters, variables, query).content;
       const thatLang = content.find(c => c.locale === localeSecondary);
 
@@ -372,12 +372,9 @@ class TextCard extends Component {
   }
 }
 
-TextCard.contextTypes = {
-  formatters: PropTypes.object
-};
-
 const mapStateToProps = state => ({
   status: state.cms.status,
+  resources: state.cms.resources,
   selectors: state.cms.status.currentPid ? state.cms.profiles.find(p => p.id === state.cms.status.currentPid).selectors : []
 });
 

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -92,6 +92,7 @@ class VisualizationCard extends Component {
     const {minData, showReorderButton} = this.props;
     const {isOpen, alertObj} = this.state;
     const {query} = this.props.status;
+    const {formatterFunctions} = this.props.resources;
 
     const minDataState = this.state.minData;
 
@@ -101,7 +102,7 @@ class VisualizationCard extends Component {
     const {localeDefault} = this.props.status;
     // Stories can use VisualizationCards, but don't have variables.
     const variables = this.props.status.variables[localeDefault] ? this.props.status.variables[localeDefault] : {};
-    const formatters = this.context.formatters[localeDefault];
+    const formatters = formatterFunctions[localeDefault];
 
     // TODO: add formatters toggle for secondaryLocale & secondaryVariables
 
@@ -182,12 +183,12 @@ class VisualizationCard extends Component {
 }
 
 VisualizationCard.contextTypes = {
-  formatters: PropTypes.object,
   variables: PropTypes.object
 };
 
 const mapStateToProps = state => ({
   status: state.cms.status,
+  resources: state.cms.resources,
   selectors: state.cms.status.currentPid ? state.cms.profiles.find(p => p.id === state.cms.status.currentPid).selectors : []
 });
 

--- a/packages/cms/src/components/editors/SimpleVisualizationEditor.jsx
+++ b/packages/cms/src/components/editors/SimpleVisualizationEditor.jsx
@@ -1,6 +1,5 @@
 import axios from "axios";
 import React, {Component} from "react";
-import PropTypes from "prop-types";
 import {connect} from "react-redux";
 import {Alert, Intent} from "@blueprintjs/core";
 import urlSwap from "../../utils/urlSwap";
@@ -338,7 +337,8 @@ class SimpleVisualizationEditor extends Component {
   render() {
     const {object, rebuildAlertOpen, payload} = this.state;
     const {localeDefault} = this.props.status;
-    const formatters = this.context.formatters[localeDefault];
+    const {formatterFunctions} = this.props.resources;
+    const formatters = formatterFunctions[localeDefault];
     const formatterList = formatters ? Object.keys(formatters).sort((a, b) => a.localeCompare(b)) : [];
     const selectedColumns = object.columns || [];
     const firstObj = payload.length > 0 && payload[0] ? payload[0] : {};
@@ -471,13 +471,10 @@ class SimpleVisualizationEditor extends Component {
   }
 }
 
-SimpleVisualizationEditor.contextTypes = {
-  formatters: PropTypes.object
-};
-
 const mapStateToProps = state => ({
   env: state.env,
-  status: state.cms.status
+  status: state.cms.status,
+  resources: state.cms.resources
 });
 
 export default connect(mapStateToProps)(SimpleVisualizationEditor);

--- a/packages/cms/src/components/editors/TextEditor.jsx
+++ b/packages/cms/src/components/editors/TextEditor.jsx
@@ -1,6 +1,5 @@
 import React, {Component} from "react";
 import QuillWrapper from "./QuillWrapper";
-import PropTypes from "prop-types";
 import {connect} from "react-redux";
 
 import formatFieldName from "../../utils/formatters/formatFieldName";
@@ -47,10 +46,9 @@ class TextEditor extends Component {
     const {data, fields} = this.state;
     const {contentType, locale} = this.props;
     // Stories use TextEditors, but don't need variables.
-    const variables = this.props.status.variables[locale] ? this.props.status.variables[locale] : {}
-    const formatters = this.context.formatters[locale];
+    const variables = this.props.status.variables[locale] ? this.props.status.variables[locale] : {};
 
-    if (!data || !fields || !variables || !formatters) return null;
+    if (!data || !fields || !variables) return null;
 
     const thisLocale = data.content.find(c => c.locale === locale);
 
@@ -71,10 +69,6 @@ class TextEditor extends Component {
     );
   }
 }
-
-TextEditor.contextTypes = {
-  formatters: PropTypes.object
-};
 
 const mapStateToProps = state => ({
   status: state.cms.status

--- a/packages/cms/src/components/interface/Navbar.jsx
+++ b/packages/cms/src/components/interface/Navbar.jsx
@@ -1,7 +1,6 @@
 import React, {Component, Fragment} from "react";
 import {connect} from "react-redux";
 import {hot} from "react-hot-loader/root";
-import PropTypes from "prop-types";
 import {Icon} from "@blueprintjs/core";
 
 import varSwapRecursive from "../../utils/varSwapRecursive";
@@ -10,7 +9,6 @@ import {getProfiles, newProfile, deleteProfile, setVariables, resetPreviews} fro
 import {getStories, newStory, deleteStory} from "../../actions/stories";
 import {setStatus} from "../../actions/status";
 import {getCubeData} from "../../actions/cubeData";
-import {getFormatters} from "../../actions/formatters";
 
 import stripHTML from "../../utils/formatters/stripHTML";
 
@@ -35,7 +33,6 @@ class Navbar extends Component {
   componentDidMount() {
     this.props.getProfiles();
     this.props.getStories();
-    this.props.getFormatters();
     this.props.getCubeData();
   }
 
@@ -185,8 +182,9 @@ class Navbar extends Component {
   formatLabel(str) {
     const {profiles} = this.props;
     const {query, localeDefault, currentPid} = this.props.status;
+    const {formatterFunctions} = this.props.resources;
     const variables = this.props.status.variables[localeDefault] || {};
-    const formatters = this.context.formatters[localeDefault];
+    const formatters = formatterFunctions[localeDefault];
     const thisProfile = profiles.find(p => p.id === currentPid);
     const selectors = thisProfile ? thisProfile.selectors : [];
     str = stripHTML(str);
@@ -463,13 +461,10 @@ class Navbar extends Component {
   }
 }
 
-Navbar.contextTypes = {
-  formatters: PropTypes.object
-};
-
 const mapStateToProps = state => ({
   auth: state.auth,
   status: state.cms.status,
+  resources: state.cms.resources,
   profiles: state.cms.profiles,
   stories: state.cms.stories
 });
@@ -487,8 +482,6 @@ const mapDispatchToProps = dispatch => ({
   // Status Operations
   setStatus: status => dispatch(setStatus(status)),
   setVariables: newVariables => dispatch(setVariables(newVariables)),
-  // Formatters
-  getFormatters: () => dispatch(getFormatters()),
   // CubeData
   getCubeData: () => dispatch(getCubeData())
 });

--- a/packages/cms/src/reducers/formatters.js
+++ b/packages/cms/src/reducers/formatters.js
@@ -5,7 +5,7 @@ export default (formatters = [], action) => {
     case "FORMATTER_NEW":
       return formatters.concat([action.data]);
     case "FORMATTER_UPDATE":
-      return formatters.map(f => f.id === action.data.id ? action.data : f);
+      return action.data;
     case "FORMATTER_DELETE":
       return action.data;
     default: return formatters;

--- a/packages/cms/src/reducers/index.js
+++ b/packages/cms/src/reducers/index.js
@@ -8,6 +8,7 @@ import cubeData from "./cubeData.js";
 import status from "./status.js";
 import formatters from "./formatters.js";
 import stories from "./stories.js";
+import resources from "./resources.js";
 
 const initialState = {
   status: {
@@ -20,7 +21,10 @@ const initialState = {
   cubeData: {},
   profiles: [],
   stories: [],
-  formatters: []
+  formatters: [],
+  resources: {
+    formatterFunctions: {}
+  }
 };
 
 /** */
@@ -30,6 +34,7 @@ export default function cmsReducer(state = initialState, action) {
     cubeData: cubeData(state.cubeData, action),
     profiles: profiles(state.profiles, action),
     stories: stories(state.stories, action),
-    formatters: formatters(state.formatters, action)
+    formatters: formatters(state.formatters, action),
+    resources: resources(state.resources, action)
   };
 }

--- a/packages/cms/src/reducers/resources.js
+++ b/packages/cms/src/reducers/resources.js
@@ -8,6 +8,12 @@ export default (resources = {}, action) => {
         formatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
       });
       return Object.assign({}, resources, {formatterFunctions});
+    case "FORMATTER_UPDATE": 
+      const updatedFormatterFunctions = {};
+      action.locales.forEach(locale => {
+        updatedFormatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
+      });
+      return Object.assign({}, resources, {formatterFunctions: updatedFormatterFunctions});
     default: return resources;
   }
 };

--- a/packages/cms/src/reducers/resources.js
+++ b/packages/cms/src/reducers/resources.js
@@ -1,0 +1,13 @@
+const funcifyFormatterByLocale = require("../utils/funcifyFormatterByLocale");
+
+export default (resources = {}, action) => {
+  switch (action.type) {
+    case "FORMATTER_GET": 
+      const formatterFunctions = {};
+      action.locales.forEach(locale => {
+        formatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
+      });
+      return Object.assign({}, resources, {formatterFunctions});
+    default: return resources;
+  }
+};

--- a/packages/cms/src/reducers/resources.js
+++ b/packages/cms/src/reducers/resources.js
@@ -1,19 +1,27 @@
 const funcifyFormatterByLocale = require("../utils/funcifyFormatterByLocale");
 
+/** 
+ * Notice that there is no FORMATTER_NEW case here. New formatters simply return `n` and have no name,
+ * so there is no need to recompile anything until the user performs the update action.
+ */
 export default (resources = {}, action) => {
+  const formatterFunctions = {};
   switch (action.type) {
     case "FORMATTER_GET": 
-      const formatterFunctions = {};
       action.locales.forEach(locale => {
         formatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
       });
       return Object.assign({}, resources, {formatterFunctions});
     case "FORMATTER_UPDATE": 
-      const updatedFormatterFunctions = {};
       action.locales.forEach(locale => {
-        updatedFormatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
+        formatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
       });
-      return Object.assign({}, resources, {formatterFunctions: updatedFormatterFunctions});
+      return Object.assign({}, resources, {formatterFunctions});
+    case "FORMATTER_DELETE": 
+      action.locales.forEach(locale => {
+        formatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
+      });
+      return Object.assign({}, resources, {formatterFunctions});
     default: return resources;
   }
 };

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -69,8 +69,9 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
     case "FORMATTER_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "formatter", forceOpen: true});
+    // Updating a formatter means that some formatter logic changed. Bump the diffcounter.
     case "FORMATTER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
     // Updating variables or saving a section or meta means that anything that depends on variables, such as TextCards 
     // Or the tree, needs to know something changed. Instead of running an expensive stringify on variables,
     // Just increment a counter that the various cards can subscribe to.

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -38,10 +38,13 @@ export default (status = {}, action) => {
     // Basic assign
     case "STATUS_SET": 
       return Object.assign({}, status, action.data);
+    // Report loading completion of stories and profiles
     case "PROFILES_GET":
       return Object.assign({}, status, {profilesLoaded: true});
     case "STORIES_GET":
       return Object.assign({}, status, {storiesLoaded: true});
+    case "FORMATTER_GET":
+      return Object.assign({}, status, {formattersLoaded: true});
     // Creation Detection
     case "PROFILE_NEW": 
       return Object.assign({}, status, {justCreated: {type: "profile", id: action.data.id}});
@@ -75,10 +78,13 @@ export default (status = {}, action) => {
       const newStatus = {variables: deepClone(action.data.variables)};
       if (action.data.diffCounter) newStatus.diffCounter = action.data.diffCounter;
       return Object.assign({}, status, newStatus);
+    // Updating sections could mean the title was updated. Bump a "diffcounter" that the Navbar tree can listen for to jigger a render
     case "SECTION_UPDATE": 
       return Object.assign({}, status, {diffCounter: action.diffCounter});
+    // When the user adds a new dimension, set a status that we are waiting for members to finish populating
     case "SEARCH_LOADING": 
       return Object.assign({}, status, {searchLoading: true});
+    // When the dimension modify returns, 
     case "DIMENSION_MODIFY": 
       return Object.assign({}, status, {diffCounter: action.diffCounter, searchLoading: false});
     case "DIMENSION_DELETE": 

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -72,6 +72,8 @@ export default (status = {}, action) => {
     // Updating a formatter means that some formatter logic changed. Bump the diffcounter.
     case "FORMATTER_UPDATE": 
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
+    case "FORMATTER_DELETE": 
+      return Object.assign({}, status, {diffCounter: action.diffCounter});
     // Updating variables or saving a section or meta means that anything that depends on variables, such as TextCards 
     // Or the tree, needs to know something changed. Instead of running an expensive stringify on variables,
     // Just increment a counter that the various cards can subscribe to.

--- a/packages/cms/src/utils/getLocales.js
+++ b/packages/cms/src/utils/getLocales.js
@@ -1,0 +1,7 @@
+// Given an env object, extract and organize the locales into a single deduped array
+module.exports = env => {
+  const localeDefault = env.CANON_LANGUAGE_DEFAULT || "en";
+  const locales = env.CANON_LANGUAGES ? env.CANON_LANGUAGES.split(",") : [localeDefault];
+  if (!locales.includes(localeDefault)) locales.push(localeDefault);
+  return locales;
+};


### PR DESCRIPTION
Closes #825 

Refactors recompiled formatters to live in a new `resources` redux object.  On CRUD operations, two things happen:

1. The actual array of database rows updates in redux `formatters`, so that the Toolbox can show the raw code and allow users to edit them
2. The new `resources` object in redux recompiles all the formatters into a lookup object for use by all cards/vizes