### PR TITLE
[cms] adds variable hashing as a token generator

### DIFF
--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -111,11 +111,11 @@ class ProfileRenderer extends Component {
     const {profile, selectors, setVarsLoading} = this.state;
     const {id, variables} = profile;
     const {locale, sectionID} = this.props;
+    const {params} = this.context.router;
     // Users should ONLY call setVariables in a callback - never in the main execution, as this
     // would cause an infinite loop. However, should they do so anyway, try and prevent the infinite
     // loop by checking if the vars are in there already, only updating if they are not yet set.
-    // const alreadySet = Object.keys(newVariables).every(key => variables[key] === newVariables[key]);
-    const alreadySet = false;
+    const alreadySet = Object.keys(newVariables).every(key => variables[key] === newVariables[key]);
     if (!setVarsLoading && !alreadySet) {
       this.setState({setVarsLoading: true});
       const payload = {variables: Object.assign({}, variables, newVariables)};
@@ -125,6 +125,8 @@ class ProfileRenderer extends Component {
       // If forceMats is true, this was called due to a user login. Run Materializers again.
       if (forceMats) url += "&forceMats=true";
       // Provide some uniqueness tokens so that the url for slug/id/role POSTs can be cached
+      url += `&tokenSlug=${params.slug}&tokenId=${params.id}`;
+      if (params.slug2 && params.id2) url += `&tokenSlug2=${params.slug2}&tokenId2=${params.id2}`;
       const {user, _matStatus, _genStatus, ...variablesWithoutUser} = payload.variables; // eslint-disable-line
       const hash = hashCode(JSON.stringify(variablesWithoutUser));
       url += `&token=${hash}`;
@@ -139,6 +141,7 @@ class ProfileRenderer extends Component {
     const {profile, selectors} = this.state;
     const {id, variables} = profile;
     const {locale, sectionID} = this.props;
+    const {params} = this.context.router;
 
     if (value instanceof Array && !value.length) delete selectors[name];
     else selectors[name] = value;
@@ -149,6 +152,8 @@ class ProfileRenderer extends Component {
     if (Object.keys(selectors).length > 0) url += `&${Object.entries(selectors).map(([key, val]) => `${key}=${val}`).join("&")}`;
     if (sectionID) url += `&section=${sectionID}`;
     // Provide some uniqueness tokens so that the url for slug/id/role POSTs can be cached
+    url += `&tokenSlug=${params.slug}&tokenId=${params.id}`;
+    if (params.slug2 && params.id2) url += `&tokenSlug2=${params.slug2}&tokenId2=${params.id2}`;
     const {user, _matStatus, _genStatus, ...variablesWithoutUser} = payload.variables; // eslint-disable-line
     const hash = hashCode(JSON.stringify(variablesWithoutUser));
     url += `&token=${hash}`;

--- a/packages/cms/src/utils/hashCode.js
+++ b/packages/cms/src/utils/hashCode.js
@@ -1,0 +1,12 @@
+// https://stackoverflow.com/questions/6122571/simple-non-secure-hash-function-for-javascript
+module.exports = str => {
+  if (!str || typeof str !== "string") return str;
+  let hash = 0;
+  if (str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash && hash;
+  }
+  return hash;
+}


### PR DESCRIPTION
Closes #980

Sorry for the incorrect branch name.

The goal of this PR is to add a unique token to the POST operation, such that if we need to turn on cloudflare caching, it can use a unique URL for storing the payload. Right now the POST endpoint has the URL form `/api/profile/{profile_id}`, with the variables object being the body of the POST. The problem here is that the url is not unique - it doesn't even include which page the user was looking at (e.g. Germany).

So, how can we make this URL unique, and reflect a "page state" suitable for caching?

## Considerations

#### Current Member
What page is the user currently viewing? For this we need slugs and ids. 

#### Login Status
When the user loads the page, they get the non-logged in version from the server. Once the client processes the login, we must fold in the user object and POST the variables so that variables like `isPro` are correctly set. For this we need the userRole integer (not the whole `user` object, at least not for now)

#### Selector/Dropdown status
When a user selects a dropdown, we POST the `variables` object as-is, but encode the chosen selectors into the URL. This actually needs no change - as the selectors ARE in the url and therefore make it unique, at least in the selectors' namespace.

#### `setVariables` state
This is the tricky one. We could encode the variables that the user changes as an ever-expanding diff encoded into URL params, but it is super difficult to track which variables were _already changed in the past_ without comparing to some initial state. 

## Proposal

Instead of peeling apart all these various states and encoding them in the URL, This PR does the following:

- Strip the `user` object and `_genStatus` and `_matStatus` cruft out of the variables object
- Make a hash integer from what remains of stringified Variables object 
- POST to the URL with `&token=hash`
- Keep no-op slug/id in the URL as no-ops for cloud debugging.

POST operations now look something like this:

```
/api/profile?profile=1&locale=en&tokenSlug=geo&tokenId=california-6&tokenSlug2=hai&tokenId2=vae&token=-24541158783
```

The integer hash of the variables state will contain/represent everything we need: the `userRole`, the current member/attributes, and most importantly, ANY combination of `setVariables` calls, all encoded into a single hash.  The selectors are encoded in the URL already, and we will also provide a no-op slug/id in the URL to assist in debugging cloudflare.

## Other considerations

This still means that we will be caching POST objects for every member, every drop down state, every `setVariables` state, and every userRole (not user). This means dozens of near-identical copies for the same page, which may not be feasible or affordable. But this PR doesn't consider that - it just makes them cacheable if we want to.

These hashes have no other purpose than future-proofing URL uniqueness, so merging this should have no blockers or major considerations.
