### PR TITLE
[cms] Fix trycatch formats

### DIFF
--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -230,6 +230,7 @@ export function fetchVariables(config, useCache) {
     if (useCache && thisProfile.variables) {
       const diffCounter = getStore().cms.status.diffCounter + 1;
       dispatch({type: "VARIABLES_SET", data: {id: currentPid, variables: deepClone(thisProfile.variables), diffCounter}});
+      dispatch({type: "VARIABLES_FETCHED"});
     }
     else {
       const locales = [localeDefault];
@@ -269,6 +270,7 @@ export function fetchVariables(config, useCache) {
               variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
               const diffCounter = getStore().cms.status.diffCounter + 1;
               dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
+              dispatch({type: "VARIABLES_FETCHED"});
             });
           }
           else if (config.type === "generator") {
@@ -287,6 +289,7 @@ export function fetchVariables(config, useCache) {
                 variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
                 const diffCounter = getStore().cms.status.diffCounter + 1;
                 dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
+                dispatch({type: "VARIABLES_FETCHED"});
               });
             });
           }
@@ -333,6 +336,7 @@ export function fetchVariables(config, useCache) {
                   variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
                   const diffCounter = getStore().cms.status.diffCounter + 1;
                   dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
+                  dispatch({type: "VARIABLES_FETCHED"});
                 });
               }
             });

--- a/packages/cms/src/components/Viz/Options.jsx
+++ b/packages/cms/src/components/Viz/Options.jsx
@@ -281,7 +281,14 @@ class Options extends Component {
             .then(resp => {
               loaded.push(resp.data);
               if (loaded.length === paths.length) {
-                const results = dataFormat(loaded.length === 1 ? loaded[0] : loaded);
+                let results;
+                try {
+                  results = dataFormat(loaded.length === 1 ? loaded[0] : loaded);
+                }
+                catch (e) {
+                  console.log("Error in Options Panel: ", e);
+                  results = [];
+                }
                 this.setState({loading: false, results});
               }
             });

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -117,6 +117,7 @@ class Table extends Component {
   // render ungrouped column
   renderColumn = col => {
     const {headerFormat, cellFormat} = this.state.config;
+    const defaultCellFormat = (key, val) => isNaN(val) ? val : abbreviate(val);
     return Object.assign({}, {
       Header: <button className="cp-table-header-button">
         {headerFormat(col)} <span className="u-visually-hidden">, sort by column</span>
@@ -124,7 +125,17 @@ class Table extends Component {
       </button>,
       id: col,
       accessor: d => d[col],
-      Cell: cell => <span className="cp-table-cell-inner" dangerouslySetInnerHTML={{__html: cellFormat(cell, cell.value)}} />
+      Cell: cell => {
+        let html;
+        try {
+          html = cellFormat(cell, cell.value);
+        }
+        catch (e) {
+          console.log("Error in cellFormat: ", e);
+          html = defaultCellFormat(cell, cell.value);
+        }
+        return <span className="cp-table-cell-inner" dangerouslySetInnerHTML={{__html: html}} />;
+      }
     });
   };
 

--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -130,8 +130,15 @@ class Viz extends Component {
               const hasMultiples = vizProps.data && Array.isArray(vizProps.data) && vizProps.data.some(d => typeof d === "string");
               const sources = hasMultiples ? resp : [resp];
               sources.forEach(r => this.analyzeData.bind(this)(r));
-              // console.log(sources);
-              return vizProps.dataFormat(resp);
+              let data;
+              try {
+                data = vizProps.dataFormat(resp);
+              }
+              catch (e) {
+                console.log("Error in dataFormat: ", e);
+                data = [];
+              }
+              return data;
             }}
             linksFormat={vizProps.linksFormat}
             nodesFormat={vizProps.nodesFormat}

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -91,7 +91,7 @@ class VisualizationCard extends Component {
   render() {
     const {minData, showReorderButton} = this.props;
     const {isOpen, alertObj} = this.state;
-    const {query} = this.props.status;
+    const {query, fetchingVariables} = this.props.status;
     const {formatterFunctions} = this.props.resources;
 
     const minDataState = this.state.minData;
@@ -172,7 +172,7 @@ class VisualizationCard extends Component {
     return (
       <Card {...cardProps}>
         {/* viz preview */}
-        {!isOpen &&
+        {!isOpen && !fetchingVariables &&
           <Viz {...vizProps} key="v" />
         }
 

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -82,11 +82,13 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
     case "VARIABLES_FETCH":
       return Object.assign({}, status, {fetchingVariables: true});
+    case "VARIABLES_FETCHED":
+      return Object.assign({}, status, {fetchingVariables: false});
     // Updating variables or saving a section or meta means that anything that depends on variables, such as TextCards 
     // Or the tree, needs to know something changed. Instead of running an expensive stringify on variables,
     // Just increment a counter that the various cards can subscribe to.
     case "VARIABLES_SET": 
-      const newStatus = {variables: deepClone(action.data.variables), fetchingVariables: false};
+      const newStatus = {variables: deepClone(action.data.variables)};
       if (action.data.diffCounter) newStatus.diffCounter = action.data.diffCounter;
       return Object.assign({}, status, newStatus);
     // Updating sections could mean the title was updated. Bump a "diffcounter" that the Navbar tree can listen for to jigger a render

--- a/packages/cms/src/utils/d3plusPropify.js
+++ b/packages/cms/src/utils/d3plusPropify.js
@@ -7,6 +7,7 @@ const envLoc = process.env.CANON_LANGUAGE_DEFAULT || "en";
 const frontEndMessage = "Error Rendering Visualization";
 const errorStub = {
   data: [],
+  dataFormat: d => d,
   type: "Treemap",
   noDataHTML: `<p style="font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;"><strong>${frontEndMessage}</strong></p>`
 };


### PR DESCRIPTION
Makes several improvements against whitescreen in the cms:

- wraps `cellFormat` and `dataFormat` in try/catch, so that "Correct Syntax but Run-time Error" passthrough functions don't crash the vizCards (and in turn, the CMS)
- Adds a `dataFormat` default to the errorStub, fixing a bug where the errorStub crashes the viz on the front-end.
- Properly makes use of a `fetchingVariables` state, which blocks vizes from rendering before variables are finished loading, preventing crashes where vizes attempted to use the (not yet loaded) variables right away.