### PR TITLE
fixes bug with options panel

### DIFF
--- a/packages/cms/src/components/Viz/Options.jsx
+++ b/packages/cms/src/components/Viz/Options.jsx
@@ -280,7 +280,7 @@ class Options extends Component {
         const loaded = resps.map(d => d.data);
         let results;
         try {
-          results = dataFormat(resps.length === 1 ? loaded[0] : loaded);
+          results = dataFormat(loaded.length === 1 ? loaded[0] : loaded);
         }
         catch (e) {
           console.log("Error in Options Panel: ", e);


### PR DESCRIPTION
Closes #943 

When investigating Felipe's bug report, I realized two problems with the Options.jsx panel.

1) The comparison for detecting changes in the data props in `componentDidUpdate` was faulty. 
 Firstly, comparing arrays in this manner will never be equal, and further, setting results naively to `data` was what was causing the bug in the first place (spread out characters of the datacall in the Table).

2) Additionally, the data fetch was being done in a `forEach` loop, and as each response returned, it was pushed onto a "loaded" array. This does not guarantee ordering, and because `dataFormat` operations depend on ordering, this would fail half the time. 

In general, we should arrange to do more testing in the coming weeks on the Options panel's view data function.