### PR TITLE
Issue 956 profile variants

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -203,6 +203,8 @@ A Canon site often takes the form of DataCountry.io, and is made of **Profiles**
 
 - **Dimension**: Any given Profile in the CMS must be linked to one or more dimensions. Examples include "Geography," "University," or "CIP" (Industry). You could have a `geo` profile, which is linked to the "Geography" dimension, whose members are things like Massachusetts or New York.
 
+- **Variant**: A given Dimension (above) may also have several **Variants**. If you have a dimension that is linked to a cube, e.g. a Subnational Dimension from a Japan Cube, you may add a variant of this `geo`-type dimension: e.g. a Subnational Dimension from a China cube. This allows you to have a single top-level profile (like "Subnational") that has multiple expressions/variants from different cubes, allowing you to share logic and layout between the different data feeds.
+
 ---
 
 ## Environment Variables

--- a/packages/cms/app/helmet.js
+++ b/packages/cms/app/helmet.js
@@ -1,6 +1,6 @@
 export default {
   link: [
-    {rel: "icon", href: "images/favicon.ico"}
+    {rel: "icon", href: "/images/favicon.ico"}
   ],
   meta: [
     {charset: "utf-8"},

--- a/packages/cms/src/Builder.jsx
+++ b/packages/cms/src/Builder.jsx
@@ -115,7 +115,7 @@ class Builder extends Component {
     // previews may come in as a string (from the URL) or an array (from the app).
     // Set the url correctly either way.
     if (pathObj.previews) {
-      const previews = typeof pathObj.previews === "string" ? pathObj.previews : pathObj.previews.map(d => d.id).join();
+      const previews = typeof pathObj.previews === "string" ? pathObj.previews : pathObj.previews.map(d => d.memberSlug).join();
       url += `&previews=${previews}`;
     }
     // Story

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -3,6 +3,7 @@ import {assign} from "d3plus-common";
 import deepClone from "../utils/deepClone";
 import getLocales from "../utils/getLocales";
 import attify from "../utils/attify";
+import groupMeta from "../utils/groupMeta";
 
 /** */
 export function getProfiles() {
@@ -178,11 +179,7 @@ export function resetPreviews() {
     const profileMeta = thisProfile.meta;
 
     // Meta may have multiple variants under the same ordering index. Group them into their shared ordering indeces.
-    const groupedMeta = profileMeta.reduce((acc, d) => {
-      if (!acc[d.ordering]) acc[d.ordering] = [];
-      acc[d.ordering].push(d);
-      return acc;
-    }, []);
+    const groupedMeta = groupMeta(profileMeta);
   
     const requests = groupedMeta.map((group, i) => {
       let url;

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -180,7 +180,8 @@ const sortProfileTree = (db, profiles) => {
   profiles = profiles.map(p => p.toJSON());
   profiles = flatSort(db.profile, profiles);
   profiles.forEach(p => {
-    p.meta = flatSort(db.profile_meta, p.meta);
+    // Don't use flatSort for meta. Meta can have multiple entities in the same ordering, so do not attempt to "flatten" them out
+    p.meta = p.meta.sort(sorter);
     p.sections = flatSort(db.section, p.sections);
   });
   return profiles;

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -281,7 +281,7 @@ module.exports = function(app) {
     }
     const genObj = id ? {where: {id}} : {where: {profile_id: pid}};
     let generators = await db.generator.findAll(genObj).catch(catcher);
-    if (generators.length === 0) return {};
+    if (id && generators.length === 0) return {};
     generators = generators.map(g => g.toJSON());
 
     /** */

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -446,8 +446,8 @@ module.exports = function(app) {
         const potentialPid = meta.find(m => m.slug === dims[0].slug && m.ordering === 0).profile_id;
         // However, still confirm that the second slug matches (if provided)
         if (dims[1] && dims[1].slug) {
-          const potentialSecondSlugs = meta.filter(m => m.profile_id === potentialPid && m.ordering === 1);
-          if (potentialSecondSlugs.map(d => d.slug).includes(dims[1].slug)) {
+          const potentialSecondSlugs = meta.filter(m => m.profile_id === potentialPid && m.ordering === 1).map(d => d.slug);
+          if (potentialSecondSlugs.includes(dims[1].slug)) {
             pid = potentialPid;
           }
         }

--- a/packages/cms/src/components/cards/DimensionCard.jsx
+++ b/packages/cms/src/components/cards/DimensionCard.jsx
@@ -81,7 +81,8 @@ class DimensionCard extends Component {
           <DefinitionList definitions={[
             {label: "slug", text: meta.slug},
             {label: "levels", text: meta.levels.join(", ")},
-            {label: "measure", text: meta.measure}
+            {label: "measure", text: meta.measure},
+            {label: "cube", text: meta.cubeName}
           ]}/>
         </Card>
 

--- a/packages/cms/src/components/cards/DimensionCard.jsx
+++ b/packages/cms/src/components/cards/DimensionCard.jsx
@@ -5,7 +5,6 @@ import Card from "./Card";
 import Dialog from "../interface/Dialog";
 import DimensionEditor from "../editors/DimensionEditor";
 import DefinitionList from "../variables/DefinitionList";
-import PreviewSearch from "../fields/PreviewSearch";
 
 import {deleteDimension} from "../../actions/profiles";
 import "./DimensionCard.css";
@@ -46,10 +45,8 @@ class DimensionCard extends Component {
   }
 
   render() {
-    const {meta, preview} = this.props;
+    const {meta} = this.props;
     const {rebuilding, alertObj, isOpen} = this.state;
-
-    if (!preview) return null;
 
     // define props for Card
     const cardProps = {
@@ -84,19 +81,7 @@ class DimensionCard extends Component {
           <DefinitionList definitions={[
             {label: "slug", text: meta.slug},
             {label: "levels", text: meta.levels.join(", ")},
-            {label: "measure", text: meta.measure},
-            {label: "preview ID", text:
-              <PreviewSearch
-                label={preview.name || preview.id || "search profiles..."}
-                previewing={preview.name || preview.id}
-                fontSize="xxs"
-                slug={meta.slug}
-                dimension={meta.dimension}
-                levels={meta.levels}
-                cubeName={meta.cubeName}
-                limit={20}
-              />
-            }
+            {label: "measure", text: meta.measure}
           ]}/>
         </Card>
 

--- a/packages/cms/src/components/editors/DimensionEditor.jsx
+++ b/packages/cms/src/components/editors/DimensionEditor.jsx
@@ -115,8 +115,7 @@ class DimensionEditor extends Component {
 
   saveProfile() {
     const {profileData, mode} = this.state;
-    const {meta} = this.props;
-    const {profiles} = this.props;
+    const {profiles, meta, ordering} = this.props;
     const {currentPid} = this.props.status;
     let takenSlugs = profiles.map(p => p.meta).reduce((acc, d) => acc.concat(d.map(m => m.slug)), []);
     // If editing, then the user provided seed data via "meta". Do not include the given
@@ -131,7 +130,10 @@ class DimensionEditor extends Component {
       });
     }
     else {
-      this.props.modifyDimension(Object.assign({}, profileData, {profile_id: currentPid}));
+      const payload = Object.assign({}, profileData, {profile_id: currentPid});
+      // If ordering was provided, this is a Variant 
+      if (!isNaN(ordering)) payload.ordering = ordering;
+      this.props.modifyDimension(payload);
       if (this.props.onComplete) this.props.onComplete();
     }
   }

--- a/packages/cms/src/components/fields/PreviewSearch.jsx
+++ b/packages/cms/src/components/fields/PreviewSearch.jsx
@@ -48,7 +48,6 @@ class PreviewSearch extends Component {
     else if (url) {
       const {limit, meta} = this.props;
       const fullUrl = `${url}?q=${userQuery}&limit=${limit}&pslug=${meta.map(m => m.slug).join()}`;
-      console.log(fullUrl);
       this.setState({userQuery});
       axios.get(fullUrl)
         .then(res => res.data)

--- a/packages/cms/src/components/fields/PreviewSearch.jsx
+++ b/packages/cms/src/components/fields/PreviewSearch.jsx
@@ -20,7 +20,7 @@ class PreviewSearch extends Component {
   }
 
   onSelectPreview(result) {
-    const {url, meta, index} = this.props;
+    const {url, group, index} = this.props;
     const {id, name, slug: memberSlug} = result;
     // When selecting a new preview, a new roundtrip is required to fetch parents.
     const fullURL = `${url}?slug=${memberSlug}&limit=1&parents=true`;
@@ -29,8 +29,8 @@ class PreviewSearch extends Component {
       if (resp.data && resp.data.results) {
         searchObj = resp.data.results[0];
       }
-      // meta is an array of possible variants. Use the clicked result to divine which one we're on.
-      const newMeta = meta.find(m => m.dimension === searchObj.dimension && m.cubeName === searchObj.cubeName);
+      // group is an array of possible meta variants. Use the clicked result to divine which one we're on.
+      const newMeta = group.find(m => m.dimension === searchObj.dimension && m.cubeName === searchObj.cubeName);
       const newPreview = {slug: newMeta.slug, id, name, memberSlug, searchObj};
       const previews = this.props.status.previews.map((p, i) => i === index ? newPreview : p);
       const pathObj = Object.assign({}, this.props.status.pathObj, {previews});
@@ -46,8 +46,8 @@ class PreviewSearch extends Component {
       this.setState({active: true, results: [], userQuery});
     }
     else if (url) {
-      const {limit, meta} = this.props;
-      const fullUrl = `${url}?q=${userQuery}&limit=${limit}&pslug=${meta.map(m => m.slug).join()}`;
+      const {limit, group} = this.props;
+      const fullUrl = `${url}?q=${userQuery}&limit=${limit}&pslug=${group.map(m => m.slug).join()}`;
       this.setState({userQuery});
       axios.get(fullUrl)
         .then(res => res.data)

--- a/packages/cms/src/components/fields/PreviewSearch.jsx
+++ b/packages/cms/src/components/fields/PreviewSearch.jsx
@@ -189,7 +189,7 @@ class PreviewSearch extends Component {
               <li
                 className="cms-search-result-item u-font-xs"
                 onClick={this.onSelect.bind(this, result)}
-                key={result.id}
+                key={result.slug}
                 result={result}
               >
                 <Button

--- a/packages/cms/src/components/fields/PreviewSearch.jsx
+++ b/packages/cms/src/components/fields/PreviewSearch.jsx
@@ -20,17 +20,19 @@ class PreviewSearch extends Component {
   }
 
   onSelectPreview(result) {
-    const {slug, url, dimension, cubeName} = this.props;
+    const {url, meta, index} = this.props;
     const {id, name, slug: memberSlug} = result;
-    // When selecting a new preview, a new roundtrip is required to look 
-    const fullURL = `${url}?id=${id}&dimension=${dimension}&cubeName=${cubeName}&limit=1&parents=true`;
+    // When selecting a new preview, a new roundtrip is required to fetch parents.
+    const fullURL = `${url}?slug=${memberSlug}&limit=1&parents=true`;
     axios.get(fullURL).then(resp => {
       let searchObj = {};
       if (resp.data && resp.data.results) {
         searchObj = resp.data.results[0];
       }
-      const newPreview = {slug, id, name, memberSlug, searchObj};
-      const previews = this.props.status.previews.map(p => p.slug === newPreview.slug ? newPreview : p);
+      // meta is an array of possible variants. Use the clicked result to divine which one we're on.
+      const newMeta = meta.find(m => m.dimension === searchObj.dimension && m.cubeName === searchObj.cubeName);
+      const newPreview = {slug: newMeta.slug, id, name, memberSlug, searchObj};
+      const previews = this.props.status.previews.map((p, i) => i === index ? newPreview : p);
       const pathObj = Object.assign({}, this.props.status.pathObj, {previews});
       this.props.setStatus({pathObj, previews, userQuery: ""});
     });
@@ -44,11 +46,9 @@ class PreviewSearch extends Component {
       this.setState({active: true, results: [], userQuery});
     }
     else if (url) {
-      const {dimension, limit, levels, cubeName} = this.props;
-      let fullUrl = `${url}?q=${userQuery}&limit=${limit}`;
-      if (dimension) fullUrl += `&dimension=${dimension}`;
-      if (levels) fullUrl += `&levels=${levels.join()}`;
-      if (cubeName) fullUrl += `&cubeName=${cubeName}`;
+      const {limit, meta} = this.props;
+      const fullUrl = `${url}?q=${userQuery}&limit=${limit}&pslug=${meta.map(m => m.slug).join()}`;
+      console.log(fullUrl);
       this.setState({userQuery});
       axios.get(fullUrl)
         .then(res => res.data)
@@ -218,7 +218,6 @@ PreviewSearch.defaultProps = {
   buttonLink: false,
   buttonText: "Search",
   className: "search",
-  dimension: false,
   icon: "search",
   inactiveComponent: false,
   inline: false,

--- a/packages/cms/src/components/interface/Dropdown.jsx
+++ b/packages/cms/src/components/interface/Dropdown.jsx
@@ -84,8 +84,8 @@ class Dropdown extends Component {
         {/* loop through nav links */}
         {items && items.length &&
           <ul className={`${namespace}-dropdown-list ${isOpen ? "is-open" : "is-closed"}`} key={`${title}-dropdown-list`}>
-            {items.map(item =>
-              <li className={`${namespace}-dropdown-item`} key={`${item.title}-dropdown-item`}>
+            {items.map((item, i) =>
+              <li className={`${namespace}-dropdown-item`} key={`${item.title}-${i}-dropdown-item`}>
                 {item.items && item.items.length
                   // nested items array; render them in a nested list
                   ? <Fragment>

--- a/packages/cms/src/components/interface/Navbar.jsx
+++ b/packages/cms/src/components/interface/Navbar.jsx
@@ -10,6 +10,7 @@ import {getStories, newStory, deleteStory} from "../../actions/stories";
 import {setStatus} from "../../actions/status";
 
 import stripHTML from "../../utils/formatters/stripHTML";
+import groupMeta from "../../utils/groupMeta";
 
 import Dropdown from "./Dropdown";
 import Outline from "./Outline";
@@ -135,9 +136,11 @@ class Navbar extends Component {
 
   // create a title by joining dimensions together
   makeTitleFromDimensions(entity) {
-    return entity.meta && entity.meta.length
-      ? entity.meta.map(m => m.slug).join(" / ")
-      : "Unnamed";
+    if (entity.meta && entity.meta.length) {
+      const groupedMeta = groupMeta(entity.meta);
+      return groupedMeta.length > 0 ? groupedMeta.map(g => g[0] ? g[0].slug : "ERR_META").join(" / ") : "Unnamed";      
+    }
+    else return "Unnamed";
   }
 
   // get the title of the current node, in the correct language

--- a/packages/cms/src/components/interface/PreviewHeader.jsx
+++ b/packages/cms/src/components/interface/PreviewHeader.jsx
@@ -68,7 +68,7 @@ class PreviewHeader extends Component {
               label={previews[i].name || previews[i].id || "search profiles..."}
               previewing={previews[i].name || previews[i].id}
               fontSize="xxs"
-              meta={group}
+              group={group}
               index={i}
               limit={20}
             />

--- a/packages/cms/src/components/interface/PreviewHeader.jsx
+++ b/packages/cms/src/components/interface/PreviewHeader.jsx
@@ -8,6 +8,8 @@ import Status from "../interface/Status";
 import {setStatus} from "../../actions/status";
 import {fetchSectionPreview} from "../../actions/profiles";
 
+import groupMeta from "../../utils/groupMeta";
+
 import "./PreviewHeader.css";
 
 class PreviewHeader extends Component {
@@ -55,19 +57,19 @@ class PreviewHeader extends Component {
 
     const localeList = locales.concat([localeDefault]);
 
+    const groupedMeta = groupMeta(meta);
+
     return (
       <Fragment>
         <div className="cms-preview-header">
-          {meta.map((m, i) =>
+          {groupedMeta.map((group, i) =>
             <PreviewSearch
-              key={`ps-${m.slug}`}
+              key={`group-${i}`}
               label={previews[i].name || previews[i].id || "search profiles..."}
               previewing={previews[i].name || previews[i].id}
               fontSize="xxs"
-              slug={m.slug}
-              dimension={m.dimension}
-              levels={m.levels}
-              cubeName={m.cubeName}
+              meta={group}
+              index={i}
               limit={20}
             />
           )}

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -33,25 +33,12 @@ class Toolbox extends Component {
     const newIDs = this.props.status.previews ? this.props.status.previews.map(p => p.id).join() : this.props.status.previews;
     const changedSinglePreview = oldSlugs === newSlugs && oldIDs !== newIDs;
     const changedEntireProfile = oldSlugs !== newSlugs;
-    const localeChanged = prevProps.status.localeSecondary !== this.props.status.localeSecondary;
+    const changedLocale = prevProps.status.localeSecondary !== this.props.status.localeSecondary;
 
-    if (changedSinglePreview) {
-      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)});
-    }
-    // TODO: This preview-changing detection is a little janky. Change NavBar.jsx (and all cmsRoute Profile gets)
-    // To always deliver profiles with previews already set, remove ResetPreviews, and just call FetchVariables immediately.
-    if (changedEntireProfile) {
-      const prevSlugs = prevProps.status.previews ? prevProps.status.previews.map(p => p.slug) : [];
-      const currSlugs = this.props.status.previews ? this.props.status.previews.map(p => p.slug) : [];
-      const addedDimension = prevSlugs.length === 0 && currSlugs.length === 1;
-      const deletedDimension = prevSlugs.length === 1 && currSlugs.length === 0;
-      // This check is not perfect, and it fires when moving from profiles with 0 to 1 dimensions and vice versa.
-      // However, the only side effect is not using the cache and re-running the generators.
-      const sameProfileButChangedMeta = addedDimension || deletedDimension || prevSlugs.some(slug => currSlugs.includes(slug));
-      const useCache = !sameProfileButChangedMeta;
-      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)}, useCache);
-    }
-    if (localeChanged) {
+    // TODO: This can be streamlined to make use of a caching system (see NavBar.jsx and profiles.js) 
+    // When a profile is loaded, save its current previews and variables (all we have is variables right now) and 
+    // Responsibly reload them when changing entire profile. For now, deal with the more heavy reload 
+    if (changedSinglePreview || changedEntireProfile || changedLocale) {
       this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)});
     }
     // Detect Deletions

--- a/packages/cms/src/profile/DimensionBuilder.css
+++ b/packages/cms/src/profile/DimensionBuilder.css
@@ -5,3 +5,17 @@
 .dimension-card-list {
   margin-top: -1.25rem;
 }
+
+.cms-dimension-deck {
+  & .cms-deck-heading {
+    & .bp3-control {
+      margin: 0 0 0 var(--gutter-sm);
+    }
+  }
+  & .cms-card-list {
+    border-top: none !important;
+    & > * {
+      flex: 1;
+    }
+  }
+}

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -44,7 +44,7 @@ class DimensionBuilder extends Component {
                 label={previews[i].name || previews[i].id || "search profiles..."}
                 previewing={previews[i].name || previews[i].id}
                 fontSize="xxs"
-                meta={group}
+                group={group}
                 index={i}
                 limit={20}
               />

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -5,6 +5,7 @@ import DimensionCard from "../components/cards/DimensionCard";
 import DimensionEditor from "../components/editors/DimensionEditor";
 import Deck from "../components/interface/Deck";
 import Dialog from "../components/interface/Dialog";
+import groupMeta from "../utils/groupMeta";
 
 import "./DimensionBuilder.css";
 
@@ -21,11 +22,7 @@ class DimensionBuilder extends Component {
     const {meta} = this.props;
     const {isOpen} = this.state;
 
-    const groupedMeta = meta.reduce((acc, d) => {
-      if (!acc[d.ordering]) acc[d.ordering] = [];
-      acc[d.ordering].push(d);
-      return acc;
-    }, []);
+    const groupedMeta = groupMeta(meta);
 
     return (
       <Fragment>

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -44,8 +44,9 @@ class DimensionBuilder extends Component {
               Dimensions
               <Switch
                 checked={compact}
-                className={"cms-variable-editor-switcher u-font-xs cms-generator-variable-editor-switcher"}
+                className={"cms-variable-editor-switcher u-font-xxs cms-generator-variable-editor-switcher"}
                 label="Compact"
+                inline={true}
                 onChange={this.toggleCompact.bind(this)}
               />
             </span>
@@ -54,7 +55,7 @@ class DimensionBuilder extends Component {
           addItem={() => this.setState({isOpen: !this.state.isOpen})}
           cards={groupedMeta.map((group, i) =>
             <div key={`group-${i}`}>
-              {!compact ? group.map(meta => 
+              {!compact ? group.map(meta =>
                 <DimensionCard
                   key={`meta-${meta.id}`}
                   meta={meta}
@@ -68,7 +69,7 @@ class DimensionBuilder extends Component {
                 index={i}
                 limit={20}
               />
-              {!compact && <Button onClick={this.addVariant.bind(this, i)} className="cms-deck-heading-add-button" fontSize="xxs" namespace="cms" icon="plus">
+              {!compact && <Button onClick={this.addVariant.bind(this, i)} className="cms-deck-heading-add-button" fontSize="xxs" namespace="cms" icon="plus" fill={true}>
                 Add Variant
               </Button>}
             </div>

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -1,6 +1,6 @@
 import React, {Component, Fragment} from "react";
 import {connect} from "react-redux";
-
+import PreviewSearch from "../components/fields/PreviewSearch";
 import DimensionCard from "../components/cards/DimensionCard";
 import DimensionEditor from "../components/editors/DimensionEditor";
 import Deck from "../components/interface/Deck";
@@ -21,20 +21,39 @@ class DimensionBuilder extends Component {
     const {meta} = this.props;
     const {isOpen} = this.state;
 
+    const groupedMeta = meta.reduce((acc, d) => {
+      if (!acc[d.ordering]) acc[d.ordering] = [];
+      acc[d.ordering].push(d);
+      return acc;
+    }, []);
+
     return (
       <Fragment>
-        <Deck
-          title="Dimensions"
-          entity="dimension"
-          addItem={() => this.setState({isOpen: !this.state.isOpen})}
-          cards={meta.map((m, i) =>
-            <DimensionCard
-              key={`dc-${m.id}`}
-              meta={meta[i]}
-              preview={previews[i]}
-            />
-          )}
-        />
+        {
+          groupedMeta.map((group, i) => 
+            <Deck
+              key={`group-${i}`}
+              title={`Dimension ${i + 1}`}
+              entity="dimension"
+              addItem={() => this.setState({isOpen: !this.state.isOpen})}
+              cards={group.map(m =>
+                <DimensionCard
+                  key={`dc-${m.id}`}
+                  meta={m}
+                />
+              )}
+            >
+              <PreviewSearch
+                label={previews[i].name || previews[i].id || "search profiles..."}
+                previewing={previews[i].name || previews[i].id}
+                fontSize="xxs"
+                meta={group}
+                index={i}
+                limit={20}
+              />
+            </Deck>
+          )
+        }
 
         <Dialog
           className="cms-dimension-editor-dialog"

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -7,6 +7,7 @@ import Deck from "../components/interface/Deck";
 import Dialog from "../components/interface/Dialog";
 import groupMeta from "../utils/groupMeta";
 import Button from "../components/fields/Button";
+import {Switch} from "@blueprintjs/core";
 
 import "./DimensionBuilder.css";
 
@@ -15,7 +16,8 @@ class DimensionBuilder extends Component {
     super(props);
     this.state = {
       isOpen: false,
-      ordering: undefined
+      ordering: undefined,
+      compact: true
     };
   }
 
@@ -23,27 +25,41 @@ class DimensionBuilder extends Component {
     this.setState({isOpen: true, ordering});
   }
 
+  toggleCompact(e) {
+    this.setState({compact: e.target.checked});
+  }
+
   render() {
     const {previews} = this.props.status;
     const {meta} = this.props;
-    const {isOpen, ordering} = this.state;
+    const {isOpen, ordering, compact} = this.state;
 
     const groupedMeta = groupMeta(meta);
 
     return (
       <Fragment>
         <Deck
-          title="Dimensions"
+          title={
+            <span>
+              Dimensions
+              <Switch
+                checked={compact}
+                className={"cms-variable-editor-switcher u-font-xs cms-generator-variable-editor-switcher"}
+                label="Compact"
+                onChange={this.toggleCompact.bind(this)}
+              />
+            </span>
+          }
           entity="dimension"
           addItem={() => this.setState({isOpen: !this.state.isOpen})}
           cards={groupedMeta.map((group, i) =>
             <div key={`group-${i}`}>
-              {group.map(meta => 
+              {!compact ? group.map(meta => 
                 <DimensionCard
                   key={`meta-${meta.id}`}
                   meta={meta}
                 />
-              )}
+              ) : []}
               <PreviewSearch
                 label={previews[i] ? previews[i].name || previews[i].id || "search profiles..." : "search profiles..."}
                 previewing={previews[i] ? previews[i].name || previews[i].id : false}
@@ -52,9 +68,9 @@ class DimensionBuilder extends Component {
                 index={i}
                 limit={20}
               />
-              <Button onClick={this.addVariant.bind(this, i)} className="cms-deck-heading-add-button" fontSize="xxs" namespace="cms" icon="plus">
+              {!compact && <Button onClick={this.addVariant.bind(this, i)} className="cms-deck-heading-add-button" fontSize="xxs" namespace="cms" icon="plus">
                 Add Variant
-              </Button>
+              </Button>}
             </div>
           )}
         />

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -6,6 +6,7 @@ import DimensionEditor from "../components/editors/DimensionEditor";
 import Deck from "../components/interface/Deck";
 import Dialog from "../components/interface/Dialog";
 import groupMeta from "../utils/groupMeta";
+import Button from "../components/fields/Button";
 
 import "./DimensionBuilder.css";
 
@@ -17,6 +18,10 @@ class DimensionBuilder extends Component {
     };
   }
 
+  addVariant(ordering) {
+    console.log(ordering);
+  }
+
   render() {
     const {previews} = this.props.status;
     const {meta} = this.props;
@@ -26,31 +31,32 @@ class DimensionBuilder extends Component {
 
     return (
       <Fragment>
-        {
-          groupedMeta.map((group, i) => 
-            <Deck
-              key={`group-${i}`}
-              title={`Dimension ${i + 1}`}
-              entity="dimension"
-              addItem={() => this.setState({isOpen: !this.state.isOpen})}
-              cards={group.map(m =>
+        <Deck
+          title="Dimensions"
+          entity="dimension"
+          addItem={() => this.setState({isOpen: !this.state.isOpen})}
+          cards={groupedMeta.map((group, i) =>
+            <div key={`group-${i}`}>
+              {group.map((meta, j) => 
                 <DimensionCard
-                  key={`dc-${m.id}`}
-                  meta={m}
+                  key={`dc-group-${j}`}
+                  meta={meta}
                 />
               )}
-            >
               <PreviewSearch
-                label={previews[i].name || previews[i].id || "search profiles..."}
-                previewing={previews[i].name || previews[i].id}
+                label={previews[i] ? previews[i].name || previews[i].id || "search profiles..." : "search profiles..."}
+                previewing={previews[i] ? previews[i].name || previews[i].id : false}
                 fontSize="xxs"
                 group={group}
                 index={i}
                 limit={20}
               />
-            </Deck>
-          )
-        }
+              <Button onClick={this.addVariant.bind(this, i)} className="cms-deck-heading-add-button" fontSize="xxs" namespace="cms" icon="plus">
+                Add Variant
+              </Button>
+            </div>
+          )}
+        />
 
         <Dialog
           className="cms-dimension-editor-dialog"

--- a/packages/cms/src/profile/DimensionBuilder.jsx
+++ b/packages/cms/src/profile/DimensionBuilder.jsx
@@ -14,18 +14,19 @@ class DimensionBuilder extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      isOpen: false
+      isOpen: false,
+      ordering: undefined
     };
   }
 
   addVariant(ordering) {
-    console.log(ordering);
+    this.setState({isOpen: true, ordering});
   }
 
   render() {
     const {previews} = this.props.status;
     const {meta} = this.props;
-    const {isOpen} = this.state;
+    const {isOpen, ordering} = this.state;
 
     const groupedMeta = groupMeta(meta);
 
@@ -37,9 +38,9 @@ class DimensionBuilder extends Component {
           addItem={() => this.setState({isOpen: !this.state.isOpen})}
           cards={groupedMeta.map((group, i) =>
             <div key={`group-${i}`}>
-              {group.map((meta, j) => 
+              {group.map(meta => 
                 <DimensionCard
-                  key={`dc-group-${j}`}
+                  key={`meta-${meta.id}`}
                   meta={meta}
                 />
               )}
@@ -67,7 +68,8 @@ class DimensionBuilder extends Component {
           icon={false}
         >
           <DimensionEditor
-            onComplete={() => this.setState({isOpen: false})}
+            onComplete={() => this.setState({isOpen: false, ordering: undefined})}
+            ordering={ordering}
           />
         </Dialog>
       </Fragment>

--- a/packages/cms/src/utils/attify.js
+++ b/packages/cms/src/utils/attify.js
@@ -5,7 +5,7 @@ module.exports = (searchRows, locale) =>
       ...acc,
       [`id${i + 1}`]: d.id,
       [`slug${i + 1}`]: d.slug,
-      [`name${i + 1}`]: d.content.find(o => o.locale === locale) ? d.content.find(o => o.locale === locale).name : "",
+      [`name${i + 1}`]: d.content && d.content.find(o => o.locale === locale) ? d.content.find(o => o.locale === locale).name : "",
       [`dimension${i + 1}`]: d.dimension,
       [`hierarchy${i + 1}`]: d.hierarchy,
       [`cubeName${i + 1}`]: d.cubeName,
@@ -14,7 +14,7 @@ module.exports = (searchRows, locale) =>
   ), searchRows.length > 0 ? {
     id: searchRows[0].id,
     slug: searchRows[0].slug,
-    name: searchRows[0].content.find(o => o.locale === locale) ? searchRows[0].content.find(o => o.locale === locale).name : "",
+    name: searchRows[0].content && searchRows[0].content.find(o => o.locale === locale) ? searchRows[0].content.find(o => o.locale === locale).name : "",
     dimension: searchRows[0].dimension,
     hierarchy: searchRows[0].hierarchy,
     cubeName: searchRows[0].cubeName,

--- a/packages/cms/src/utils/groupMeta.js
+++ b/packages/cms/src/utils/groupMeta.js
@@ -1,0 +1,6 @@
+module.exports = meta => 
+  meta.reduce((acc, d) => {
+    if (!acc[d.ordering]) acc[d.ordering] = [];
+    acc[d.ordering].push(d);
+    return acc;
+  }, []);


### PR DESCRIPTION
Adds Variants to Dimensions, allowing for one profile to make use of several dimension variants. For example, a Subnational profile may have several geo variants (from varying cubes) that are fed through the same generators and profile text.

Does not require any database changes, however, some abstract structural changes have been made worth noting.

Profiles have a `meta` component that was a strictly ordered list of dimensions - `geo/product` for example. To accommodate variants, MULTIPLE dimensions may exist at a single index. This means that your 0th index could be a list of subnational_jpn, subnational_chn, etc. Essentially, profile_meta is now two dimensional:

```
    dimensions ------------------>
    variants
            |      0       1
            |      0       1
            V      0
```

A new method called `groupMeta` is available in `/utils` to change the flat list of meta info into a 2d grid.

Closes #956 