### PR TITLE
adds automatic attribute generator to profiles

### DIFF
--- a/packages/cms/src/components/cards/GeneratorCard.jsx
+++ b/packages/cms/src/components/cards/GeneratorCard.jsx
@@ -172,8 +172,8 @@ class GeneratorCard extends Component {
     if (minData && variables) {
       Object.assign(cardProps, {
         title: minData.name, // overwrites placeholder
-        onEdit: this.openEditor.bind(this),
-        onDelete: this.maybeDelete.bind(this),
+        onEdit: minData.locked ? null : this.openEditor.bind(this),
+        onDelete: minData.locked ? null : this.maybeDelete.bind(this),
         // reorder
         reorderProps: showReorderButton ? {
           id: minData.id,
@@ -185,7 +185,7 @@ class GeneratorCard extends Component {
       });
     }
 
-    const {id} = this.props;
+    const {id} = this.props.minData;
 
     return (
       <React.Fragment>
@@ -247,11 +247,8 @@ GeneratorCard.defaultProps = {
   context: "generator" // mostly a styling hook used for formatter cards
 };
 
-const mapStateToProps = (state, ownProps) => ({
-  status: state.cms.status,
-  minData: ownProps.type === "formatter" 
-    ? state.cms.formatters.find(f => f.id === ownProps.id) 
-    : state.cms.profiles.find(p => p.id === state.cms.status.currentPid)[`${ownProps.type}s`].find(g => g.id === ownProps.id)
+const mapStateToProps = state => ({
+  status: state.cms.status
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -200,9 +200,8 @@ SelectorCard.contextTypes = {
   formatters: PropTypes.object
 };
 
-const mapStateToProps = (state, ownProps) => ({
-  status: state.cms.status,
-  minData: state.cms.profiles.find(p => p.id === state.cms.status.currentPid).selectors.find(s => s.id === ownProps.id)
+const mapStateToProps = state => ({
+  status: state.cms.status
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/cms/src/components/interface/Navbar.jsx
+++ b/packages/cms/src/components/interface/Navbar.jsx
@@ -166,6 +166,8 @@ class Navbar extends Component {
       else {
         this.props.setStatus({currentPid: Number(pathObj.profile), pathObj: newPathObj});
         this.props.resetPreviews();
+        // TODO: Remove reset previews - have all profiles come from the server 
+        // with their default values already set.
       }
       if (pathObj.section) {
         this.setState({outlineOpen: true});

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -1,11 +1,14 @@
 import React, {Component} from "react";
 import {connect} from "react-redux";
 import Deck from "./Deck";
+
 import Button from "../fields/Button";
 import ButtonGroup from "../fields/ButtonGroup";
 import FilterSearch from "../fields/FilterSearch";
+
 import GeneratorCard from "../cards/GeneratorCard";
 import SelectorCard from "../cards/SelectorCard";
+
 import ConsoleVariable from "../variables/ConsoleVariable";
 
 import {fetchVariables, newEntity} from "../../actions/profiles";
@@ -37,8 +40,18 @@ class Toolbox extends Component {
     if (changedSinglePreview) {
       this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)});
     }
-    if (changedEntireProfile) {
-      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)}, true);
+    // TODO: This preview-changing detection is a little janky. Change NavBar.jsx (and all cmsRoute Profile gets)
+    // To always deliver profiles with previews already set, remove ResetPreviews, and just call FetchVariables immediately.
+    if (changedEntireProfile) { 
+      const prevSlugs = prevProps.status.previews ? prevProps.status.previews.map(p => p.slug) : [];
+      const currSlugs = this.props.status.previews ? this.props.status.previews.map(p => p.slug) : [];
+      const addedDimension = prevSlugs.length === 0 && currSlugs.length === 1;
+      const deletedDimension = prevSlugs.length === 1 && currSlugs.length === 0;
+      // This check is not perfect, and it fires when moving from profiles with 0 to 1 dimensions and vice versa.
+      // However, the only side effect is not using the cache and re-running the generators.
+      const sameProfileButChangedMeta = addedDimension || deletedDimension || prevSlugs.some(slug => currSlugs.includes(slug));
+      const useCache = !sameProfileButChangedMeta;
+      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)}, useCache);
     }
     if (localeChanged) {
       this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)});
@@ -47,7 +60,7 @@ class Toolbox extends Component {
     const {justDeleted} = this.props.status;
     if (JSON.stringify(prevProps.status.justDeleted) !== JSON.stringify(justDeleted)) {
       // Providing fetchvariables (and ultimately, /api/variables) with a now deleted generator or materializer id
-    // is handled gracefully - it prunes the provided id from the variables object and re-runs necessary gens/mats.
+      // is handled gracefully - it prunes the provided id from the variables object and re-runs necessary gens/mats.
       if (justDeleted.type === "generator") {
         this.props.fetchVariables({type: "generator", ids: [justDeleted.id]});  
       }
@@ -118,10 +131,18 @@ class Toolbox extends Component {
 
     if (!varsLoaded || !defLoaded || !locLoaded) return <div className="cms-toolbox is-loading"><h3>Loading...</h3></div>;
 
-    const generators = profile.generators
+    const attrGen = {
+      id: "attributes",
+      name: "Attributes",
+      locked: true
+    };
+
+    let generators = profile.generators
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(d => Object.assign({}, {type: "generator"}, d))
       .filter(this.filterFunc.bind(this));
+
+    if (this.props.status.profilesLoaded) generators = [attrGen].concat(generators);
 
     const materializers = profile.materializers
       .sort((a, b) => a.ordering - b.ordering)
@@ -213,7 +234,7 @@ class Toolbox extends Component {
               cards={generators.map(g =>
                 <GeneratorCard
                   key={g.id}
-                  id={g.id}
+                  minData={g}
                   context="generator"
                   hidden={!detailView}
                   attr={profile.attr || {}}
@@ -232,7 +253,7 @@ class Toolbox extends Component {
               cards={materializers.map(m =>
                 <GeneratorCard
                   key={m.id}
-                  id={m.id}
+                  minData={m}
                   context="materializer"
                   hidden={!detailView}
                   type="materializer"
@@ -251,7 +272,7 @@ class Toolbox extends Component {
               cards={selectors.map(s =>
                 <SelectorCard
                   key={s.id}
-                  id={s.id}
+                  minData={s}
                 />
               )}
             />
@@ -267,7 +288,7 @@ class Toolbox extends Component {
                 <GeneratorCard
                   context="formatter"
                   key={f.id}
-                  id={f.id}
+                  minData={f}
                   type="formatter"
                   variables={{}}
                 />

--- a/packages/cms/src/utils/mortarEval.js
+++ b/packages/cms/src/utils/mortarEval.js
@@ -2,16 +2,29 @@ const libs = require("./libs");
 
 const envLoc = process.env.CANON_LANGUAGE_DEFAULT || "en";
 
-module.exports = (varInnerName, varOuterValue, logic, formatterFunctions, locale = envLoc) => {
+module.exports = (varInnerName, varOuterValue, logic, formatterFunctions, locale = envLoc, attributes = false) => {
   let vars = {};
   // Because logic is arbitrary javascript, it may be malformed. We need to wrap the
   // entire execution in a try/catch.
   try {
     if (varOuterValue) {
-      eval(`
-        let f = (${varInnerName}, libs, formatters, locale) => {${logic}};
-        vars = f(varOuterValue, libs, formatterFunctions, locale);
-      `);
+      // If attributes has been set, this is being run by a generator who is providing search attributes.
+      // We want those attributes to be available as variables, so pass that in as an argument
+      if (attributes) {
+        eval(`
+          let f = (${varInnerName}, libs, formatters, locale, variables) => {${logic}};
+          vars = f(varOuterValue, libs, formatterFunctions, locale, attributes);
+        `);
+      }
+      // If attributes hasn't been set, this is being run by a materializer. Because a materializer can't ever
+      // be run without generators being run first (and injecting attributes above), we don't need anything special
+      // and can just pass in the variables as normal (via varInnerName)
+      else {
+        eval(`
+          let f = (${varInnerName}, libs, formatters, locale) => {${logic}};
+          vars = f(varOuterValue, libs, formatterFunctions, locale);
+        `);
+      }
       // A successfully run eval will return the vars generated
       return {vars, error: null};
     }


### PR DESCRIPTION
closes #838 

Adds a permanent, automatic attribute generator to all profiles. It will automatically export the `id`, `dimension`, `hierarchy`, and `slug` of the currently selected preview.

Additionally (and importantly!), these attributes run BEFORE the generators. Users now have access to these keys via the normal `variables` object in the generators themselves, allowing for more complex behaviors in the code of the generators.

This PR also includes a few notes in it for a future refactor of managing previews, which I've moved to a new issue, #841