### PR TITLE
Fix section groupings

### DIFF
--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -676,7 +676,7 @@ module.exports = function(app) {
    */
   const swapList = [
     {elements: ["profile"], parent: null},
-    {elements: ["author", "story_description", "story_footnote", "storysection"], parent: "story_id"},
+    {elements: ["author", "story_description", "story_footnote"], parent: "story_id"},
     {elements: ["materializer"], parent: "profile_id"},
     {elements: ["section_subtitle", "section_description", "section_stat", "section_visualization"], parent: "section_id"},
     {elements: ["storysection_subtitle", "storysection_description", "storysection_stat", "storysection_visualization"], parent: "storysection_id"}
@@ -701,50 +701,57 @@ module.exports = function(app) {
 
   /* CUSTOM SWAPS */
 
-  app.post("/api/cms/section/swap", isEnabled, async(req, res) => {
-    // Sections can be Groupings, which requires a more complex swap that brings it child sections along with it 
-    const {id} = req.body;
-    const original = await db.section.findOne({where: {id}}).catch(catcher);
-    let sections = await db.section.findAll({where: {profile_id: original.profile_id}, order: [["ordering", "ASC"]]}).catch(catcher);
-    sections = sections.map(s => s.toJSON());
-    // Create a hierarchical array that respects groupings that looks like: [[G1, S1, S2], [G2, S3, S4, S5]] for easy swapping
-    const sectionsGrouped = [];
-    let hitGrouping = false;
-    sections.forEach(section => {
-      if (!hitGrouping || section.type === "Grouping") {
-        sectionsGrouped.push([section]);
-        if (section.type === "Grouping") hitGrouping = true;
-      }
+  const sectionSwapList = [
+    {ref: "section", parent: "profile_id"},
+    {ref: "storysection", parent: "story_id"}
+  ];
+  sectionSwapList.forEach(swap => {
+    app.post(`/api/cms/${swap.ref}/swap`, isEnabled, async(req, res) => {
+      // Sections can be Groupings, which requires a more complex swap that brings it child sections along with it 
+      const {id} = req.body;
+      const original = await db[swap.ref].findOne({where: {id}}).catch(catcher);
+      let sections = await db[swap.ref].findAll({where: {[swap.parent]: original[swap.parent]}, order: [["ordering", "ASC"]]}).catch(catcher);
+      sections = sections.map(s => s.toJSON());
+      // Create a hierarchical array that respects groupings that looks like: [[G1, S1, S2], [G2, S3, S4, S5]] for easy swapping
+      const sectionsGrouped = [];
+      let hitGrouping = false;
+      sections.forEach(section => {
+        if (!hitGrouping || section.type === "Grouping") {
+          sectionsGrouped.push([section]);
+          if (section.type === "Grouping") hitGrouping = true;
+        }
+        else {
+          sectionsGrouped[sectionsGrouped.length - 1].push(section);
+        }
+      });
+      // Sections that come before the Groupings start are technically in groups of their own. 
+      let isGroupLeader = false;
+      sectionsGrouped.forEach(group => {
+        if (group.map(d => d.id).includes(original.id) && group[0].id === original.id) isGroupLeader = true;
+      });
+      let updatedSections = [];
+      if (isGroupLeader) {
+        const ogi = sectionsGrouped.findIndex(group => group[0].id === id);
+        const ngi = ogi + 1;
+        // https://stackoverflow.com/a/872317
+        [sectionsGrouped[ogi], sectionsGrouped[ngi]] = [sectionsGrouped[ngi], sectionsGrouped[ogi]];
+        updatedSections = sectionsGrouped
+          .flat()
+          .map((section, i) => ({...section, ordering: i}));
+      } 
       else {
-        sectionsGrouped[sectionsGrouped.length - 1].push(section);
+        const oi = original.ordering;
+        const ni = original.ordering + 1;
+        [sections[oi], sections[ni]] = [sections[ni], sections[oi]];
+        updatedSections = sections.map((section, i) => ({...section, ordering: i}));
       }
+      for (const section of updatedSections) {
+        await db[swap.ref].update({ordering: section.ordering}, {where: {id: section.id}});
+      }
+      return res.json(updatedSections.map(d => ({id: d.id, ordering: d.ordering})));
     });
-    // Sections that come before the Groupings start are technically in groups of their own. 
-    let isGroupLeader = false;
-    sectionsGrouped.forEach(group => {
-      if (group.map(d => d.id).includes(original.id) && group[0].id === original.id) isGroupLeader = true;
-    });
-    let updatedSections = [];
-    if (isGroupLeader) {
-      const ogi = sectionsGrouped.findIndex(group => group[0].id === id);
-      const ngi = ogi + 1;
-      // https://stackoverflow.com/a/872317
-      [sectionsGrouped[ogi], sectionsGrouped[ngi]] = [sectionsGrouped[ngi], sectionsGrouped[ogi]];
-      updatedSections = sectionsGrouped
-        .flat()
-        .map((section, i) => ({...section, ordering: i}));
-    } 
-    else {
-      const oi = original.ordering;
-      const ni = original.ordering + 1;
-      [sections[oi], sections[ni]] = [sections[ni], sections[oi]];
-      updatedSections = sections.map((section, i) => ({...section, ordering: i}));
-    }
-    for (const section of updatedSections) {
-      await db.section.update({ordering: section.ordering}, {where: {id: section.id}});
-    }
-    return res.json(updatedSections.map(d => ({id: d.id, ordering: d.ordering})));
   });
+
 
   app.post("/api/cms/section_selector/swap", isEnabled, async(req, res) => {
     const {id} = req.body;

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -687,11 +687,15 @@ module.exports = function(app) {
         const {id} = req.body;
         const original = await db[ref].findOne({where: {id}}).catch(catcher);
         let otherWhere = {ordering: original.ordering + 1};
-        if (ref === "section") {
+        // If a Group is being swapped, don't swap with its neighbor. 
+        if (ref === "section" && original.type === "Grouping") {
           let sections = await db.section.findAll({where: {profile_id: original.profile_id}}).catch(catcher);
           sections = sections.map(s => s.toJSON());
           const nextGrouping = sections.find(s => s.type === "Grouping" && s.ordering > original.ordering);
-          if (nextGrouping) otherWhere = {ordering: nextGrouping.ordering};
+          if (nextGrouping) {
+            otherWhere = {ordering: nextGrouping.ordering};
+            // also move all sections
+          }
         }
         if (list.parent) otherWhere[list.parent] = original[list.parent];
         const other = await db[ref].findOne({where: otherWhere}).catch(catcher);

--- a/packages/cms/src/components/interface/Outline.jsx
+++ b/packages/cms/src/components/interface/Outline.jsx
@@ -24,12 +24,27 @@ class Outline extends Component {
 
   createSection(node) {
     const ordering = node.ordering + 1;
+    const {type} = node;
     const {tab} = this.props.status.pathObj;
     const {currentPid, currentStoryPid} = this.props.status;
     if (tab === "profiles") {
-      this.props.newEntity("section", {profile_id: currentPid, ordering});
+      const payload = {profile_id: currentPid, ordering};
+      // Groups are special, when adding a new group it should "jump" past all the child sections and 
+      // Add itself before the next grouping, or, if there is none, at the end (but still as a Grouping)
+      if (type === "Grouping") {
+        payload.type = type;
+        const nextGrouping = this.props.tree.find(s => s.type === "Grouping" && s.ordering > node.ordering);
+        payload.ordering = nextGrouping ? nextGrouping.ordering : undefined;
+      }
+      this.props.newEntity("section", payload);
     }
-    if (tab === "stories") {
+    else if (tab === "stories") {
+      const payload = {story_id: currentStoryPid, ordering};
+      if (type === "Grouping") {
+        payload.type = type;
+        const nextGrouping = this.props.tree.find(s => s.type === "Grouping" && s.ordering > node.ordering);
+        payload.ordering = nextGrouping ? nextGrouping.ordering : undefined;
+      }
       this.props.newEntity("storysection", {story_id: currentStoryPid, ordering});
     }
   }

--- a/packages/cms/src/components/interface/Outline.jsx
+++ b/packages/cms/src/components/interface/Outline.jsx
@@ -22,14 +22,15 @@ class Outline extends Component {
     }
   }
 
-  createSection(id) {
+  createSection(node) {
+    const ordering = node.ordering + 1;
     const {tab} = this.props.status.pathObj;
     const {currentPid, currentStoryPid} = this.props.status;
     if (tab === "profiles") {
-      this.props.newEntity("section", {profile_id: currentPid});
+      this.props.newEntity("section", {profile_id: currentPid, ordering});
     }
     if (tab === "stories") {
-      this.props.newEntity("storysection", {story_id: currentStoryPid});
+      this.props.newEntity("storysection", {story_id: currentStoryPid, ordering});
     }
   }
 
@@ -90,7 +91,7 @@ class Outline extends Component {
       <div className="cms-outline-item-actions cms-button">
         {/* add section */}
         <Button
-          onClick={() => this.createSection(node.id)}
+          onClick={() => this.createSection(node)}
           className="cms-outline-item-actions-button"
           namespace="cms"
           fontSize="xxs"

--- a/packages/cms/src/components/interface/Outline.jsx
+++ b/packages/cms/src/components/interface/Outline.jsx
@@ -150,18 +150,20 @@ class Outline extends Component {
       section.sections && section.sections.find(nestedSection => nestedSection.id === Number(pathObj[sectionKey]))
     );
 
+    console.log(nestedOutline);
+
     return <Fragment>
       {/* top row */}
       <ul className={`cms-outline ${isOpen ? "is-open" : "is-closed"}`} key="outline-main">
         {nodes.map((node, i) =>
-          this.renderNode(node, nodes, sectionKey, tree, i)
+          this.renderNode(node, nodes, sectionKey, nodes, i)
         )}
       </ul>
 
       {/* render nested list with current grouping's sections, if the current section is a grouping or within a group */}
       <ul className={`cms-outline cms-nested-outline ${nestedOutline && isOpen ? "is-open" : "is-closed"}`} key="outline-nested">
         {nestedOutline && nestedOutline.sections.map((node, i) =>
-          this.renderNode(node, nodes, sectionKey, tree, i)
+          this.renderNode(node, nodes, sectionKey, nestedOutline.sections, i)
         )}
       </ul>
     </Fragment>;

--- a/packages/cms/src/components/interface/Outline.jsx
+++ b/packages/cms/src/components/interface/Outline.jsx
@@ -45,7 +45,7 @@ class Outline extends Component {
         const nextGrouping = this.props.tree.find(s => s.type === "Grouping" && s.ordering > node.ordering);
         payload.ordering = nextGrouping ? nextGrouping.ordering : undefined;
       }
-      this.props.newEntity("storysection", {story_id: currentStoryPid, ordering});
+      this.props.newEntity("storysection", payload);
     }
   }
 

--- a/packages/cms/src/reducers/profiles.js
+++ b/packages/cms/src/reducers/profiles.js
@@ -1,8 +1,13 @@
 const deepClone = require("../utils/deepClone");
 
+const sorter = (a, b) => a.ordering - b.ordering;
+
 const addSectionEntity = (profiles, data, accessor) => profiles.map(p => 
   Object.assign({}, p, {sections: p.sections.map(s => 
-    s.id === data.section_id ? Object.assign({}, s, {[accessor]: s[accessor].concat([data])}) : s)}));
+    s.id === data.section_id ? Object.assign({}, s, {[accessor]: s[accessor]
+      .map(a => a.ordering >= data.ordering ? Object.assign({}, a, {ordering: a.ordering + 1}) : a)
+      .concat([data])
+      .sort(sorter)}) : s)}));
 
 const updateSectionEntity = (profiles, data, accessor) => profiles.map(p => 
   Object.assign({}, p, {sections: p.sections.map(s => 
@@ -18,7 +23,7 @@ const swapSectionEntity = (profiles, data, accessor) => profiles.map(p =>
     Object.assign({}, s, {[accessor]: s[accessor].map(entity => {
       const match = data.find(d => d.id === entity.id);
       return match ? Object.assign({}, entity, {ordering: match.ordering}) : entity;
-    }).sort((a, b) => a.ordering - b.ordering)})
+    }).sort(sorter)})
   )}));
 
 export default (profiles = [], action) => {
@@ -91,7 +96,10 @@ export default (profiles = [], action) => {
           return match ? Object.assign({}, s, {ordering: match.ordering}) : s;  
         }).sort((a, b) => a.ordering - b.ordering)}));
     case "SECTION_NEW":
-      return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections.concat([action.data])}) : p);
+      return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections
+        .map(s => s.ordering >= action.data.ordering ? Object.assign({}, s, {ordering: s.ordering + 1}) : s)
+        .concat([action.data])
+        .sort(sorter)}) : p);
     case "SECTION_DUPLICATE":
       return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections.concat([action.data])}) : p);
     case "SECTION_UPDATE":
