### PR TITLE
[cms] Performance improvements

### DIFF
--- a/packages/cms/api/proxy.js
+++ b/packages/cms/api/proxy.js
@@ -1,0 +1,88 @@
+const axios = require("axios"),
+      jwt = require("jsonwebtoken"),
+      url = require("url");
+
+const {
+  OLAP_PROXY_ENDPOINT,
+  OLAP_PROXY_SECRET
+} = process.env;
+
+const isRole = role => (req, res, next) => {
+  if (req.isAuthenticated()) {
+    if (req.user.role >= role) return next();
+    else {
+      res.status(401).send("user does not have sufficient privileges").end();
+      return;
+    }
+  }
+  res.status(401).send("not logged in").end();
+  return;
+};
+
+module.exports = function(app) {
+
+  app.get("/olap-proxy/*", async(req, res) => {
+
+    const params = req.params[0];
+    const baseURL = url.resolve(OLAP_PROXY_ENDPOINT, params);
+    const queryString = url.parse(req.url).query;
+    const fullURL = queryString ? `${baseURL}?${queryString}` : baseURL;
+    const {user} = req;
+
+    let apiToken = req.headers["x-tesseract-jwt-token"];
+    if (!apiToken) {
+      apiToken = jwt.sign(
+        {
+          auth_level: user ? user.role : 0,
+          sub: user ? user.id : "localhost",
+          status: "valid"
+        },
+        OLAP_PROXY_SECRET,
+        {expiresIn: "30m"}
+      );
+    }
+
+    const config = {
+      headers: {
+        "x-tesseract-jwt-token": apiToken
+      }
+    };
+
+    const data = await axios.get(fullURL, config)
+      .then(resp => resp.data)
+      .catch(error => {
+        const {response} = error;
+        const errorObject = Object.assign({}, response, {request: undefined});
+        res.status(response.status);
+        return errorObject;
+      });
+
+    res.send(data).end();
+
+  });
+
+  app.get("/auth/token", isRole(10), (req, res) => {
+
+    const token = jwt.sign(
+      {
+        auth_level: 10,
+        sub: "server",
+        status: "valid"
+      },
+      OLAP_PROXY_SECRET,
+      {expiresIn: "5y"}
+    );
+
+    const origin = `${ req.protocol }://${ req.headers.host }`;
+    const baseURL = `${origin}/olap-proxy/`;
+
+    const config = {
+      url: baseURL,
+      headers: {"x-tesseract-jwt-token": token}
+    };
+
+    res.json(config);
+
+  });
+
+};

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -240,7 +240,7 @@ export function resetPreviews() {
  */
 export function fetchVariables(config) { 
   return async function(dispatch, getStore) {    
-    dispatch({type: "VARIABLES_FETCH"});
+    dispatch({type: "VARIABLES_FETCH", data: "Generators"});
     const {previews, localeDefault, localeSecondary, currentPid} = getStore().cms.status;
     const {auth} = getStore();
 
@@ -291,6 +291,7 @@ export function fetchVariables(config) {
         const gen = await axios.post(`${getStore().env.CANON_API}/api/generators/${currentPid}?locale=${thisLocale}${paramString}`, {attributes}).catch(catcher);
         variables[thisLocale] = assign({}, variables[thisLocale], gen.data);
       }
+      dispatch({type: "VARIABLES_FETCH", data: "Materializers"});
       // Clean out stale materializers
       Object.keys(variables[thisLocale]._matStatus).forEach(mid => {
         Object.keys(variables[thisLocale]._matStatus[mid]).forEach(k => {

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -7,7 +7,7 @@ import groupMeta from "../utils/groupMeta";
 
 const catcher = e => {
   console.log(`Error in profile action: ${e}`);
-  return {};
+  return {data: {}};
 };
 
 /** */

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -315,6 +315,8 @@ module.exports = function(app) {
         config.headers = {"x-tesseract-jwt-token": apiToken};
       }
 
+      config.timeout = 3000
+
       return axios.get(url, config)
         .then(resp => {
           if (verbose) console.log("Variable Loaded:", url);

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -29,7 +29,7 @@ const LOGINS = process.env.CANON_LOGINS || false;
 const PORT = process.env.CANON_PORT || 3300;
 const NODE_ENV = process.env.NODE_ENV || "development";
 const REQUESTS_PER_SECOND = process.env.CANON_CMS_REQUESTS_PER_SECOND ? parseInt(process.env.CANON_CMS_REQUESTS_PER_SECOND, 10) : 20;
-const GENERATOR_TIMEOUT = process.env.CANON_CMS_GENERATOR_TIMEOUT ? parseInt(process.env.CANON_CMS_GENERATOR_TIMEOUT, 10) : 3000;
+const GENERATOR_TIMEOUT = process.env.CANON_CMS_GENERATOR_TIMEOUT ? parseInt(process.env.CANON_CMS_GENERATOR_TIMEOUT, 10) : 5000;
 let cubeRoot = process.env.CANON_CMS_CUBES;
 if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -29,6 +29,7 @@ const LOGINS = process.env.CANON_LOGINS || false;
 const PORT = process.env.CANON_PORT || 3300;
 const NODE_ENV = process.env.NODE_ENV || "development";
 const REQUESTS_PER_SECOND = process.env.CANON_CMS_REQUESTS_PER_SECOND ? parseInt(process.env.CANON_CMS_REQUESTS_PER_SECOND, 10) : 20;
+const GENERATOR_TIMEOUT = process.env.CANON_CMS_GENERATOR_TIMEOUT ? parseInt(process.env.CANON_CMS_GENERATOR_TIMEOUT, 10) : 3000;
 let cubeRoot = process.env.CANON_CMS_CUBES;
 if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 
@@ -315,7 +316,7 @@ module.exports = function(app) {
         config.headers = {"x-tesseract-jwt-token": apiToken};
       }
 
-      config.timeout = 3000
+      config.timeout = GENERATOR_TIMEOUT;
 
       return axios.get(url, config)
         .then(resp => {

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -73,7 +73,7 @@ class SelectorCard extends Component {
   openEditor() {
     const minData = deepClone(this.props.minData);
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: true});
+    this.props.setStatus({toolboxDialogOpen: {type: "selector", id: minData.id}});
     this.setState({minData, isOpen});
   }
 

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -125,9 +125,10 @@ class VariableCard extends Component {
   }
 
   openEditor() {
+    const {type} = this.props;
     const minData = deepClone(this.props.minData);
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: true});
+    this.props.setStatus({toolboxDialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -45,7 +45,7 @@ class VariableCard extends Component {
     if (JSON.stringify(prevProps.minData) !== JSON.stringify(this.props.minData)) {
       // If a gen/mat was saved, re-run fetchvariables for just this one gen/mat.
       if (type === "generator" || type === "materializer") {
-        const config = {type, ids: [minData.id]};
+        const config = {type, id: minData.id};
         this.props.fetchVariables(config);
       }
       // Clone the new object for manipulation in state.

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -12,6 +12,7 @@ import VariableEditor from "../editors/VariableEditor";
 import Dialog from "../interface/Dialog";
 
 import {deleteEntity, updateEntity} from "../../actions/profiles";
+import {setStatus} from "../../actions/status";
 
 import "./VisualizationCard.css";
 
@@ -54,12 +55,14 @@ class VisualizationCard extends Component {
     const {type} = this.props;
     const {minData} = this.state;
     this.props.updateEntity(type, minData);
+    this.props.setStatus({toolboxDialogOpen: false});
     this.setState({isOpen: false});
   }
 
   openEditor() {
     const minData = deepClone(this.props.minData);
     const isOpen = true;
+    this.props.setStatus({toolboxDialogOpen: {type: "visualization", id: minData.id}});
     this.setState({minData, isOpen});
   }
 
@@ -85,6 +88,7 @@ class VisualizationCard extends Component {
   }
 
   closeEditorWithoutSaving() {
+    this.props.setStatus({toolboxDialogOpen: false});
     this.setState({isOpen: false, alertObj: false, isDirty: false});
   }
 
@@ -197,7 +201,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   updateEntity: (type, payload) => dispatch(updateEntity(type, payload)),
-  deleteEntity: (type, payload) => dispatch(deleteEntity(type, payload))
+  deleteEntity: (type, payload) => dispatch(deleteEntity(type, payload)),
+  setStatus: status => dispatch(setStatus(status))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(VisualizationCard);

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -39,7 +39,7 @@ class Toolbox extends Component {
     // When a profile is loaded, save its current previews and variables (all we have is variables right now) and 
     // Responsibly reload them when changing entire profile. For now, deal with the more heavy reload 
     if (changedSinglePreview || changedEntireProfile || changedLocale) {
-      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id)});
+      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id), init: true});
     }
     // Detect Deletions
     const {justDeleted} = this.props.status;

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -125,22 +125,26 @@ class Toolbox extends Component {
     let generators = profile.generators
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(d => Object.assign({}, {type: "generator"}, d))
-      .filter(this.filterFunc.bind(this));
+      .filter(this.filterFunc.bind(this))
+      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "generator" && toolboxDialogOpen.id === d.id);
 
     if (this.props.status.profilesLoaded) generators = [attrGen].concat(generators);
 
     const materializers = profile.materializers
       .sort((a, b) => a.ordering - b.ordering)
       .map(d => Object.assign({}, {type: "materializer"}, d))
-      .filter(this.filterFunc.bind(this));
+      .filter(this.filterFunc.bind(this))
+      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "materializer" && toolboxDialogOpen.id === d.id);
 
     const formatters = formattersAll
       .sort((a, b) => a.name.localeCompare(b.name))
-      .filter(this.filterFunc.bind(this));
+      .filter(this.filterFunc.bind(this))
+      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "formatter" && toolboxDialogOpen.id === d.id);
 
     const selectors = profile.selectors
       .sort((a, b) => a.title.localeCompare(b.title))
-      .filter(this.filterFunc.bind(this));
+      .filter(this.filterFunc.bind(this))
+      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "selector" && toolboxDialogOpen.id === d.id);
 
     // If a search filter causes no results, hide the entire grouping. However, if
     // the ORIGINAL data has length 0, always show it, so the user can add the first one.

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -222,7 +222,6 @@ class Toolbox extends Component {
                   minData={g}
                   context="generator"
                   hidden={!detailView}
-                  attr={profile.attr || {}}
                   type="generator"
                   readOnly={i === 0}
                   usePortalForAlert
@@ -279,7 +278,6 @@ class Toolbox extends Component {
                   key={f.id}
                   minData={f}
                   type="formatter"
-                  variables={{}}
                   usePortalForAlert
                 />
               )}

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -39,7 +39,7 @@ class Toolbox extends Component {
     // When a profile is loaded, save its current previews and variables (all we have is variables right now) and 
     // Responsibly reload them when changing entire profile. For now, deal with the more heavy reload 
     if (changedSinglePreview || changedEntireProfile || changedLocale) {
-      this.props.fetchVariables({type: "generator", ids: this.props.profile.generators.map(g => g.id), init: true});
+      this.props.fetchVariables();
     }
     // Detect Deletions
     const {justDeleted} = this.props.status;
@@ -47,10 +47,10 @@ class Toolbox extends Component {
       // Providing fetchvariables (and ultimately, /api/variables) with a now deleted generator or materializer id
       // is handled gracefully - it prunes the provided id from the variables object and re-runs necessary gens/mats.
       if (justDeleted.type === "generator") {
-        this.props.fetchVariables({type: "generator", ids: [justDeleted.id]});
+        this.props.fetchVariables({type: "generator", id: justDeleted.id});
       }
       else if (justDeleted.type === "materializer") {
-        this.props.fetchVariables({type: "materializer", ids: [justDeleted.id]});
+        this.props.fetchVariables({type: "materializer", id: justDeleted.id});
       }
     }
   }

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -56,7 +56,7 @@ class ProfileBuilder extends Component {
     const id = pathObj.section ? Number(pathObj.section) : pathObj.profile ? Number(pathObj.profile) : null;
 
     const gensRecompiling = fetchingVariables;
-    const gensBusy = "Loading Variables...";
+    const gensBusy = `Loading ${fetchingVariables}...`;
     const gensDone = "Variables Loaded";
 
     const searchRecompiling = searchLoading;

--- a/packages/cms/src/profile/ProfileBuilder.jsx
+++ b/packages/cms/src/profile/ProfileBuilder.jsx
@@ -48,19 +48,19 @@ class ProfileBuilder extends Component {
   render() {
 
     const {toolboxVisible} = this.state;
-    const {currentPid, gensLoaded, gensTotal, genLang, pathObj, previews, profilesLoaded, searchLoading} = this.props.status;
+    const {currentPid, fetchingVariables, pathObj, previews, profilesLoaded, searchLoading} = this.props.status;
 
     const type = pathObj.section ? "section" : pathObj.profile ? "profile" : null;
     const editorTypes = {profile: ProfileEditor, section: SectionEditor};
     const Editor = editorTypes[type];
     const id = pathObj.section ? Number(pathObj.section) : pathObj.profile ? Number(pathObj.profile) : null;
 
-    const gensRecompiling = gensLoaded !== gensTotal;
-    const gensBusy = `${gensLoaded} of ${gensTotal} Generators Loaded (${genLang})`;
+    const gensRecompiling = fetchingVariables;
+    const gensBusy = "Loading Variables...";
     const gensDone = "Variables Loaded";
 
     const searchRecompiling = searchLoading;
-    const searchBusy = "Loading search members…";
+    const searchBusy = "Loading search members...";
     const searchDone = "Members loaded";
 
     if (!profilesLoaded) return null;

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -81,7 +81,7 @@ export default (status = {}, action) => {
     case "FORMATTER_DELETE": 
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
     case "VARIABLES_FETCH":
-      return Object.assign({}, status, {fetchingVariables: true});
+      return Object.assign({}, status, {fetchingVariables: action.data});
     case "VARIABLES_FETCHED":
       return Object.assign({}, status, {fetchingVariables: false});
     // Updating variables or saving a section or meta means that anything that depends on variables, such as TextCards 


### PR DESCRIPTION
Made a few changes to try to speed things up in the CMS.

- On initial load, changed from piecemeal generator gets to a full server-side promise.all fetch. Loses granularity of "26 of 53" type progress bar, but is much faster.
- Only updates redux variables once - when all have loaded.
- Adopts a "fail fast" strategy; adds a configurable generator timeout, `CANON_CMS_GENERATOR_TIMEOUT`, which defaults to 5000ms. This may need to be set higher for OEC, but it's important that this is configurable
- Dynamically hides toolbox elements underneath modals. This means modals take slightly longer to open and close, but once they are open, typing inside them is much nicer.

I've learned that updating redux is... chunkier than I'd like. I plan to continue to investigate ways to speed up the cms, especially concerning the large variables object inside the redux store.