### PR TITLE
[cms] fixes bug with image hosting wires crossed

### DIFF
--- a/packages/cms/src/api/imageRoute.js
+++ b/packages/cms/src/api/imageRoute.js
@@ -59,12 +59,12 @@ module.exports = function(app) {
     const locale = req.query.locale || envLoc;
     const jsonError = () => res.json({error: "Not Found"});
     const imageError = () => res.sendFile(`${process.cwd()}/static/images/transparent.png`);
-    const reqObj = req.query.dimension ? {where: {dimension: req.query.dimension}} : {where: {slug}};
+    const reqObj = req.query.dimension && req.query.cubeName ? {where: {dimension: req.query.dimension, cubeName: req.query.cubeName}} : {where: {slug}};
     const meta = await db.profile_meta.findOne(reqObj).catch(catcher);
     if (!meta) return type === "json" ? jsonError() : imageError();  
-    const {dimension} = meta;
+    const {dimension, cubeName} = meta;
     let member = await db.search.findOne({
-      where: {dimension, [sequelize.Op.or]: {id, slug: id}},
+      where: {dimension, cubeName, [sequelize.Op.or]: {id, slug: id}},
       include: {model: db.image, include: [{association: "content"}]}
     }).catch(catcher);
     if (!member) return type === "json" ? jsonError() : imageError();

--- a/packages/cms/src/member/MetaEditor.jsx
+++ b/packages/cms/src/member/MetaEditor.jsx
@@ -302,7 +302,8 @@ class MetaEditor extends Component {
           minWidth: this.columnWidths("image"),
           accessor: d => d.image ? d.image.url : null,
           Cell: cell => {
-            const imgURL = `/api/image?dimension=${cell.original.dimension}&id=${cell.original.id}&type=thumb&t=${epoch}`;
+            const {dimension, cubeName, id} = cell.original;
+            const imgURL = `/api/image?dimension=${dimension}&cubeName=${cubeName}&id=${id}&type=thumb&t=${epoch}`;
             return cell.value
               // image wrapped inside a button
               ? <button className="cp-table-cell-cover-button" onClick={this.clickCell.bind(this, cell)}>
@@ -744,10 +745,10 @@ class MetaEditor extends Component {
               />
 
               <div className="cms-meta-selected-img-wrapper">
-                {currentRow.imageId && currentRow.dimension && currentRow.id
+                {currentRow.imageId && currentRow.dimension && currentRow.id && currentRow.cubeName
                   ? <img
                     className="cms-meta-selected-img"
-                    src={`/api/image?dimension=${currentRow.dimension}&id=${currentRow.id}&type=thumb&t=${epoch}`}
+                    src={`/api/image?dimension=${currentRow.dimension}&cubeName=${currentRow.cubeName}&id=${currentRow.id}&type=thumb&t=${epoch}`}
                     alt=""
                     draggable="false"
                   />


### PR DESCRIPTION
Victor discovered a bug where images with the same member id were not showing different images, only the "first" one. This was because I hadn't worked the new `cubeName` uniqueness into the image hosting logic. This PR fixes that bug.