### PR TITLE
fixes sorting and normalizes on the fly

### DIFF
--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -269,17 +269,10 @@ module.exports = function(app) {
           order: [["zvalue", "DESC NULLS LAST"]],
           limit
         });
-        if (!results.results[dc.dimension]) results.results[dc.dimension] = [];
-        let fixedRows = rows.map(d => rowToResult(d));
-        const max = await db.search.findOne({
-          where: {dimension: dc.dimension, cubeName: dc.cubeName},
-          order: [["zvalue", "DESC NULLS LAST"]]
+        rows.forEach(row => {
+          if (!results.results[row.dimension]) results.results[row.dimension] = [];
+          results.results[row.dimension].push(rowToResult(row));
         });
-        if (max && fixedRows && fixedRows.length > 0) {
-          const maxZ = max.zvalue;
-          fixedRows = fixedRows.map(d => ({...d, confidence: d.confidence / maxZ}));
-        }
-        results.results[dc.dimension] = results.results[dc.dimension].concat(fixedRows);
       }
     }
     else {

--- a/packages/cms/src/utils/populateSearch.js
+++ b/packages/cms/src/utils/populateSearch.js
@@ -82,6 +82,10 @@ const formatter = (members, data, dimension, level) => {
   const st = d3Array.deviation(newData, d => d.zvalue);
   const average = d3Array.median(newData, d => d.zvalue);
   newData.forEach(d => d.zvalue = (d.zvalue - average) / st);
+  // Normalize z-values
+  const max = d3Array.max(newData, d => d.zvalue);
+  const min = d3Array.min(newData, d => d.zvalue);
+  newData.forEach(d => d.zvalue = (d.zvalue - min) / (max - min));
   return newData;
 };
 


### PR DESCRIPTION
closes #968 

Fixes entity sorting in the "nothing typed yet" autofill of the search panel.

Also required me to fix zvalues - we now normalize them on the fly (in this empty-search case) to avoid needing a new db column to store them.