### PR TITLE
[cms] Add custom allowed field

### DIFF
--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -339,7 +339,7 @@ class TextCard extends Component {
             { !hideAllowed &&
               <AllowedSelector
                 variables={variables}
-                value={minDataState.allowed || "always"}
+                value={minDataState.allowed !== undefined ? minDataState.allowed : "always"}
                 onChange={this.chooseVariable.bind(this)}
               />
             }

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -28,7 +28,8 @@ class TextCard extends Component {
       thatDisplayData: null,
       initialData: null,
       alertObj: false,
-      isDirty: false
+      isDirty: false,
+      customAllowed: false
     };
   }
 
@@ -226,6 +227,10 @@ class TextCard extends Component {
     );
   }
 
+  toggleCustom(e) {
+    this.setState({customAllowed: e.target.checked});
+  }
+
   chooseVariable(e) {
     const {minData} = this.state;
     minData.allowed = e.target.value;
@@ -233,7 +238,7 @@ class TextCard extends Component {
   }
 
   render() {
-    const {alertObj, thisDisplayData, thatDisplayData, isOpen} = this.state;
+    const {alertObj, thisDisplayData, thatDisplayData, isOpen, customAllowed} = this.state;
     const {minData} = this.props;
     const {fields, hideAllowed, plainfields, type, showReorderButton} = this.props;
     const {localeDefault, localeSecondary} = this.props.status;
@@ -300,7 +305,7 @@ class TextCard extends Component {
           return <option key={key} value={key} dangerouslySetInnerHTML={{__html: `${key}${label}`}}></option>;
         }));
 
