### PR TITLE
[cms] Automatic Parents Lookup

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -10,6 +10,7 @@ Content Management System for Canon sites.
 * [Environment Variables](#environment-variables)
 * [Sections](#sections)
 * [Search](#search)
+* [Advanced Generator Techniques](#advanced-generator-techniques)
 * [Advanced Visualization Techniques](#advanced-visualization-techniques)
 * [Authentication](#authentication)
 * [Frequently Asked Questions](#frequently-asked-questions)
@@ -426,6 +427,42 @@ If you would prefer to build your own search component, the DeepSearch API is av
 |`min_confidence`|Confidence threshold (Deepsearch Only)|
 
 Results will be returned in a response object that includes metadata on the results. Matching members separated by profile can be found in the `profiles` key of the response object. A single grouped list of all matching profiles can be found in the `grouped` key of the response object.
+
+---
+
+## Advanced Generator Techniques
+
+For complex generator calls, crafting an API URL using dynamic properties of the current member can be difficult. 
+
+### Using Member Attributes in API Calls
+
+The most basic example of this feature is including the `id` of the current member in the API call. Say, for example, you want to retrieve the population for the current state ID. For a given state ID of `25`, your API call may look something like this:
+
+```
+/api?measures=Population&drilldowns=State&State%20ID=25
+```
+
+However, the very point of the CMS is to swap out the `25` with whatever `id` you are previewing. This is the purpose of the fixed "Attributes" Generator at the top of the Generators panel. Any of the variables in this Attributes Generator can be swapped into a Generator API URL by using the `<variable>` syntax. So, the API call above would become:
+
+```
+/api?measures=Population&drilldowns=State&State%20ID=<id>
+```
+
+And the CMS will swap `25` in for `<id>`. This allows you to make complex API calls based on the `hierarchy`, `dimension`, etc. of the current member.
+
+### Object / Array Access
+
+Certain elements of the Attributes Generator, such as `parents` or `user`, are objects or arrays. You may access these using dot notation and array accessors:
+
+```
+/api?hierarchy=<parents[0].value>
+```
+
+However, be warned that this is not "true" javascript, merely string manipulation, so operations like `<parents[parents.length - 1].value>` are not supported. To access the ends of lists, use a python-esque negative index accessor like so:
+
+```
+/api?hierarchy=<parents[-1].value>
+```
 
 ---
 

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -220,6 +220,7 @@ export function fetchVariables(config, useCache) {
   return function(dispatch, getStore) {    
     dispatch({type: "VARIABLES_FETCH"});
     const {previews, localeDefault, localeSecondary, currentPid} = getStore().cms.status;
+    const {auth} = getStore();
 
     const thisProfile = getStore().cms.profiles.find(p => p.id === currentPid);
     let variables = deepClone(thisProfile.variables);
@@ -239,6 +240,12 @@ export function fetchVariables(config, useCache) {
       if (localeSecondary) locales.push(localeSecondary);
       for (const thisLocale of locales) {
         const attributes = attify(previews.map(d => d.searchObj), thisLocale);
+        if (auth.user) {
+          const {password, salt, ...user} = auth.user; // eslint-disable-line
+          attributes.user = user;
+          // Bubble up userRole for easy access in front end (for hiding sections based on role)
+          attributes.userRole = user.role;
+        }
         // If the config is for a materializer, or its for zero-length generators (like in a new profile) 
         // don't run custom generators. Just use our current variables for the POST action for materializers
         if (config.type === "materializer" || config.type === "generator" && config.ids.length === 0) {

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import {assign} from "d3plus-common";
 import deepClone from "../utils/deepClone";
 import getLocales from "../utils/getLocales";
+import attify from "../utils/attify";
 
 /** */
 export function getProfiles() {
@@ -180,7 +181,7 @@ export function resetPreviews() {
     const requests = profileMeta.map((meta, i) => {
       const levels = meta.levels ? meta.levels.join() : false;
       const levelString = levels ? `&levels=${levels}` : "";
-      let url = `${getStore().env.CANON_API}/api/search?q=&dimension=${meta.dimension}${levelString}&cubeName=${meta.cubeName}&limit=1`;
+      let url = `${getStore().env.CANON_API}/api/search?q=&dimension=${meta.dimension}${levelString}&cubeName=${meta.cubeName}&limit=1&parents=true`;
       
       const ps = pathObj.previews;
       // If previews is of type string, then it came from the URL permalink. Override
@@ -199,7 +200,8 @@ export function resetPreviews() {
           slug: profileMeta[i].slug,
           id: resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0].id : "",
           name: resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0].name : "",
-          memberSlug: resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0].slug : ""
+          memberSlug: resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0].slug : "",
+          searchObj: resp && resp.data && resp.data.results && resp.data.results[0] ? resp.data.results[0] : {}
         });
       });
       const newPathObj = Object.assign({}, pathObj, {previews});
@@ -236,6 +238,7 @@ export function fetchVariables(config, useCache) {
       const locales = [localeDefault];
       if (localeSecondary) locales.push(localeSecondary);
       for (const thisLocale of locales) {
+        const attributes = attify(previews.map(d => d.searchObj), thisLocale);
         // If the config is for a materializer, or its for zero-length generators (like in a new profile) 
         // don't run custom generators. Just use our current variables for the POST action for materializers
         if (config.type === "materializer" || config.type === "generator" && config.ids.length === 0) {
@@ -247,10 +250,6 @@ export function fetchVariables(config, useCache) {
           if (config.type === "materializer") {
             const mid = config.ids[0];
             query = {materializer: mid};
-          }
-          // Generator 0 is a special short-circuit ID that returns only Attributes variables
-          else if (config.type === "generator") {
-            query = {generator: 0};
           }
           Object.keys(query).forEach(k => {
             paramString += `&${k}=${query[k]}`;
@@ -281,16 +280,15 @@ export function fetchVariables(config, useCache) {
               });
               delete variables[thisLocale]._matStatus[mid];
             });
-            // We only arrive here in the case of zero-length generators. Zero length generators STILL NEED to run 
-            // the special built-in attribute endpoint, to handle the case of new profiles (and generator-less profiles)
-            axios.get(`${getStore().env.CANON_API}/api/generators/${currentPid}?locale=${thisLocale}${paramString}`).then(gen => {
-              variables[thisLocale] = assign({}, variables[thisLocale], gen.data);
-              axios.post(`${getStore().env.CANON_API}/api/materializers/${currentPid}?locale=${thisLocale}${paramString}`, {variables: variables[thisLocale]}).then(mat => {
-                variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
-                const diffCounter = getStore().cms.status.diffCounter + 1;
-                dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
-                dispatch({type: "VARIABLES_FETCHED"});
-              });
+            // We only arrive here in the case of zero-length generators. Zero length generators STILL NEED to use 
+            // the special built-in attributes, to handle the case of new profiles (and generator-less profiles)
+            const genStub = {...attributes, _genStatus: {attributes}};
+            variables[thisLocale] = assign({}, variables[thisLocale], genStub);
+            axios.post(`${getStore().env.CANON_API}/api/materializers/${currentPid}?locale=${thisLocale}${paramString}`, {variables: variables[thisLocale]}).then(mat => {
+              variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
+              const diffCounter = getStore().cms.status.diffCounter + 1;
+              dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
+              dispatch({type: "VARIABLES_FETCHED"});
             });
           }
         }
@@ -304,59 +302,44 @@ export function fetchVariables(config, useCache) {
             }
             delete variables[thisLocale]._genStatus[gid];
           }
-          // Whether this is a single gid (saving a generator) or the whole lot (loading a profile), we need to run
-          // the attributes-only generator first and store it in variables. The :parents operation in the attributes generator
-          // is quite slow, and technically need be done only once (though every generator needs it). So, GET the special id=0
-          // attributes generator, and from then on, POST that attributes payload to each and every generator fetch, so those
-          // fetches can have the attributes available to them, but don't need to run the expensive :parents operation
-          let paramString = "&generator=0";
-          previews.forEach((p, i) => {
-            paramString += `&slug${i + 1}=${p.slug}&id${i + 1}=${p.id}`;
-          });
-          console.log("running parents");
-          axios.get(`${getStore().env.CANON_API}/api/generators/${currentPid}?locale=${thisLocale}${paramString}`).then(gen0 => {
-            variables[thisLocale] = assign({}, variables[thisLocale], gen0.data);
-            console.log("got parents");
-            for (const gid of gids) {
-              const query = {generator: gid};
-              let paramString = "";
-              previews.forEach((p, i) => {
-                paramString += `&slug${i + 1}=${p.slug}&id${i + 1}=${p.id}`;
-              });
-              Object.keys(query).forEach(k => {
-                paramString += `&${k}=${query[k]}`;
-              });
-              const attributes = gen0.data;
-              console.log("sending", attributes);
-              axios.post(`${getStore().env.CANON_API}/api/generators/${currentPid}?locale=${thisLocale}${paramString}`, {attributes}).then(gen => {
-                variables[thisLocale] = assign({}, variables[thisLocale], gen.data);
-                let gensLoaded = Object.keys(variables[thisLocale]._genStatus).filter(d => gids.includes(Number(d))).length;
-                const gensTotal = gids.length;
-                const genLang = thisLocale;
-                // If the user is deleting a generator, then this function was called with a single gid (the one that was deleted)
-                // The pruning code above already removed its vars and _genStatus from the original vars, so the loading progress
-                // Can't know what to wait for. In this single instance, use this short-circuit to be instantly done and move onto mats.
-                if (gids.length === 1 && JSON.stringify(gen.data) === "{}") gensLoaded = 1;
-                dispatch({type: "STATUS_SET", data: {gensLoaded, gensTotal, genLang}});
-                dispatch({type: "VARIABLES_SET", data: {id: currentPid, variables}});
-                if (gensLoaded === gids.length) {
-                  // Clean out stale materializers (see above comment)
-                  Object.keys(variables[thisLocale]._matStatus).forEach(mid => {
-                    Object.keys(variables[thisLocale]._matStatus[mid]).forEach(k => {
-                      delete variables[thisLocale][k]; 
-                    });
-                    delete variables[thisLocale]._matStatus[mid];
+          for (const gid of gids) {
+            const query = {generator: gid};
+            let paramString = "";
+            previews.forEach((p, i) => {
+              paramString += `&slug${i + 1}=${p.slug}&id${i + 1}=${p.id}`;
+            });
+            Object.keys(query).forEach(k => {
+              paramString += `&${k}=${query[k]}`;
+            });
+            
+            axios.post(`${getStore().env.CANON_API}/api/generators/${currentPid}?locale=${thisLocale}${paramString}`, {attributes}).then(gen => {
+              variables[thisLocale] = assign({}, variables[thisLocale], gen.data);
+              let gensLoaded = Object.keys(variables[thisLocale]._genStatus).filter(d => gids.includes(Number(d))).length;
+              const gensTotal = gids.length;
+              const genLang = thisLocale;
+              // If the user is deleting a generator, then this function was called with a single gid (the one that was deleted)
+              // The pruning code above already removed its vars and _genStatus from the original vars, so the loading progress
+              // Can't know what to wait for. In this single instance, use this short-circuit to be instantly done and move onto mats.
+              if (gids.length === 1 && JSON.stringify(gen.data) === "{}") gensLoaded = 1;
+              dispatch({type: "STATUS_SET", data: {gensLoaded, gensTotal, genLang}});
+              dispatch({type: "VARIABLES_SET", data: {id: currentPid, variables}});
+              if (gensLoaded === gids.length) {
+                // Clean out stale materializers (see above comment)
+                Object.keys(variables[thisLocale]._matStatus).forEach(mid => {
+                  Object.keys(variables[thisLocale]._matStatus[mid]).forEach(k => {
+                    delete variables[thisLocale][k]; 
                   });
-                  axios.post(`${getStore().env.CANON_API}/api/materializers/${currentPid}?locale=${thisLocale}${paramString}`, {variables: variables[thisLocale]}).then(mat => {
-                    variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
-                    const diffCounter = getStore().cms.status.diffCounter + 1;
-                    dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
-                    dispatch({type: "VARIABLES_FETCHED"});
-                  });
-                }
-              });
-            }
-          });
+                  delete variables[thisLocale]._matStatus[mid];
+                });
+                axios.post(`${getStore().env.CANON_API}/api/materializers/${currentPid}?locale=${thisLocale}${paramString}`, {variables: variables[thisLocale]}).then(mat => {
+                  variables[thisLocale] = assign({}, variables[thisLocale], mat.data);
+                  const diffCounter = getStore().cms.status.diffCounter + 1;
+                  dispatch({type: "VARIABLES_SET", data: {id: currentPid, diffCounter, variables}});
+                  dispatch({type: "VARIABLES_FETCHED"});
+                });
+              }
+            });
+          }
         }
       }
     }

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -274,9 +274,6 @@ module.exports = function(app) {
         smallAttr.parents = resp.data.data;
       }
     }
-    // The id "0" is a special case to retrieve ONLY the Attributes variables (without running any real generators)
-    // Used in fetchVariables for new profiles that have no custom generators but still need to run this function.
-    if (id === "0") return {...smallAttr, _genStatus: {attributes: {...smallAttr}}};
     const genObj = id ? {where: {id}} : {where: {profile_id: pid}};
     let generators = await db.generator.findAll(genObj).catch(catcher);
     if (generators.length === 0) return {};

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -23,6 +23,8 @@ const LOGINS = process.env.CANON_LOGINS || false;
 const PORT = process.env.CANON_PORT || 3300;
 const NODE_ENV = process.env.NODE_ENV || "development";
 const REQUESTS_PER_SECOND = process.env.CANON_CMS_REQUESTS_PER_SECOND ? parseInt(process.env.CANON_CMS_REQUESTS_PER_SECOND, 10) : 20;
+let cubeRoot = process.env.CANON_CMS_CUBES;
+if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 
 const canonVars = {
   CANON_API: process.env.CANON_API,
@@ -261,6 +263,15 @@ module.exports = function(app) {
       smallAttr.user = user;
       // Bubble up userRole for easy access in front end (for hiding sections based on role)
       smallAttr.userRole = user.role;
+    }
+    // Fetch Parents
+    const resp = await axios.get(`${cubeRoot}/relations.jsonrecords?cube=${attr.cubeName}&${attr.hierarchy}=${attr.id}:parents`).catch(() => {
+      if (verbose) console.log("Warning: Parent endpoint misconfigured or not available");
+      return [];
+    });
+    if (resp && resp.data && resp.data.data && resp.data.data.length > 0) {
+      const parents = resp.data.data.reverse();
+      smallAttr.parents = parents;
     }
     // The id "0" is a special case to retrieve ONLY the Attributes variables (without running any real generators)
     // Used in fetchVariables for new profiles that have no custom generators but still need to run this function.

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -301,7 +301,7 @@ module.exports = function(app) {
     const formatterFunctions = await formatters4eval(db, locale);
 
     const requests = Array.from(new Set(generators.map(g => g.api)));
-    const fetches = requests.map(url => throttle.add(createGeneratorFetch.bind(this, url, attr)));
+    const fetches = requests.map(url => throttle.add(createGeneratorFetch.bind(this, url, smallAttr)));
     const results = await Promise.all(fetches).catch(catcher);
 
     // Seed the return variables with the stripped-down attr object

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -511,6 +511,7 @@ module.exports = function(app) {
         result.keywords = defCon.keywords;
         result.attr = defCon.attr;
       }
+      result.content = d.content;
       results.push(result);
     }
 

--- a/packages/cms/src/components/fields/PreviewSearch.jsx
+++ b/packages/cms/src/components/fields/PreviewSearch.jsx
@@ -20,12 +20,20 @@ class PreviewSearch extends Component {
   }
 
   onSelectPreview(result) {
-    const {slug} = this.props;
+    const {slug, url, dimension, cubeName} = this.props;
     const {id, name, slug: memberSlug} = result;
-    const newPreview = {slug, id, name, memberSlug};
-    const previews = this.props.status.previews.map(p => p.slug === newPreview.slug ? newPreview : p);
-    const pathObj = Object.assign({}, this.props.status.pathObj, {previews});
-    this.props.setStatus({pathObj, previews, userQuery: ""});
+    // When selecting a new preview, a new roundtrip is required to look 
+    const fullURL = `${url}?id=${id}&dimension=${dimension}&cubeName=${cubeName}&limit=1&parents=true`;
+    axios.get(fullURL).then(resp => {
+      let searchObj = {};
+      if (resp.data && resp.data.results) {
+        searchObj = resp.data.results[0];
+      }
+      const newPreview = {slug, id, name, memberSlug, searchObj};
+      const previews = this.props.status.previews.map(p => p.slug === newPreview.slug ? newPreview : p);
+      const pathObj = Object.assign({}, this.props.status.pathObj, {previews});
+      this.props.setStatus({pathObj, previews, userQuery: ""});
+    });
   }
 
   onChange(e) {

--- a/packages/cms/src/utils/attify.js
+++ b/packages/cms/src/utils/attify.js
@@ -1,0 +1,20 @@
+// Given a list of search rows, "attribute-ify" them into a single numerically-keyed object
+module.exports = (searchRows, locale) => 
+  searchRows.reduce((acc, d, i) => (
+    {
+      ...acc,
+      [`id${i + 1}`]: d.id,
+      [`slug${i + 1}`]: d.slug,
+      [`name${i + 1}`]: d.name,
+      [`dimension${i + 1}`]: d.dimension,
+      [`hierarchy${i + 1}`]: d.hierarchy,
+      [`parents${i + 1}`]: d.parents
+    }
+  ), {
+    id: searchRows[0].id,
+    slug: searchRows[0].slug,
+    name: searchRows[0].name,
+    dimension: searchRows[0].dimension,
+    hierarchy: searchRows[0].hierarchy,
+    parents: searchRows[0].parents
+  });

--- a/packages/cms/src/utils/attify.js
+++ b/packages/cms/src/utils/attify.js
@@ -5,7 +5,7 @@ module.exports = (searchRows, locale) =>
       ...acc,
       [`id${i + 1}`]: d.id,
       [`slug${i + 1}`]: d.slug,
-      [`name${i + 1}`]: d.name,
+      [`name${i + 1}`]: d.content.find(o => o.locale === locale) ? d.content.find(o => o.locale === locale).name : "",
       [`dimension${i + 1}`]: d.dimension,
       [`hierarchy${i + 1}`]: d.hierarchy,
       [`parents${i + 1}`]: d.parents
@@ -13,7 +13,7 @@ module.exports = (searchRows, locale) =>
   ), {
     id: searchRows[0].id,
     slug: searchRows[0].slug,
-    name: searchRows[0].name,
+    name: searchRows[0].content.find(o => o.locale === locale) ? searchRows[0].content.find(o => o.locale === locale).name : "",
     dimension: searchRows[0].dimension,
     hierarchy: searchRows[0].hierarchy,
     parents: searchRows[0].parents

--- a/packages/cms/src/utils/urlSwap.js
+++ b/packages/cms/src/utils/urlSwap.js
@@ -15,11 +15,18 @@ module.exports = function(url, params) {
   const lookup = Object.assign({}, env, params);
 
   (url.match(/<[^\&\=\/>]+>/g) || []).forEach(variable => {
+    // Remove the <> brackets from the edges
     const x = variable.slice(1, -1);
+    // Create an array of accessor strings, e.g. parents[0].ids[3].name => ["parents", "0", "ids", "3", "name"]
     const accessors = x.match(/[^\]\[.]+/g);
     let value;
     try {
-      value = accessors.reduce((o, i) => o[i], lookup);
+      value = accessors.reduce((o, i) => {
+        // If the acccessor is a negative number, attempt a python-esque negative index access pattern
+        const int = parseInt(i, 10);
+        if (!isNaN(int) && int < 0) i = Math.abs((int + o.length) % o.length);
+        return o[i];
+      }, lookup);
     }
     catch (e) {
       if (verbose) console.error("Error in urlSwap: ", e.message);


### PR DESCRIPTION
Closes #910 

Adds a `parents` object to the Attributes generator, allowing for subsequent generator API calls to make use of its contents.

Adds functionality and documentation for string-based object crawling in Generator APIs, e.g., `/api?hierarchy=<parents[0].value>`

Also adds locale-specific "name" to the Attributes generator.

Notes:

- The parents call currently takes up to 10 seconds. Because having the parents object is necessary for subsequent generators, parent fetching blocks all generators from running until this operation is complete. @MarcioPorto is looking into this at the cube level, but @alexandersimoes should be aware that upgrading OEC to a version of the CMS that has this PR in it will add to load times (until the parents endpoint is examined)
- @alexandersimoes You will also want to examine conflicting variables after upgrading. If you had specific generators for finding the `name` or the `parents` in the past, you will need to clean those up as the Attributes Generator should handle them now.