### PR TITLE
Duplication of Profiles and Sections

### DIFF
--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -44,6 +44,16 @@ export function duplicateProfile(id) {
 }
 
 /** */
+export function duplicateSection(id, pid) { 
+  return function(dispatch, getStore) {
+    return axios.post(`${getStore().env.CANON_API}/api/cms/section/duplicate`, {id, pid})
+      .then(({data}) => {
+        dispatch({type: "SECTION_DUPLICATE", data});
+      });
+  };
+}
+
+/** */
 export function swapEntity(type, id) {
   return function(dispatch, getStore) {
     return axios.post(`${getStore().env.CANON_API}/api/cms/${type}/swap`, {id})

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -34,6 +34,16 @@ export function deleteProfile(id) {
 }
 
 /** */
+export function duplicateProfile(id) { 
+  return function(dispatch, getStore) {
+    return axios.post(`${getStore().env.CANON_API}/api/cms/profile/duplicate`, {id})
+      .then(({data}) => {
+        dispatch({type: "PROFILE_DUPLICATE", data});
+      });
+  };
+}
+
+/** */
 export function swapEntity(type, id) {
   return function(dispatch, getStore) {
     return axios.post(`${getStore().env.CANON_API}/api/cms/${type}/swap`, {id})

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -222,6 +222,7 @@ const sortStoryTree = (db, stories) => {
 const sortProfile = (db, profile) => {
   profile.meta = flatSort(db.profile_meta, profile.meta);
   profile.materializers = flatSort(db.materializer, profile.materializers);
+  profile.sections = flatSort(db.section, profile.sections);
   return profile;
 };
 
@@ -712,7 +713,8 @@ module.exports = function(app) {
         const newRows = oldSection[`${entity}s`].map(d => {
           // If the entity is a selector, replace its selector id with the newly cloned selector (created above in lookup)
           if (entity === "selector") {
-            return Object.assign({}, stripID(d), {section_id: newSection.id, selector_id: selectorLookup[d.selector_id]});
+            const s = d.section_selector;
+            return Object.assign({}, stripID(s), {section_id: newSection.id, selector_id: selectorLookup[s.selector_id]});
           }
           // Otherwise, simple overwrite the section id and delete the id as usual
           else {

--- a/packages/cms/src/components/interface/Header.jsx
+++ b/packages/cms/src/components/interface/Header.jsx
@@ -41,6 +41,7 @@ class Header extends Component {
   duplicate(itemToDuplicate) {
     const {type, id} = itemToDuplicate;
     if (type === "profile") this.props.duplicateProfile(id);
+    this.setState({itemToDuplicate: null});
   }
 
   maybeDelete() {
@@ -208,7 +209,7 @@ class Header extends Component {
           onConfirm={() => this.duplicate.bind(this)(itemToDuplicate)}
           onCancel={() => this.setState({itemToDuplicate: null})}
         >
-          select a profile from this list maybe
+          Duplicate this Profile?
         </Alert>
         <Alert
           isOpen={itemToDelete}

--- a/packages/cms/src/components/interface/Header.jsx
+++ b/packages/cms/src/components/interface/Header.jsx
@@ -173,7 +173,7 @@ class Header extends Component {
 
           {/* TODO: make this a popover once we have more options */}
           {/* duplicate entity */}
-          <div className="cms-header-actions-container" key="header-actions-container-duplicate">
+          {pathObj.tab === "profiles" && <div className="cms-header-actions-container" key="header-actions-container-duplicate">
             <Button
               className="cms-header-actions-button cms-header-delete-button"
               onClick={this.maybeDuplicate.bind(this)}
@@ -183,7 +183,7 @@ class Header extends Component {
             >
               {`Duplicate ${entityType === "storysection" ? "section" : entityType}`}
             </Button>
-          </div>
+          </div>}
           {/* delete entity */}
           {showDeleteButton &&
             <div className="cms-header-actions-container" key="header-actions-container-delete">

--- a/packages/cms/src/reducers/profiles.js
+++ b/packages/cms/src/reducers/profiles.js
@@ -28,6 +28,8 @@ export default (profiles = [], action) => {
       return action.data;
     case "PROFILE_NEW":
       return profiles.concat([action.data]);
+    case "PROFILE_DUPLICATE": 
+      return profiles.concat([action.data]);
     case "PROFILE_DELETE":
       return action.data.profiles;
     case "PROFILE_UPDATE":

--- a/packages/cms/src/reducers/profiles.js
+++ b/packages/cms/src/reducers/profiles.js
@@ -92,6 +92,8 @@ export default (profiles = [], action) => {
         }).sort((a, b) => a.ordering - b.ordering)}));
     case "SECTION_NEW":
       return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections.concat([action.data])}) : p);
+    case "SECTION_DUPLICATE":
+      return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections.concat([action.data])}) : p);
     case "SECTION_UPDATE":
       return profiles.map(p => Object.assign({}, p, {sections: p.sections.map(s => s.id === action.data.id ? Object.assign({}, s, {...action.data}) : s)}));
     case "SECTION_DELETE":

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -48,6 +48,8 @@ export default (status = {}, action) => {
     // Creation Detection
     case "PROFILE_NEW": 
       return Object.assign({}, status, {justCreated: {type: "profile", id: action.data.id}});
+    case "PROFILE_DUPLICATE": 
+      return Object.assign({}, status, {justCreated: {type: "profile", id: action.data.id}});
     case "SECTION_NEW": 
       return Object.assign({}, status, {justCreated: {type: "section", id: action.data.id, profile_id: action.data.profile_id}});
     case "STORY_NEW": 

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -52,6 +52,8 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {justCreated: {type: "profile", id: action.data.id}});
     case "SECTION_NEW": 
       return Object.assign({}, status, {justCreated: {type: "section", id: action.data.id, profile_id: action.data.profile_id}});
+    case "SECTION_DUPLICATE": 
+      return Object.assign({}, status, {justCreated: {type: "section", id: action.data.id, profile_id: action.data.profile_id}});
     case "STORY_NEW": 
       return Object.assign({}, status, {justCreated: {type: "story", id: action.data.id}});
     case "STORYSECTION_NEW": 


### PR DESCRIPTION
This PR adds the ability to duplicate profiles and sections.

When copying profiles, the entire tree is preserved.  If a section is copied from one profile to another, many of its variables may be `N/A` due to the fact that the target profile will not share generators. Additionally, if a section is copied to a new profile, it will lose all selectors (as selectors are profile-wide, and the target profile will not have the same selectors).

However, if a section is copied within the same profile, selectors will be preserved.

Closes #826 