### PR TITLE
Issue 905 searchfix

### DIFF
--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -402,9 +402,9 @@ const populateSearch = async(profileData, db) => {
 
       const slugify = str => strip(str).replace(/-{2,}/g, "-").toLowerCase();
 
-      // Add a generated slug to the write payload
       if (verbose) console.log("Generating slugs...");
-      const searchList = fullList.map(member => ({slug: slugify(member.name, member.id), ...member}));
+      // Add a generated slug to the write payload
+      const searchList = fullList.map(member => ({slug: slugify(member.name), ...member}));
       if (verbose) console.log("Deduping slugs...");
       searchList.forEach(member => {
         usedSlugs[member.slug] ? member.slug = `${member.slug}-${member.id}` : usedSlugs[member.slug] = true;

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -360,7 +360,7 @@ const populateSearch = async(profileData, db) => {
 
   for (const locale of LANGUAGES) {
 
-    if (verbose) console.log(`============================\nStarting ingest for locale: ${locale}...`);
+    if (verbose) console.log(`Starting ingest for locale: ${locale}...`);
 
     let fullList = [];
     
@@ -412,6 +412,7 @@ const populateSearch = async(profileData, db) => {
       if (verbose) console.log("Slug generation complete.");
 
       const searchInsertKeys = Object.keys(searchList[0]).filter(d => d !== "name");
+      // On conflict (update), do not attempt to change the slug
       const searchUpdateKeys = searchInsertKeys.filter(d => d !== "slug");
 
       let searchQuery = `INSERT INTO canon_cms_search (${searchInsertKeys.join(", ")})\nVALUES `;
@@ -445,10 +446,8 @@ const populateSearch = async(profileData, db) => {
       if (verbose) console.log(`Upserting content table for ${locale}...`);
       const [contentRows] = await db.query(contentQuery).catch(catcher);
       if (verbose) console.log(`Upserted ${contentRows.length} content rows for locale: ${locale}.`);
-
     }
   }
-
   if (verbose) console.log("SEARCH INGEST COMPLETE");  
 };
 
@@ -620,6 +619,7 @@ module.exports = function(app) {
   });
 
   app.post("/api/cms/profile/upsertDimension", isEnabled, async(req, res) => {
+    req.setTimeout(1000 * 60 * 5);
     const profileData = req.body;
     const {profile_id} = profileData;  // eslint-disable-line
     profileData.dimension = profileData.dimName;

--- a/packages/cms/src/components/cards/DimensionCard.jsx
+++ b/packages/cms/src/components/cards/DimensionCard.jsx
@@ -25,8 +25,9 @@ class DimensionCard extends Component {
     const {meta} = this.props;
     const {id} = meta;
     const url = "/api/cms/repopulateSearch/";
+    const timeout = 1000 * 60 * 5;
     this.setState({rebuilding: true});
-    axios.post(url, {id}).then(() => {
+    axios.post(url, {id}, {timeout}).then(() => {
       this.setState({rebuilding: false});
     });
   }

--- a/packages/cms/src/components/cards/DimensionCard.jsx
+++ b/packages/cms/src/components/cards/DimensionCard.jsx
@@ -5,7 +5,6 @@ import Card from "./Card";
 import Dialog from "../interface/Dialog";
 import DimensionEditor from "../editors/DimensionEditor";
 import DefinitionList from "../variables/DefinitionList";
-import Button from "../fields/Button";
 import PreviewSearch from "../fields/PreviewSearch";
 
 import {deleteDimension} from "../../actions/profiles";


### PR DESCRIPTION
Does not require a major version release.

Two primary changes here:

- As discovered via the `Metro Areas` bug in DM, we now crawl through *ALL* hierarchies and take the set union of the discovered levels before hitting the cube.
- Search ingest changed from a looping `await` to a bulk upsert, speeding up ingest by an order of magnitude. Due to limitations in the search table and in sequelize (namely, search table uses a composite key) we were unable to use the `bulkCreate` method, and instead generate and execute a raw SQL query with an `ON CONFLICT` clause. This is not ideal, but the speed gains are undeniable. 

**NOTE:** I'd request that users take a backup of their cms db before running the new ingests, and if possible, contact me directly to supervise new ingests so I can confirm functionality. I've done as much testing as I can but would like to make sure it behaves nicely in the wild.

Closes #905 
