### PR TITLE
[cms] catches non-object return in viz configs

### DIFF
--- a/packages/cms/src/utils/d3plusPropify.js
+++ b/packages/cms/src/utils/d3plusPropify.js
@@ -4,6 +4,13 @@ import {parse} from "./FUNC";
 
 const envLoc = process.env.CANON_LANGUAGE_DEFAULT || "en";
 
+const frontEndMessage = "Error Rendering Visualization";
+const errorStub = {
+  data: [],
+  type: "Treemap",
+  noDataHTML: `<p style="font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;"><strong>${frontEndMessage}</strong></p>`
+};
+
 export default (logic, formatters = {}, variables = {}, locale = envLoc, id = null, actions = {}) => {
 
   let config;
@@ -17,13 +24,16 @@ export default (logic, formatters = {}, variables = {}, locale = envLoc, id = nu
   catch (e) {
     console.error(`Parsing Error in propify (ID: ${id})`);
     console.error(`Error message: ${e.message}`);
-    const frontEndMessage = "Error Rendering Visualization";
     return {
       error: `${e}`,
-      config: {
-        data: [],
-        type: "Treemap",
-        noDataHTML: `<p style="font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;"><strong>${frontEndMessage}</strong></p>`}
+      config: errorStub
+    };
+  }
+  // If the user added correct javascript, but it doesn't return an object, don't attempt to render.
+  if (typeof config !== "object") {
+    return {
+      error: "Visualization JS code must return an object",
+      config: errorStub
     };
   }
 


### PR DESCRIPTION
closes #918 

The "no data url" case was actually already handled in Table.jsx from a previous fix, but the "user JS doesn't return an object at all" case was not.

This catches for that case, preventing white screen of death.