### PR TITLE
Add throttle config

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -210,7 +210,7 @@ A Canon site often takes the form of DataCountry.io, and is made of **Profiles**
 |`CANON_CMS_CUBES`|Path to the mondrian or tesseract|`undefined (required)`|
 |`CANON_CMS_ENABLE`|Setting this env var to `true` allows access to the cms in production builds.|`false`|
 |`CANON_CMS_LOGGING`|Enable verbose logging in console.|`false`|
-|`CANON_CMS_REQUESTS_PER_SECOND`|Sets the `requestsPerSecond` value in [promise-throttle](https://www.npmjs.com/package/promise-throttle) library, used for rate-limiting Generator requests|20|
+|`CANON_CMS_REQUESTS_PER_SECOND`|Sets the `requestsPerSecond` value in the [promise-throttle](https://www.npmjs.com/package/promise-throttle) library, used for rate-limiting Generator requests|20|
 |`FLICKR_API_KEY`|Used to configure Flickr Authentication|`undefined`|
 |`GOOGLE_APPLICATION_CREDENTIALS`|Path to JSON token file for Cloud Storage|`undefined`|
 |`CANON_CONST_STORAGE_BUCKET`|Name of Google Cloud Storage Bucket|`undefined`|

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -210,10 +210,12 @@ A Canon site often takes the form of DataCountry.io, and is made of **Profiles**
 |`CANON_CMS_CUBES`|Path to the mondrian or tesseract|`undefined (required)`|
 |`CANON_CMS_ENABLE`|Setting this env var to `true` allows access to the cms in production builds.|`false`|
 |`CANON_CMS_LOGGING`|Enable verbose logging in console.|`false`|
+|`CANON_CMS_REQUESTS_PER_SECOND`|Sets the `requestsPerSecond` value in [promise-throttle](https://www.npmjs.com/package/promise-throttle) library, used for rate-limiting Generator requests|20|
 |`FLICKR_API_KEY`|Used to configure Flickr Authentication|`undefined`|
 |`GOOGLE_APPLICATION_CREDENTIALS`|Path to JSON token file for Cloud Storage|`undefined`|
 |`CANON_CONST_STORAGE_BUCKET`|Name of Google Cloud Storage Bucket|`undefined`|
 |`CANON_CONST_IMAGE_SPLASH_SIZE`|Splash width to resize flickr images|1400|
+|`CANON_CONST_IMAGE_THUMB_SIZE`|Thumb width to resize flickr images|200|
 |`CANON_CONST_IMAGE_THUMB_SIZE`|Thumb width to resize flickr images|200|
 
 ---

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -22,6 +22,7 @@ const LANGUAGES = process.env.CANON_LANGUAGES || LANGUAGE_DEFAULT;
 const LOGINS = process.env.CANON_LOGINS || false;
 const PORT = process.env.CANON_PORT || 3300;
 const NODE_ENV = process.env.NODE_ENV || "development";
+const REQUESTS_PER_SECOND = process.env.CANON_CMS_REQUESTS_PER_SECOND ? parseInt(process.env.CANON_CMS_REQUESTS_PER_SECOND, 10) : 20;
 
 const canonVars = {
   CANON_API: process.env.CANON_API,
@@ -41,7 +42,7 @@ Object.keys(process.env).forEach(k => {
 });
 
 const throttle = new PromiseThrottle({
-  requestsPerSecond: 10,
+  requestsPerSecond: REQUESTS_PER_SECOND,
   promiseImplementation: Promise
 });
 


### PR DESCRIPTION
Adds `CANON_CMS_REQUESTS_PER_SECOND` to config, a pass-through to `requestsPerSecond` in [promise-throttle](https://www.npmjs.com/package/promise-throttle).  updated readme.