### PR TITLE
adds duplicate catcher

### DIFF
--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -199,7 +199,6 @@ export function resetPreviews() {
 export function fetchVariables(config, useCache) { 
   return function(dispatch, getStore) {    
     const {previews, localeDefault, localeSecondary, currentPid} = getStore().cms.status;
-    const diffCounter = getStore().cms.status.diffCounter + 1;
 
     const thisProfile = getStore().cms.profiles.find(p => p.id === currentPid);
     let variables = deepClone(thisProfile.variables);
@@ -210,6 +209,7 @@ export function fetchVariables(config, useCache) {
     // useCache will be true if the front-end is telling us we have the variables already. Short circuit the gets/puts
     // However, still increment diffCounter so a re-render happens on cards that rely on variables.
     if (useCache && thisProfile.variables) {
+      const diffCounter = getStore().cms.status.diffCounter + 1;
       dispatch({type: "VARIABLES_SET", data: {id: currentPid, variables: deepClone(thisProfile.variables), diffCounter}});
     }
     else {
@@ -253,6 +253,7 @@ export function fetchVariables(config, useCache) {
           // Once pruned, we can POST the variables to the materializer endpoint
           axios.post(`${getStore().env.CANON_API}/api/materializers/${currentPid}?locale=${thisLocale}${paramString}`, {variables: variables[thisLocale]}).then(mat => {
             variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
+            const diffCounter = getStore().cms.status.diffCounter + 1;
             dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
           });
         }
@@ -296,6 +297,7 @@ export function fetchVariables(config, useCache) {
                 });
                 axios.post(`${getStore().env.CANON_API}/api/materializers/${currentPid}?locale=${thisLocale}${paramString}`, {variables: variables[thisLocale]}).then(mat => {
                   variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
+                  const diffCounter = getStore().cms.status.diffCounter + 1;
                   dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
                 });
               }

--- a/packages/cms/src/components/cards/GeneratorCard.css
+++ b/packages/cms/src/components/cards/GeneratorCard.css
@@ -14,3 +14,5 @@
   margin-top: 0.25em;
   margin-bottom: 0.25em;
 }
+
+.cms-card-error { @mixin error-text; }

--- a/packages/cms/src/components/cards/GeneratorCard.jsx
+++ b/packages/cms/src/components/cards/GeneratorCard.jsx
@@ -22,7 +22,8 @@ class GeneratorCard extends Component {
       displayData: null,
       secondaryDisplayData: null,
       alertObj: false,
-      isDirty: false
+      isDirty: false,
+      dupes: []
     };
   }
 
@@ -37,7 +38,6 @@ class GeneratorCard extends Component {
   componentDidUpdate(prevProps) {
     const {type, minData} = this.props;
     const {id} = minData;
-    const {localeDefault, localeSecondary} = this.props.status;
     // If the props we receive from redux have changed, then an update action has occured.
     if (JSON.stringify(prevProps.minData) !== JSON.stringify(this.props.minData)) {
       // If a gen/mat was saved, re-run fetchvariables for just this one gen/mat.
@@ -48,21 +48,14 @@ class GeneratorCard extends Component {
       // Clone the new object for manipulation in state.
       this.setState({minData: deepClone(this.props.minData)});
     }
-    // If any of the variables for THIS gen/mat has changed, update the display panel
+    // If diffCounter incremented, it means a variables update completed, either from this card saving,
+    // or from ANOTHER card saving. If it was this card, we need to update the front panel, if it was another card,
+    // we may need to update whether this card contains a duplicate. Either way, format the display.
     if (type === "generator" || type === "materializer") {
-      let locales = [localeDefault];
-      if (this.props.status.localeSecondary) locales = locales.concat([localeSecondary]);
-      const changed = locales.some(loc => 
-        ["_genStatus", "_matStatus"].some(status => 
-          prevProps.status.variables[loc] && 
-          prevProps.status.variables[loc][status] && 
-          this.props.status.variables[loc] && 
-          this.props.status.variables[loc][status] && 
-          JSON.stringify(prevProps.status.variables[loc][status][id]) !== JSON.stringify(this.props.status.variables[loc][status][id])
-        )
-      );
-      if (changed) this.formatDisplay.bind(this)();
+      const variablesChanged = prevProps.status.diffCounter !== this.props.status.diffCounter;
+      if (variablesChanged) this.formatDisplay.bind(this)();
     }
+
     if (this.props.status.forceType === type && !prevProps.status.forceID && this.props.status.forceID === id) {
       this.openEditor.bind(this)();
     }
@@ -75,6 +68,7 @@ class GeneratorCard extends Component {
     const secondaryVariables = this.props.status.variables[localeSecondary];
     const {id} = this.props.minData;
     let displayData, secondaryDisplayData = {};
+    let dupes = [];
     if (type === "generator") {
       displayData = variables._genStatus[id];
       if (localeSecondary) {
@@ -87,7 +81,19 @@ class GeneratorCard extends Component {
         secondaryDisplayData = secondaryVariables._matStatus[id];
       }
     }
-    this.setState({displayData, secondaryDisplayData});
+    if (type === "generator" || type === "materializer") {
+      const status = type === "generator" ? "_genStatus" : "_matStatus";
+      const theseVars = variables[status][id];
+      if (theseVars) {
+        const otherGens = Object.keys(variables._genStatus).reduce((acc, _id) => 
+          type === "materializer" || Number(id) !== Number(_id) ? Object.assign({}, acc, variables._genStatus[_id]) : acc, {});
+        const otherMats = Object.keys(variables._matStatus).reduce((acc, _id) => 
+          type === "generator" || Number(id) !== Number(_id) ? Object.assign({}, acc, variables._matStatus[_id]) : acc, {});    
+        const thoseVars = {...otherGens, ...otherMats};
+        dupes = dupes.concat(Object.keys(theseVars).reduce((acc, k) => thoseVars[k] !== undefined ? acc.concat(k) : acc, []));
+      }
+    }
+    this.setState({displayData, secondaryDisplayData, dupes});
   }
 
   maybeDelete() {
@@ -148,7 +154,7 @@ class GeneratorCard extends Component {
     const {attr, context, type, showReorderButton} = this.props;
     const {localeDefault, localeSecondary} = this.props.status;
     const {variables} = this.props.status;
-    const {displayData, secondaryDisplayData, isOpen, alertObj} = this.state;
+    const {displayData, secondaryDisplayData, isOpen, alertObj, dupes} = this.state;
 
     const {minData} = this.props;
 
@@ -202,16 +208,19 @@ class GeneratorCard extends Component {
                 {localeSecondary &&
                   <LocaleName>{localeDefault}</LocaleName>
                 }
-                <VarTable dataset={displayData} />
+                <VarTable dataset={displayData} dupes={dupes}/>
               </div>
 
               {localeSecondary &&
                 <div className="cms-card-locale-container">
                   <LocaleName>{localeSecondary}</LocaleName>
-                  <VarTable dataset={secondaryDisplayData} />
+                  <VarTable dataset={secondaryDisplayData} dupes={dupes} />
                 </div>
               }
             </div>
+          }
+          {dupes.length > 0 && 
+            <div style={{color: "red"}}>Warning: Variables reused!</div>
           }
         </Card>
 

--- a/packages/cms/src/components/cards/GeneratorCard.jsx
+++ b/packages/cms/src/components/cards/GeneratorCard.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {Dialog} from "@blueprintjs/core";
+import {Dialog, Tooltip} from "@blueprintjs/core";
 import GeneratorEditor from "../editors/GeneratorEditor";
 import FooterButtons from "../editors/components/FooterButtons";
 import {connect} from "react-redux";
@@ -220,7 +220,7 @@ class GeneratorCard extends Component {
             </div>
           }
           {dupes.length > 0 && 
-            <div style={{color: "red"}}>Warning: Variables reused!</div>
+            <div style={{color: "red"}}>Warning: Highlighted variables conflict with another generator or materializer</div>
           }
         </Card>
 

--- a/packages/cms/src/components/cards/GeneratorCard.jsx
+++ b/packages/cms/src/components/cards/GeneratorCard.jsx
@@ -220,7 +220,7 @@ class GeneratorCard extends Component {
             </div>
           }
           {dupes.length > 0 && 
-            <div style={{color: "red"}}>Warning: Highlighted variables conflict with another generator or materializer</div>
+            <p className="cms-card-error u-font-xxs">Warning: Highlighted variables conflict with another generator or materializer</p>
           }
         </Card>
 

--- a/packages/cms/src/components/variables/ConsoleVariable.jsx
+++ b/packages/cms/src/components/variables/ConsoleVariable.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import "./ConsoleVariable.css";
 
-function evalType(value) {
+const evalType = value => {
   let t = typeof value;
   if (t === "object") {
     if (value === null) return "undefined";
@@ -9,7 +9,7 @@ function evalType(value) {
     else if (["Error", "EvalError", "ReferenceError", "SyntaxError"].includes(value.constructor.name)) t = "error";
   }
   return t;
-}
+};
 
 export default class ConsoleVariable extends Component {
 

--- a/packages/cms/src/components/variables/VarTable.css
+++ b/packages/cms/src/components/variables/VarTable.css
@@ -42,3 +42,5 @@
     top: -3px;
   }
 }
+
+.cms-var-table-cell.warning { @mixin error-text; }

--- a/packages/cms/src/components/variables/VarTable.jsx
+++ b/packages/cms/src/components/variables/VarTable.jsx
@@ -18,7 +18,7 @@ export default class VarTable extends Component {
             {Object.keys(dataset).map(k =>
               <tr className="cms-var-table-row" key={ k }>
                 {dupes.includes(k) 
-                  ? <td style={{color: "red"}} className="cms-var-table-cell">
+                  ? <td className="cms-var-table-cell warning">
                     { k }:
                   </td>
                   : <td className="cms-var-table-cell">

--- a/packages/cms/src/components/variables/VarTable.jsx
+++ b/packages/cms/src/components/variables/VarTable.jsx
@@ -6,6 +6,7 @@ import "./VarTable.css";
 export default class VarTable extends Component {
   render() {
     const {dataset} = this.props;
+    const dupes = this.props.dupes || [];
 
     return dataset
       ? dataset.error || Object.values(dataset).length < 1
@@ -16,9 +17,15 @@ export default class VarTable extends Component {
           <tbody className="cms-var-table-body">
             {Object.keys(dataset).map(k =>
               <tr className="cms-var-table-row" key={ k }>
-                <td className="cms-var-table-cell">
-                  { k }:
-                </td>
+                {dupes.includes(k) 
+                  ? <td style={{color: "red"}} className="cms-var-table-cell">
+                    { k }:
+                  </td>
+                  : <td className="cms-var-table-cell">
+                    { k }:
+                  </td>
+                }
+                
                 <td className="cms-var-table-cell">
                   <ConsoleVariable value={ dataset[k] } />
                 </td>

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -63,13 +63,9 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "generator", forceOpen: true});
     case "GENERATOR_UPDATE": 
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
-    case "GENERATOR_DELETE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
     case "MATERIALIZER_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "materializer", forceOpen: true});
     case "MATERIALIZER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
-    case "MATERIALIZER_DELETE": 
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
     case "SELECTOR_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "selector", forceOpen: true});
@@ -109,9 +105,15 @@ export default (status = {}, action) => {
     case "SECTION_DELETE": 
       return Object.assign({}, status, {justDeleted: {type: "section", id: action.data.id, parent_id: action.data.parent_id}});
     case "GENERATOR_DELETE": 
-      return Object.assign({}, status, {justDeleted: {type: "generator", id: action.data.id, parent_id: action.data.parent_id}});
+      return Object.assign({}, status, {
+        justDeleted: {type: "generator", id: action.data.id, parent_id: action.data.parent_id},
+        toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false
+      });
     case "MATERIALIZER_DELETE": 
-      return Object.assign({}, status, {justDeleted: {type: "materializer", id: action.data.id, parent_id: action.data.parent_id}});
+      return Object.assign({}, status, {
+        justDeleted: {type: "materializer", id: action.data.id, parent_id: action.data.parent_id},
+        toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false
+      });
     case "STORY_DELETE": 
       return Object.assign({}, status, {justDeleted: {type: "story", id: action.data.id}, currentStoryPid: false});
     case "STORYSECTION_DELETE": 


### PR DESCRIPTION
Catches duplicate variables, Closes #707

I also backpacked a few bug fixes into this PR:

- fixed a bug that caused some variables not to show when switching to multi-language mode (due to a problem with how `diffCounter` was incremented)
- Simplified logic that GeneratorCards use to determine when to update their display panel
- Combined accidental duplicate cases in profile reducer, causing gen/mat deletions to misbehave.