### PR TITLE
adds profile label option

### DIFF
--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -245,8 +245,8 @@ class TextCard extends Component {
     const minDataState = this.state.minData;
 
     const entityList = ["profile", "section", "story", "storysection"];
-    const availableFields = ["id", "locale", "image", "profile_id", "allowed", "date", "ordering", "slug", "label", "type"];
-    const displaySort = ["title", "value", "subtitle", "description", "tooltip", "short"];
+    const availableFields = ["id", "locale", "image", "profile_id", "allowed", "date", "ordering", "slug", "type"];
+    const displaySort = ["title", "value", "subtitle", "description", "tooltip", "short", "label"];
 
     const primaryDisplay = Object.keys(primaryDisplayData)
       .filter(k => typeof primaryDisplayData[k] === "string" && !availableFields.includes(k))

--- a/packages/cms/src/components/interface/Navbar.jsx
+++ b/packages/cms/src/components/interface/Navbar.jsx
@@ -136,7 +136,12 @@ class Navbar extends Component {
 
   // create a title by joining dimensions together
   makeTitleFromDimensions(entity) {
-    if (entity.meta && entity.meta.length) {
+    const {localeDefault} = this.props.status;
+    const defCon = entity.content.find(c => c.locale === localeDefault);
+    if (defCon && defCon.label && defCon.label !== "New Profile Label") {
+      return stripHTML(defCon.label);
+    }
+    else if (entity.meta && entity.meta.length) {
       const groupedMeta = groupMeta(entity.meta);
       return groupedMeta.length > 0 ? groupedMeta.map(g => g[0] ? g[0].slug : "ERR_META").join(" / ") : "Unnamed";      
     }

--- a/packages/cms/src/profile/ProfileEditor.jsx
+++ b/packages/cms/src/profile/ProfileEditor.jsx
@@ -40,7 +40,7 @@ class ProfileEditor extends Component {
           cards={
             <TextCard
               minData={minData}
-              fields={["title", "subtitle"]}
+              fields={["title", "subtitle", "label"]}
               type="profile"
               hideAllowed={true}
             />


### PR DESCRIPTION
closes #972 

Makes use of the otherwise unused `label` property of a profile to give CMS users a vanity plate for a given profile (instead of the first variant's slug).