### PR TITLE
Issue 891 usergen

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -11,7 +11,7 @@ Content Management System for Canon sites.
 * [Sections](#sections)
 * [Search](#search)
 * [Advanced Visualization Techniques](#advanced-visualization-techniques)
-* [Authentication](#authentication})
+* [Authentication](#authentication)
 * [Frequently Asked Questions](#frequently-asked-questions)
 * [Release Notes](#release-notes)
 * [Migration](#migration)

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -11,6 +11,7 @@ Content Management System for Canon sites.
 * [Sections](#sections)
 * [Search](#search)
 * [Advanced Visualization Techniques](#advanced-visualization-techniques)
+* [Authentication](#authentication})
 * [Frequently Asked Questions](#frequently-asked-questions)
 * [Release Notes](#release-notes)
 * [Migration](#migration)
@@ -443,6 +444,16 @@ Keep in mind that you may combine the two advanced functions! If your planned mo
 ```
 
 You are then welcome, in the `myModalSlug` section, to make use of `idForMyModal` and trust that it will be set when the modal opens.
+
+---
+
+## Authentication
+
+Canon CMS makes use of the [User Management](https://github.com/Datawheel/canon#user-management) from Canon Core. If `CANON_LOGINS` is set to true, the CMS will require a user of `role` of `1` or higher to access the CMS.
+
+The CMS also exports the `user` object and a `userRole` boolean for the currently logged in user in the Locked Attributes Generator for every profile. You can make use of these variables to hide, show, or limit information based on the role of the currently logged in user.
+
+**Note:** If you create new variables from the user data (e.g., `const isPro = role >= 1`), these operations **must** be performed in materializers to have any effect.
 
 ---
 

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -442,7 +442,14 @@ module.exports = function(app) {
     // If the user has provided variables, this is a POST request. Use those variables,
     // And skip the entire variable fetching process.
     if (req.body.variables) {
-      variables = req.body.variables;
+      // If the forceMats option was provided, use the POSTed variables to run
+      // Materializers. Used for Login in ProfileRenderer.jsx
+      if (req.query.forceMats === "true") {
+        variables = await runMaterializers(req, req.body.variables, pid);
+      }
+      else {
+        variables = req.body.variables;
+      }
     }
     // If the user has not provided variables, this is a GET request. Run Generators.
     else {

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -252,6 +252,15 @@ module.exports = function(app) {
     // Strip the attr object down to just some relevant keys
     const smallKeys = ["id", "dimension", "hierarchy", "slug"];
     const smallAttr = Object.keys(attr).reverse().reduce((acc, k) => smallKeys.includes(k.replace(/\d+/g, "")) ? {[k]: attr[k], ...acc} : acc, {});
+    // Retrieve user login data
+    smallAttr.user = false;
+    if (LOGINS && req.user) {
+      // Extract sensitive data
+      const {password, salt, ...user} = req.user; // eslint-disable-line
+      smallAttr.user = user;
+      // Bubble up userRole for easy access in front end (for hiding sections based on role)
+      smallAttr.userRole = user.role;
+    }
     // The id "0" is a special case to retrieve ONLY the Attributes variables (without running any real generators)
     // Used in fetchVariables for new profiles that have no custom generators but still need to run this function.
     if (id === "0") return {...smallAttr, _genStatus: {attributes: {...smallAttr}}};

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -43,7 +43,7 @@ class ProfileRenderer extends Component {
   }
 
   componentDidMount() {
-    this.props.isAuthenticated();
+    if (!this.props.auth.user) this.props.isAuthenticated();
     if (isIE) this.setState({isIE: true});
   }
 

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -1,6 +1,8 @@
 import axios from "axios";
+import {connect} from "react-redux";
 import React, {Component, Fragment} from "react";
 import {hot} from "react-hot-loader/root";
+import {isAuthenticated} from "@datawheel/canon-core";
 import PropTypes from "prop-types";
 import {Dialog, Icon} from "@blueprintjs/core";
 
@@ -41,11 +43,17 @@ class ProfileRenderer extends Component {
   }
 
   componentDidMount() {
+    this.props.isAuthenticated();
     if (isIE) this.setState({isIE: true});
   }
 
   componentDidUpdate(prevProps) {
     const {isModal, sectionID} = this.props;
+    if (!prevProps.auth.user && this.props.auth.user) {
+      const {user} = this.props.auth;
+      const userRole = user.role;
+      this.onSetVariables.bind(this)({user, userRole}, true);
+    }
     // If this is a modal with a sectionID, then this component is being rendered as a section preview
     // in the CMS. When that is the case, the profile could be updated from the OUTSIDE, i.e., the user
     // changes a dropdown in PreviewHeader.jsx. In that case, listen for a new profile from props.
@@ -89,7 +97,7 @@ class ProfileRenderer extends Component {
    * This requires a server round trip, because the user may have changed a variable that would affect
    * the "allowed" status of a given section.
    */
-  onSetVariables(newVariables) {
+  onSetVariables(newVariables, forceMats) {
     const {profile, selectors, setVarsLoading} = this.state;
     const {id, variables} = profile;
     const {locale, sectionID} = this.props;
@@ -101,6 +109,7 @@ class ProfileRenderer extends Component {
       this.setState({setVarsLoading: true});
       let url = `/api/profile?profile=${id}&locale=${locale}&${Object.entries(selectors).map(([key, val]) => `${key}=${val}`).join("&")}`;
       if (sectionID) url += `&section=${sectionID}`;
+      if (forceMats) url += "&forceMats=true";
       const payload = {variables: Object.assign({}, variables, newVariables)};
       axios.post(url, payload)
         .then(resp => {
@@ -290,4 +299,12 @@ ProfileRenderer.childContextTypes = {
   onOpenModal: PropTypes.func
 };
 
-export default hot(ProfileRenderer);
+const mapStateToProps = state => ({
+  auth: state.auth
+});
+
+const mapDispatchToProps = dispatch => ({
+  isAuthenticated: () => dispatch(isAuthenticated())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(hot(ProfileRenderer));


### PR DESCRIPTION
Adds a `user` object and a `userRole` boolean to the Attributes generator, for the hiding / showing of content for a logged in user.

Note: If you want to make new variables based off `user` or `userRole` (such as `isPro` or `isPremium`), you **must make them in Materializers**.  These are the only entities that are re-run AFTER page load when the user object is instantiated.

Closes #891