@@ -143,7 +151,10 @@ export default (profiles = [], action) => {
     case "SECTION_SELECTOR_NEW":
       return profiles.map(p => 
         Object.assign({}, p, {sections: p.sections.map(s => 
-          s.id === action.data.section_selector.section_id ? Object.assign({}, s, {selectors: s.selectors.concat([action.data])}) : s)}));
+          s.id === action.data.section_selector.section_id ? Object.assign({}, s, {selectors: s.selectors
+            .map(sel => sel.ordering >= action.data.ordering ? Object.assign({}, sel, {ordering: sel.ordering + 1}) : sel)
+            .concat([action.data])
+            .sort(sorter)}) : s)}));
     case "SECTION_SELECTOR_DELETE":
       return profiles.map(p => 
         Object.assign({}, p, {sections: p.sections.map(s => 

--- a/packages/cms/src/reducers/stories.js
+++ b/packages/cms/src/reducers/stories.js
@@ -23,7 +23,8 @@ const addStorysectionEntity = (stories, data, accessor) => stories.map(p =>
   Object.assign({}, p, {storysections: p.storysections.map(s => 
     s.id === data.storysection_id ? Object.assign({}, s, {[accessor]: s[accessor]
       .map(a => a.ordering >= data.ordering ? Object.assign({}, a, {ordering: a.ordering + 1}) : a)
-      .concat([data])}) : s)}));
+      .concat([data])
+      .sort(sorter)}) : s)}));
 
 const updateStorysectionEntity = (stories, data, accessor) => stories.map(p => 
   Object.assign({}, p, {storysections: p.storysections.map(s => 

--- a/packages/cms/src/reducers/stories.js
+++ b/packages/cms/src/reducers/stories.js
@@ -1,5 +1,10 @@
+const sorter = (a, b) => a.ordering - b.ordering;
+
 const addStoryEntity = (stories, data, accessor) => stories.map(p => 
-  p.id === data.story_id ? Object.assign({}, p, {[accessor]: p[accessor].concat([data])}) : p);
+  p.id === data.story_id ? Object.assign({}, p, {[accessor]: p[accessor]
+    .map(a => a.ordering >= data.ordering ? Object.assign({}, a, {ordering: a.ordering + 1}) : a)
+    .concat([data])
+    .sort(sorter)}) : p);
 
 const updateStoryEntity = (stories, data, accessor) => stories.map(p => 
   p.id === data.story_id ? Object.assign({}, p, {[accessor]: p[accessor].map(entity => 
@@ -16,7 +21,9 @@ const swapStoryEntity = (stories, data, accessor) => stories.map(p =>
 
 const addStorysectionEntity = (stories, data, accessor) => stories.map(p => 
   Object.assign({}, p, {storysections: p.storysections.map(s => 
-    s.id === data.storysection_id ? Object.assign({}, s, {[accessor]: s[accessor].concat([data])}) : s)}));
+    s.id === data.storysection_id ? Object.assign({}, s, {[accessor]: s[accessor]
+      .map(a => a.ordering >= data.ordering ? Object.assign({}, a, {ordering: a.ordering + 1}) : a)
+      .concat([data])}) : s)}));
 
 const updateStorysectionEntity = (stories, data, accessor) => stories.map(p => 
   Object.assign({}, p, {storysections: p.storysections.map(s => 
@@ -91,7 +98,10 @@ export default (stories = [], action) => {
           return match ? Object.assign({}, s, {ordering: match.ordering}) : s;  
         }).sort((a, b) => a.ordering - b.ordering)}));
     case "STORYSECTION_NEW":
-      return stories.map(p => p.id === action.data.story_id ? Object.assign({}, p, {storysections: p.storysections.concat([action.data])}) : p);
+      return stories.map(p => p.id === action.data.story_id ? Object.assign({}, p, {storysections: p.storysections
+        .map(s => s.ordering >= action.data.ordering ? Object.assign({}, s, {ordering: s.ordering + 1}) : s)
+        .concat([action.data])
+        .sort(sorter)}) : p);
     case "STORYSECTION_UPDATE":
       return stories.map(p => Object.assign({}, p, {storysections: p.storysections.map(s => s.id === action.data.id ? Object.assign({}, s, {...action.data}) : s)}));
     case "STORYSECTION_DELETE":


### PR DESCRIPTION
Closes #844 
Closes #846 
Closes #845 

Changes the way sections are re-ordered in the following ways:
- Inserting section after another one now works (no longer appends to end of list)
- Inserting a section after a Grouping section creates a new Grouping
- Swapping two Grouping Sections properly swaps all their children as well
- Disallows for swapping for both the Final Group in a profile, and also the final section of any given group. This avoids confusing situations where sections seem to jump around.

This is still not quite perfect. There are some edge cases that feel a little janky, so another design pass should be scheduled.