### PR TITLE
adds duplicated section directly after source section

### DIFF
--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -788,7 +788,7 @@ module.exports = function(app) {
       });
       // Because this is the same profile, we want its ordering to be after the duplication source.
       // Slide up all of the other sections to make room
-      await db.section.update({ordering: sequelize.literal("ordering +1")}, {where: {profile_id: pid, ordering: {[Op.gte]: oldSection.ordering}}}).catch(catcher);
+      await db.section.update({ordering: sequelize.literal("ordering +1")}, {where: {profile_id: pid, ordering: {[Op.gt]: oldSection.ordering}}}).catch(catcher);
       // Then override the ordering of oldSection to be after the source one (i.e., one higher)
       oldSection.ordering++;
     }

--- a/packages/cms/src/reducers/profiles.js
+++ b/packages/cms/src/reducers/profiles.js
@@ -101,7 +101,10 @@ export default (profiles = [], action) => {
         .concat([action.data])
         .sort(sorter)}) : p);
     case "SECTION_DUPLICATE":
-      return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections.concat([action.data])}) : p);
+      return profiles.map(p => p.id === action.data.profile_id ? Object.assign({}, p, {sections: p.sections
+        .map(s => s.ordering >= action.data.ordering ? Object.assign({}, s, {ordering: s.ordering + 1}) : s)
+        .concat([action.data])
+        .sort(sorter)}) : p);
     case "SECTION_UPDATE":
       return profiles.map(p => Object.assign({}, p, {sections: p.sections.map(s => s.id === action.data.id ? Object.assign({}, s, {...action.data}) : s)}));
     case "SECTION_DELETE":


### PR DESCRIPTION
Cesar pointed out that, when duplicating a section, it is confusing for the duplicated section to append all the way to the end of the profile.

Duplicating a section now adds a duplicate directly after the source section.

Closes #876 