### PR TITLE
pushes null z values to end of search result

### DIFF
--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -255,7 +255,7 @@ module.exports = function(app) {
         const rows = await db.search.findAll({
           where: {dimension: dc.dimension, cubeName: dc.cubeName},
           include: [{model: db.image, include: [{association: "content"}]}, {association: "content"}],
-          order: [["zvalue", "DESC"]],
+          order: [["zvalue", "DESC NULLS LAST"]],
           limit
         });
         rows.forEach(row => {
@@ -297,7 +297,7 @@ module.exports = function(app) {
           // Pad out the limit by multiplying by the number of unique dimensions, then limit (slice) them later.
           // Not perfect, could probably revisit the logic here.
           limit: limit * allDimCubes.length,
-          order: [["zvalue", "DESC"]],
+          order: [["zvalue", "DESC NULLS LAST"]],
           where: searchWhere
         });
         results.origin = "legacy";
@@ -454,7 +454,7 @@ module.exports = function(app) {
       rows = await db.search.findAll({
         include: [{model: db.image, include: [{association: "content"}]}, {association: "content"}],
         limit,
-        order: [["zvalue", "DESC"]],
+        order: [["zvalue", "DESC NULLS LAST"]],
         where: searchWhere
       });
     }


### PR DESCRIPTION
For legacy dimension-based searches, put `NULL` zvalues at end of list instead of beginning.