-    const showVars = Object.keys(variables).length > 0 && !hideAllowed;
+    const showVars = Object.keys(variables).length > 0;
 
     return (
       <Card {...cardProps}>
@@ -349,17 +354,29 @@ class TextCard extends Component {
               }
             </div>
 
-            { showVars &&
-              <Select
-                label="Visible"
-                namespace="cms"
-                value={minDataState.allowed || "always"}
-                onChange={this.chooseVariable.bind(this)}
-                inline
-              >
-                {varOptions}
-              </Select>
+            { !hideAllowed 
+              ? customAllowed
+                ? <input type="text" />
+                : showVars
+                  ? <Select
+                    label="Visible"
+                    namespace="cms"
+                    value={minDataState.allowed || "always"}
+                    onChange={this.chooseVariable.bind(this)}
+                    inline
+                  >
+                    {varOptions}
+                  </Select>
+                  : null
+              : null
             }
+            <label>
+              <input 
+                type="checkbox" 
+                value={customAllowed} 
+                onChange={this.toggleCustom.bind(this)} 
+              /> Override Visible property with custom variable
+            </label>
           </div>
 
           <FooterButtons

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -5,13 +5,13 @@ import varSwapRecursive from "../../utils/varSwapRecursive";
 import Loading from "components/Loading";
 import DefinitionList from "../variables/DefinitionList";
 import FooterButtons from "../editors/components/FooterButtons";
-import Select from "./../fields/Select";
 import TextEditor from "../editors/TextEditor";
 import PlainTextEditor from "../editors/PlainTextEditor";
 import deepClone from "../../utils/deepClone";
 import stripHTML from "../../utils/formatters/stripHTML";
 import formatFieldName from "../../utils/formatters/formatFieldName";
 import LocaleName from "./components/LocaleName";
+import AllowedSelector from "../interface/AllowedSelector";
 import Card from "./Card";
 
 import {updateEntity, deleteEntity} from "../../actions/profiles";
@@ -49,7 +49,6 @@ class TextCard extends Component {
     if (variablesChanged || selectorsChanged || queryChanged) {
       this.formatDisplay.bind(this)();
     }
-    
   }
 
   populateLanguageContent(minData) {
@@ -227,10 +226,6 @@ class TextCard extends Component {
     );
   }
 
-  toggleCustom(e) {
-    this.setState({customAllowed: e.target.checked});
-  }
-
   chooseVariable(e) {
     const {minData} = this.state;
     minData.allowed = e.target.value;
@@ -238,7 +233,7 @@ class TextCard extends Component {
   }
 
   render() {
-    const {alertObj, thisDisplayData, thatDisplayData, isOpen, customAllowed} = this.state;
+    const {alertObj, thisDisplayData, thatDisplayData, isOpen} = this.state;
     const {minData} = this.props;
     const {fields, hideAllowed, plainfields, type, showReorderButton} = this.props;
     const {localeDefault, localeSecondary} = this.props.status;
@@ -294,19 +289,6 @@ class TextCard extends Component {
       onAlertCancel: () => this.setState({alertObj: false})
     };
 
-    const varOptions = [<option key="always" value="always">Always</option>]
-      .concat(Object.keys(variables)
-        .filter(key => !key.startsWith("_"))
-        .sort((a, b) => a.localeCompare(b))
-        .map(key => {
-          const value = variables[key];
-          const type = typeof value;
-          const label = !["string", "number", "boolean"].includes(type) ? ` <i>(${type})</i>` : `: ${`${value}`.slice(0, 20)}${`${value}`.length > 20 ? "..." : ""}`;
-          return <option key={key} value={key} dangerouslySetInnerHTML={{__html: `${key}${label}`}}></option>;
-        }));
-
-    const showVars = Object.keys(variables).length > 0;
-
     return (
       <Card {...cardProps}>
 
@@ -354,29 +336,13 @@ class TextCard extends Component {
               }
             </div>
 
-            { !hideAllowed 
-              ? customAllowed
-                ? <input type="text" />
-                : showVars
-                  ? <Select
-                    label="Visible"
-                    namespace="cms"
-                    value={minDataState.allowed || "always"}
-                    onChange={this.chooseVariable.bind(this)}
-                    inline
-                  >
-                    {varOptions}
-                  </Select>
-                  : null
-              : null
+            { !hideAllowed &&
+              <AllowedSelector
+                variables={variables}
+                value={minDataState.allowed || "always"}
+                onChange={this.chooseVariable.bind(this)}
+              />
             }
-            <label>
-              <input 
-                type="checkbox" 
-                value={customAllowed} 
-                onChange={this.toggleCustom.bind(this)} 
-              /> Override Visible property with custom variable
-            </label>
           </div>
 
           <FooterButtons

--- a/packages/cms/src/components/editors/GeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/GeneratorEditor.jsx
@@ -335,7 +335,7 @@ class GeneratorEditor extends Component {
         { type === "section_visualization" &&
           <AllowedSelector
             variables={variables}
-            value={data.allowed || "always"}
+            value={data.allowed !== undefined ? data.allowed : "always"}
             onChange={this.chooseVariable.bind(this)}
           />
         }

--- a/packages/cms/src/components/editors/GeneratorEditor.jsx
+++ b/packages/cms/src/components/editors/GeneratorEditor.jsx
@@ -9,6 +9,7 @@ import urlSwap from "../../utils/urlSwap";
 import Select from "../fields/Select";
 import TextInput from "../fields/TextInput";
 import TextButtonGroup from "../fields/TextButtonGroup";
+import AllowedSelector from "../interface/AllowedSelector";
 
 import "./GeneratorEditor.css";
 
@@ -237,17 +238,6 @@ class GeneratorEditor extends Component {
       formatter: <React.Fragment>Be sure to return a <strong>string</strong> that represents your formatted content.</React.Fragment>
     };
 
-    const varOptions = [<option key="always" value="always">Always</option>]
-      .concat(Object.keys(variables)
-        .filter(key => !key.startsWith("_"))
-        .sort((a, b) => a.localeCompare(b))
-        .map(key => {
-          const value = variables[key];
-          const type = typeof value;
-          const label = !["string", "number", "boolean"].includes(type) ? ` <i>(${type})</i>` : `: ${`${value}`.slice(0, 20)}${`${value}`.length > 20 ? "..." : ""}`;
-          return <option key={key} value={key} dangerouslySetInnerHTML={{__html: `${key}${label}`}}></option>;
-        }));
-
     if (!data) return null;
 
     return (
@@ -342,17 +332,12 @@ class GeneratorEditor extends Component {
         </div>
 
         {/* visibility */}
-        { (type === "profile_visualization" || type === "section_visualization") &&
-          <Select
-            label="Visible"
-            inline
-            fontSize="xs"
-            namespace="cms"
+        { type === "section_visualization" &&
+          <AllowedSelector
+            variables={variables}
             value={data.allowed || "always"}
             onChange={this.chooseVariable.bind(this)}
-          >
-            {varOptions}
-          </Select>
+          />
         }
 
         {/* UI/JS mode toggle */}

--- a/packages/cms/src/components/interface/AllowedSelector.jsx
+++ b/packages/cms/src/components/interface/AllowedSelector.jsx
@@ -1,0 +1,86 @@
+import React, {Component} from "react";
+import Select from "../fields/Select";
+
+class AllowedSelector extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      customAllowed: false
+    };
+  }
+
+  componentDidMount() {
+    const customAllowed = this.determineAllowed.bind(this)();
+    this.setState({customAllowed});
+  }
+
+  determineAllowed() {
+    const variables = this.props.variables || {};
+    return !Object.keys(variables).includes(this.props.value) && this.props.value !== "always";
+  }
+
+
+  toggleCustom(e) {
+    // If the user has a custom entry, and is disabling custom mode, the ensuing dropdown needs
+    // the default to be "always". Send this synthetic event so the drop-down is correctly set.
+    if (!e.target.checked) {
+      if (this.determineAllowed.bind(this)()) {
+        this.props.onChange({target: {value: "always"}});
+      } 
+    }
+    this.setState({customAllowed: e.target.checked});
+  }
+
+  render() {
+
+    const {customAllowed} = this.state;
+    const {variables, value} = this.props;
+
+    const varOptions = [<option key="always" value="always">Always</option>]
+      .concat(Object.keys(variables)
+        .filter(key => !key.startsWith("_"))
+        .sort((a, b) => a.localeCompare(b))
+        .map(key => {
+          const value = variables[key];
+          const type = typeof value;
+          const label = !["string", "number", "boolean"].includes(type) ? ` <i>(${type})</i>` : `: ${`${value}`.slice(0, 20)}${`${value}`.length > 20 ? "..." : ""}`;
+          return <option key={key} value={key} dangerouslySetInnerHTML={{__html: `${key}${label}`}}></option>;
+        }));
+
+    const showVars = Object.keys(variables).length > 0;
+  
+    return (
+      <React.Fragment>
+        { customAllowed
+          ? <label>
+            Enter a variable name, using <code>[[selectors]]</code> if desired.<br/><br/>
+            <code>{"{{"}</code><input type="text" value={value} onChange={this.props.onChange}/><code>{"}}"}</code><br/><br/>
+          </label>
+          : showVars
+            ? <Select
+              label="Visible"
+              namespace="cms"
+              value={value || "always"}
+              onChange={this.props.onChange}
+              inline
+            >
+              {varOptions}
+            </Select>
+            : null
+        }
+        <label>
+          <input 
+            type="checkbox" 
+            checked={customAllowed} 
+            onChange={this.toggleCustom.bind(this)} 
+          /> Override Visible property with custom variable
+        </label>
+      </React.Fragment>
+    );
+  }
+
+}
+
+export default AllowedSelector;
+

--- a/packages/cms/src/utils/varSwapRecursive.js
+++ b/packages/cms/src/utils/varSwapRecursive.js
@@ -31,7 +31,7 @@ const strSwap = (str, formatterFunctions, variables, selectors, isLogic = false,
 */
   
 const varSwapRecursive = (sourceObj, formatterFunctions, variables, query = {}, selectors = []) => {
-  const allowed = obj => variables[obj.allowed] || obj.allowed === null || obj.allowed === undefined || obj.allowed === "always";
+  const allowed = obj => !obj.allowed || obj.allowed === "always" || variables[selSwap(obj.allowed, selectors)];
   const obj = Object.assign({}, sourceObj);
   // If I'm a section and have selectors, extract and prep them for use
   if (obj.selectors) {


### PR DESCRIPTION
Adds ability to customize allowed field, so one can use selectors in them.

This means that if someone had a compound variable that relies on a selector, like `{{tradeFlow[[ieSelector]]}}`, one could also use the value of that compound variable as the `allowed` property of that stat/entity - Meaning you could hide or show a given stat based on the truthiness of this compound variable.

![image](https://user-images.githubusercontent.com/1714292/70184051-0828ba80-16b5-11ea-84cc-de2ba2dae27d.png)


Closes #851 