### PR TITLE
Issue 861 flat section hierarchy bugs

### DIFF
--- a/packages/cms/src/components/Viz/StatGroup.css
+++ b/packages/cms/src/components/Viz/StatGroup.css
@@ -7,6 +7,10 @@
   overflow-x: hidden;
   width: calc(100% + var(--gutter-md));
 
+  &.single-stat {
+    width: 100%;
+  }
+
   /* grouped stats */
   & > .cp-stat-group {
     /* layout spans 2 columsn by default */

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -82,7 +82,8 @@ class Hero extends Component {
       if (contents.stats.length > 0) {
         const statGroups = nest().key(d => d.title).entries(contents.stats);
 
-        statContent = <div className="cp-stat-group-wrapper cp-hero-stat-group-wrapper">
+        statContent = <div className={`cp-stat-group-wrapper cp-hero-stat-group-wrapper${statGroups.length === 1 ? " single-stat" : ""}`}>
+          {console.log(statGroups.length)}
           {statGroups.map(({key, values}) => <StatGroup className="cp-hero-stat" key={key} title={key} stats={values} />)}
         </div>;
       }

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -83,7 +83,6 @@ class Hero extends Component {
         const statGroups = nest().key(d => d.title).entries(contents.stats);
 
         statContent = <div className={`cp-stat-group-wrapper cp-hero-stat-group-wrapper${statGroups.length === 1 ? " single-stat" : ""}`}>
-          {console.log(statGroups.length)}
           {statGroups.map(({key, values}) => <StatGroup className="cp-hero-stat" key={key} title={key} stats={values} />)}
         </div>;
       }

--- a/packages/cms/src/components/sections/Section.jsx
+++ b/packages/cms/src/components/sections/Section.jsx
@@ -212,7 +212,7 @@ class Section extends Component {
       const statGroups = nest().key(d => d.title).entries(stats);
 
       if (stats.length > 0) {
-        statContent = <div className="cp-stat-group-wrapper">
+        statContent = <div className={`cp-stat-group-wrapper${stats.length === 1 ? " single-stat" : ""}`}>
           {statGroups.map(({key, values}, i) => !(layout === "InfoCard" && i > 0) // only push the first stat for cards
             ? <StatGroup key={key} title={key} stats={values} /> : ""
           )}

--- a/packages/cms/src/components/sections/components/Subnav.jsx
+++ b/packages/cms/src/components/sections/components/Subnav.jsx
@@ -47,13 +47,13 @@ class Subnav extends Component {
       if (sections.length === 1) {
         flattenedSections = sections[0]
           .map(s => s[0])
-          .filter(s => s.type.toLowerCase() !== "grouping"); // only show groupings
+          .filter(s => s.type.toLowerCase() !== "grouping"); // don't show groupings
       }
       // we got groupings
       else {
         flattenedSections = sections
           .map(s => s[0][0])
-          .filter(s => s.type.toLowerCase() === "grouping"); // don't show groupings
+          .filter(s => s.type.toLowerCase() === "grouping"); // only show groupings
       }
     }
 

--- a/packages/cms/src/components/sections/components/Subnav.jsx
+++ b/packages/cms/src/components/sections/components/Subnav.jsx
@@ -43,7 +43,18 @@ class Subnav extends Component {
       sections[0] && sections[0][0] &&
       sections[0][0] === Object(sections[0][0])
     ) {
-      flattenedSections = sections.map(s => s[0][0]);
+      // the hierarchy is flat (i.e., <= 1 grouping)
+      if (sections.length === 1) {
+        flattenedSections = sections[0]
+          .map(s => s[0])
+          .filter(s => s.type.toLowerCase() !== "grouping"); // only show groupings
+      }
+      // we got groupings
+      else {
+        flattenedSections = sections
+          .map(s => s[0][0])
+          .filter(s => s.type.toLowerCase() === "grouping"); // don't show groupings
+      }
     }
 
     return flattenedSections;
@@ -96,7 +107,7 @@ class Subnav extends Component {
     const {currSection, fixed} = this.state;
     const sections = this.flattenSections(this.props.sections);
 
-    if (!sections || !Array.isArray(sections)) return null;
+    if (!sections || !Array.isArray(sections) || sections.length < 3) return null;
 
     let height = 50;
     if (typeof window !== "undefined" && this.subnav.current) {


### PR DESCRIPTION
Changes to subnav logic:

- If there are <2 groupings, each non-grouping section will be shown in the subnav
- If there are >2 groupings, only grouping sections will be shown in the subnav
- if there are <3 subnav items, the subnav will not be shown

Closes #861