### PR TITLE
Issue 901 error catches

### DIFF
--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -113,7 +113,7 @@ export function updateEntity(type, payload) {
     const diffCounter = getStore().cms.status.diffCounter + 1;
     // Formatters require locales in the payload to know what languages to compile for
     const locales = getLocales(getStore().env);
-    return axios.post(`${getStore().env.CANON_API}/apix/cms/${type}/update`, payload)
+    return axios.post(`${getStore().env.CANON_API}/api/cms/${type}/update`, payload)
       .then(resp => {
         if (resp.status === 200) {
           dispatch({type: `${type.toUpperCase()}_UPDATE`, data: resp.data, diffCounter, locales});

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -103,13 +103,21 @@ export function newEntity(type, payload) {
 /** */
 export function updateEntity(type, payload) { 
   return function(dispatch, getStore) {
+    dispatch({type: "CLEAR_UPDATED"});
     // Updates might need to trigger re-running certain displays. Use diffCounter to track changes
     const diffCounter = getStore().cms.status.diffCounter + 1;
     // Formatters require locales in the payload to know what languages to compile for
     const locales = getLocales(getStore().env);
-    return axios.post(`${getStore().env.CANON_API}/api/cms/${type}/update`, payload)
-      .then(({data}) => {
-        dispatch({type: `${type.toUpperCase()}_UPDATE`, data, diffCounter, locales});
+    return axios.post(`${getStore().env.CANON_API}/apix/cms/${type}/update`, payload)
+      .then(resp => {
+        if (resp.status === 200) {
+          dispatch({type: `${type.toUpperCase()}_UPDATE`, data: resp.data, diffCounter, locales});
+        }
+        else {
+          dispatch({type: `${type.toUpperCase()}_ERROR`, data: {id: payload.id}});
+        }
+      }).catch(() => {
+        dispatch({type: `${type.toUpperCase()}_ERROR`, data: {id: payload.id}});
       });
   };
 }

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -522,7 +522,7 @@ module.exports = function(app) {
       // Formatters are a special update case - return the whole list on update (necessary for recompiling them)
       if (ref === "formatter") {
         const rows = await db.formatter.findAll().catch(catcher);
-        return res.json(rows);
+        return res.json({id, formatters: rows});
       }
       else {
         if (contentTables.includes(ref)) {

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -36,7 +36,7 @@ class SelectorCard extends Component {
     const {dialogOpen} = this.props.status;
     const {minData, type} = this.props;
     this.setState({minData: deepClone(this.props.minData)});
-    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.force && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -58,7 +58,7 @@ class SelectorCard extends Component {
       }
     }
 
-    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen && this.props.status.dialogOpen.force;
     const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === id;
     if (thisOpened) {
       this.openEditor.bind(this)();

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 
 import deepClone from "../../utils/deepClone";
 
+import {Intent} from "@blueprintjs/core";
+
 import Card from "./Card";
 import Dialog from "../interface/Dialog";
 import SelectorEditor from "../editors/SelectorEditor";
@@ -37,10 +39,21 @@ class SelectorCard extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    // If the props we receive from redux have changed, then an update action has occured.
-    if (JSON.stringify(prevProps.minData) !== JSON.stringify(this.props.minData)) {
-      // Clone the new object for manipulation in state.
-      this.setState({minData: deepClone(this.props.minData)});
+    const type = "selector";
+
+    const didUpdate = this.props.status.justUpdated && this.props.status.justUpdated.type === type && this.props.status.justUpdated.id === this.props.minData.id && JSON.stringify(this.props.status.justUpdated) !== JSON.stringify(prevProps.status.justUpdated);
+    if (didUpdate) {
+      const Toast = this.context.toast.current;
+      const {status} = this.props.status.justUpdated;
+      if (status === "SUCCESS") {
+        Toast.show({icon: "saved", intent: Intent.SUCCESS, message: "Saved!", timeout: 1000});
+        // Clone the new object for manipulation in state.
+        this.setState({isOpen: false, minData: deepClone(this.props.minData)});
+      }
+      else if (status === "ERROR") {
+        Toast.show({icon: "error", intent: Intent.DANGER, message: "Error: Not Saved!", timeout: 3000});
+        // Don't close window
+      }
     }
   }
 
@@ -51,8 +64,8 @@ class SelectorCard extends Component {
 
   save() {
     const {minData} = this.state;
+    // note: isOpen will close on update success (see componentDidUpdate)
     this.props.updateEntity("selector", minData);
-    this.setState({isOpen: false});
   }
 
   maybeDelete() {
@@ -196,7 +209,8 @@ class SelectorCard extends Component {
 }
 
 SelectorCard.contextTypes = {
-  formatters: PropTypes.object
+  formatters: PropTypes.object,
+  toast: PropTypes.object
 };
 
 const mapStateToProps = state => ({

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -33,13 +33,15 @@ class SelectorCard extends Component {
   }
 
   componentDidMount() {
-    const {forceType, forceID} = this.props.status;
+    const {forceOpen} = this.props.status;
+    const {minData, type} = this.props;
     this.setState({minData: deepClone(this.props.minData)});
-    if (forceType === "selector" && forceID === this.props.minData.id) this.openEditor.bind(this)();
+    if (forceOpen && forceOpen.type === type && forceOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
-    const type = "selector";
+    const {type} = this.props;
+    const {id} = this.props.minData;
 
     const didUpdate = this.props.status.justUpdated && this.props.status.justUpdated.type === type && this.props.status.justUpdated.id === this.props.minData.id && JSON.stringify(this.props.status.justUpdated) !== JSON.stringify(prevProps.status.justUpdated);
     if (didUpdate) {
@@ -55,6 +57,12 @@ class SelectorCard extends Component {
         // Don't close window
       }
     }
+
+    const somethingOpened = !prevProps.status.forceOpen && this.props.status.forceOpen;
+    const thisOpened = somethingOpened && this.props.status.forceOpen.type === type && this.props.status.forceOpen.id === id;
+    if (thisOpened) {
+      this.openEditor.bind(this)();
+    }
   }
 
   markAsDirty() {
@@ -64,8 +72,9 @@ class SelectorCard extends Component {
 
   save() {
     const {minData} = this.state;
+    const {type} = this.props;
     // note: isOpen will close on update success (see componentDidUpdate)
-    this.props.updateEntity("selector", minData);
+    this.props.updateEntity(type, minData);
   }
 
   maybeDelete() {
@@ -80,13 +89,15 @@ class SelectorCard extends Component {
 
   delete() {
     const {id} = this.props.minData;
-    this.props.deleteEntity("selector", {id});
+    const {type} = this.props;
+    this.props.deleteEntity(type, {id});
   }
 
   openEditor() {
+    const {type} = this.props;
     const minData = deepClone(this.props.minData);
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: {type: "selector", id: minData.id}});
+    this.props.setStatus({toolboxDialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 
@@ -207,6 +218,10 @@ class SelectorCard extends Component {
     );
   }
 }
+
+SelectorCard.defaultProps = {
+  type: "selector"
+};
 
 SelectorCard.contextTypes = {
   formatters: PropTypes.object,

--- a/packages/cms/src/components/cards/SelectorCard.jsx
+++ b/packages/cms/src/components/cards/SelectorCard.jsx
@@ -33,10 +33,10 @@ class SelectorCard extends Component {
   }
 
   componentDidMount() {
-    const {forceOpen} = this.props.status;
+    const {dialogOpen} = this.props.status;
     const {minData, type} = this.props;
     this.setState({minData: deepClone(this.props.minData)});
-    if (forceOpen && forceOpen.type === type && forceOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -58,8 +58,8 @@ class SelectorCard extends Component {
       }
     }
 
-    const somethingOpened = !prevProps.status.forceOpen && this.props.status.forceOpen;
-    const thisOpened = somethingOpened && this.props.status.forceOpen.type === type && this.props.status.forceOpen.id === id;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === id;
     if (thisOpened) {
       this.openEditor.bind(this)();
     }
@@ -97,7 +97,7 @@ class SelectorCard extends Component {
     const {type} = this.props;
     const minData = deepClone(this.props.minData);
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: {type, id: minData.id}});
+    this.props.setStatus({dialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 
@@ -119,7 +119,7 @@ class SelectorCard extends Component {
 
   closeEditorWithoutSaving() {
     this.setState({isOpen: false, alertObj: false, isDirty: false});
-    this.props.setStatus({toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+    this.props.setStatus({dialogOpen: false});
   }
 
   render() {

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -43,15 +43,11 @@ class TextCard extends Component {
 
   componentDidUpdate(prevProps) {
     const {type} = this.props;
-    const contentChanged = prevProps.minData.id !== this.props.minData.id || JSON.stringify(prevProps.minData.content) !== JSON.stringify(this.props.minData.content);
     const variablesChanged = prevProps.status.diffCounter !== this.props.status.diffCounter;
     const selectorsChanged = JSON.stringify(this.props.selectors) !== JSON.stringify(prevProps.selectors);
     const queryChanged = JSON.stringify(this.props.status.query) !== JSON.stringify(prevProps.status.query);
     const didUpdate = this.props.status.justUpdated && this.props.status.justUpdated.type === type && this.props.status.justUpdated.id === this.props.minData.id && JSON.stringify(this.props.status.justUpdated) !== JSON.stringify(prevProps.status.justUpdated);
 
-    if (contentChanged) {
-      this.setState({minData: deepClone(this.props.minData)}, this.formatDisplay.bind(this));
-    }
     if (variablesChanged || selectorsChanged || queryChanged) {
       this.formatDisplay.bind(this)();
     }
@@ -61,7 +57,7 @@ class TextCard extends Component {
       const {status} = this.props.status.justUpdated;
       if (status === "SUCCESS") {
         Toast.show({icon: "saved", intent: Intent.SUCCESS, message: "Saved!", timeout: 1000});
-        this.setState({isOpen: false, isDirty: false});
+        this.setState({isOpen: false, isDirty: false, minData: deepClone(this.props.minData)}, this.formatDisplay.bind(this));
       }
       else if (status === "ERROR") {
         Toast.show({icon: "error", intent: Intent.DANGER, message: "Error: Not Saved!", timeout: 3000});

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -225,8 +225,10 @@ class TextCard extends Component {
   }
 
   openEditor() {
+    const {type} = this.props;
     const minData = this.populateLanguageContent.bind(this)(deepClone(this.props.minData));
     const isOpen = true;
+    this.props.setStatus({toolboxDialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -59,14 +59,13 @@ class TextCard extends Component {
     if (didUpdate) {
       const Toast = this.context.toast.current;
       const {status} = this.props.status.justUpdated;
-      console.log(status);
       if (status === "SUCCESS") {
         Toast.show({icon: "saved", intent: Intent.SUCCESS, message: "Saved!", timeout: 1000});
         this.setState({isOpen: false, isDirty: false});
       }
       else if (status === "ERROR") {
         Toast.show({icon: "error", intent: Intent.DANGER, message: "Error: Not Saved!", timeout: 3000});
-        // don't close window
+        // Don't close window
       }
     }
   }

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -39,10 +39,10 @@ class TextCard extends Component {
   }
 
   componentDidMount() {
-    const {forceOpen} = this.props.status;
+    const {dialogOpen} = this.props.status;
     const {minData, type} = this.props;
     this.setState({minData: deepClone(minData)}, this.formatDisplay.bind(this));
-    if (forceOpen && forceOpen.type === type && forceOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -74,8 +74,8 @@ class TextCard extends Component {
       }
     }
 
-    const somethingOpened = !prevProps.status.forceOpen && this.props.status.forceOpen;
-    const thisOpened = somethingOpened && this.props.status.forceOpen.type === type && this.props.status.forceOpen.id === this.props.minData.id;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === this.props.minData.id;
     if (thisOpened) {
       this.openEditor.bind(this)();
     }
@@ -228,7 +228,7 @@ class TextCard extends Component {
     const {type} = this.props;
     const minData = this.populateLanguageContent.bind(this)(deepClone(this.props.minData));
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: {type, id: minData.id}});
+    this.props.setStatus({dialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 
@@ -250,7 +250,7 @@ class TextCard extends Component {
 
   closeEditorWithoutSaving() {
     this.setState({isOpen: false, alertObj: false, isDirty: false});
-    this.props.setStatus({forceOpen: false, toolboxDialogOpen: false});
+    this.props.setStatus({dialogOpen: false});
   }
 
   prettifyType(type) {

--- a/packages/cms/src/components/cards/TextCard.jsx
+++ b/packages/cms/src/components/cards/TextCard.jsx
@@ -42,7 +42,7 @@ class TextCard extends Component {
     const {dialogOpen} = this.props.status;
     const {minData, type} = this.props;
     this.setState({minData: deepClone(minData)}, this.formatDisplay.bind(this));
-    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.force && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -74,7 +74,7 @@ class TextCard extends Component {
       }
     }
 
-    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen && this.props.status.dialogOpen.force;
     const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === this.props.minData.id;
     if (thisOpened) {
       this.openEditor.bind(this)();

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -51,7 +51,6 @@ class VariableCard extends Component {
         Toast.show({icon: "saved", intent: Intent.SUCCESS, message: "Saved!", timeout: 1000});
         // If a gen/mat was saved, re-run fetchvariables for just this one gen/mat.
         if (type === "generator" || type === "materializer") {
-          console.log(prevProps.minData, this.props.minData);
           const config = {type, id: minData.id};
           this.props.fetchVariables(config);
         }

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -33,10 +33,10 @@ class VariableCard extends Component {
 
   componentDidMount() {
     const {minData, type} = this.props;
-    const {forceType, forceID} = this.props.status;
+    const {forceOpen} = this.props.status;
     this.setState({minData: deepClone(minData)});
     this.formatDisplay.bind(this)();
-    if (forceType === type && forceID === minData.id) this.openEditor.bind(this)();
+    if (forceOpen && forceOpen.type === type && forceOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -63,7 +63,6 @@ class VariableCard extends Component {
       }
     }
 
-
     // If diffCounter incremented, it means a variables update completed, either from this card saving,
     // or from ANOTHER card saving. If it was this card, we need to update the front panel, if it was another card,
     // we may need to update whether this card contains a duplicate. Either way, format the display.
@@ -72,7 +71,9 @@ class VariableCard extends Component {
       if (variablesChanged) this.formatDisplay.bind(this)();
     }
 
-    if (this.props.status.forceType === type && !prevProps.status.forceID && this.props.status.forceID === id) {
+    const somethingOpened = !prevProps.status.forceOpen && this.props.status.forceOpen;
+    const thisOpened = somethingOpened && this.props.status.forceOpen.type === type && this.props.status.forceOpen.id === id;
+    if (thisOpened) {
       this.openEditor.bind(this)();
     }
   }
@@ -163,7 +164,7 @@ class VariableCard extends Component {
 
   closeEditorWithoutSaving() {
     this.setState({isOpen: false, alertObj: false, isDirty: false});
-    this.props.setStatus({toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+    this.props.setStatus({toolboxDialogOpen: false, forceOpen: false});
   }
 
   markAsDirty() {

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -33,10 +33,10 @@ class VariableCard extends Component {
 
   componentDidMount() {
     const {minData, type} = this.props;
-    const {forceOpen} = this.props.status;
+    const {dialogOpen} = this.props.status;
     this.setState({minData: deepClone(minData)});
     this.formatDisplay.bind(this)();
-    if (forceOpen && forceOpen.type === type && forceOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -44,7 +44,7 @@ class VariableCard extends Component {
     const {id} = minData;
 
     const didUpdate = this.props.status.justUpdated && this.props.status.justUpdated.type === type && this.props.status.justUpdated.id === this.props.minData.id && JSON.stringify(this.props.status.justUpdated) !== JSON.stringify(prevProps.status.justUpdated);
-    if (didUpdate) {
+    if (didUpdate) {      
       const Toast = this.context.toast.current;
       const {status} = this.props.status.justUpdated;
       if (status === "SUCCESS") {
@@ -71,8 +71,8 @@ class VariableCard extends Component {
       if (variablesChanged) this.formatDisplay.bind(this)();
     }
 
-    const somethingOpened = !prevProps.status.forceOpen && this.props.status.forceOpen;
-    const thisOpened = somethingOpened && this.props.status.forceOpen.type === type && this.props.status.forceOpen.id === id;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === id;
     if (thisOpened) {
       this.openEditor.bind(this)();
     }
@@ -142,7 +142,7 @@ class VariableCard extends Component {
     const {type} = this.props;
     const minData = deepClone(this.props.minData);
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: {type, id: minData.id}});
+    this.props.setStatus({dialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 
@@ -164,7 +164,7 @@ class VariableCard extends Component {
 
   closeEditorWithoutSaving() {
     this.setState({isOpen: false, alertObj: false, isDirty: false});
-    this.props.setStatus({toolboxDialogOpen: false, forceOpen: false});
+    this.props.setStatus({dialogOpen: false});
   }
 
   markAsDirty() {

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -36,7 +36,7 @@ class VariableCard extends Component {
     const {dialogOpen} = this.props.status;
     this.setState({minData: deepClone(minData)});
     this.formatDisplay.bind(this)();
-    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.force && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -71,7 +71,7 @@ class VariableCard extends Component {
       if (variablesChanged) this.formatDisplay.bind(this)();
     }
 
-    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen && this.props.status.dialogOpen.force;
     const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === id;
     if (thisOpened) {
       this.openEditor.bind(this)();

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -32,7 +32,7 @@ class VisualizationCard extends Component {
     const {dialogOpen} = this.props.status;
     const {minData, type} = this.props;
     this.setState({minData: deepClone(minData)});
-    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
+    if (dialogOpen && dialogOpen.force && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -54,7 +54,7 @@ class VisualizationCard extends Component {
       }
     }
 
-    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen && this.props.status.dialogOpen.force;
     const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === this.props.minData.id;
     if (thisOpened) {
       this.openEditor.bind(this)();

--- a/packages/cms/src/components/cards/VisualizationCard.jsx
+++ b/packages/cms/src/components/cards/VisualizationCard.jsx
@@ -29,8 +29,10 @@ class VisualizationCard extends Component {
   }
 
   componentDidMount() {
-    const {minData} = this.props;
+    const {dialogOpen} = this.props.status;
+    const {minData, type} = this.props;
     this.setState({minData: deepClone(minData)});
+    if (dialogOpen && dialogOpen.type === type && dialogOpen.id === minData.id) this.openEditor.bind(this)();
   }
 
   componentDidUpdate(prevProps) {
@@ -44,12 +46,18 @@ class VisualizationCard extends Component {
         Toast.show({icon: "saved", intent: Intent.SUCCESS, message: "Saved!", timeout: 1000});
         // Clone the new object for manipulation in state.
         this.setState({isOpen: false, minData: deepClone(this.props.minData)});
-        this.props.setStatus({toolboxDialogOpen: false});
+        this.props.setStatus({dialogOpen: false});
       }
       else if (status === "ERROR") {
         Toast.show({icon: "error", intent: Intent.DANGER, message: "Error: Not Saved!", timeout: 3000});
         // Don't close window
       }
+    }
+
+    const somethingOpened = !prevProps.status.dialogOpen && this.props.status.dialogOpen;
+    const thisOpened = somethingOpened && this.props.status.dialogOpen.type === type && this.props.status.dialogOpen.id === this.props.minData.id;
+    if (thisOpened) {
+      this.openEditor.bind(this)();
     }
   }
 
@@ -75,9 +83,10 @@ class VisualizationCard extends Component {
   }
 
   openEditor() {
+    const {type} = this.props;
     const minData = deepClone(this.props.minData);
     const isOpen = true;
-    this.props.setStatus({toolboxDialogOpen: {type: "visualization", id: minData.id}});
+    this.props.setStatus({dialogOpen: {type, id: minData.id}});
     this.setState({minData, isOpen});
   }
 
@@ -103,7 +112,7 @@ class VisualizationCard extends Component {
   }
 
   closeEditorWithoutSaving() {
-    this.props.setStatus({toolboxDialogOpen: false});
+    this.props.setStatus({dialogOpen: false});
     this.setState({isOpen: false, alertObj: false, isDirty: false});
   }
 

--- a/packages/cms/src/components/interface/Dialog.css
+++ b/packages/cms/src/components/interface/Dialog.css
@@ -1,5 +1,10 @@
 @import "../../css/mixins.css";
 
+/* this is bad */
+.bp3-toast-container {
+  z-index: 150 !important;
+}
+
 .cms-dialog.is-modal,
 .cms-dialog .cms-dialog-overlay {
   @mixin absolute-expand;

--- a/packages/cms/src/components/interface/Dialog.css
+++ b/packages/cms/src/components/interface/Dialog.css
@@ -1,6 +1,7 @@
 @import "../../css/mixins.css";
 
-/* this is bad */
+/* Overrides the z-index of toast so it can be seen over the Dialog shade
+ * This should be more responsibly nested */
 .bp3-toast-container {
   z-index: 150 !important;
 }

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -72,10 +72,10 @@ class Toolbox extends Component {
 
   filterFunc(d) {
     const {query} = this.state;
-    const {forceOpen} = this.props.status;
+    const {dialogOpen} = this.props.status;
     const fields = ["name", "description", "title"];
     const matched = fields.map(f => d[f] !== undefined ? d[f].toLowerCase().includes(query) : false).some(d => d);
-    const opened = forceOpen && d.type === forceOpen.type && d.id === forceOpen.id;
+    const opened = dialogOpen && d.type === dialogOpen.type && d.id === dialogOpen.id;
     return matched || opened;
   }
 
@@ -87,14 +87,14 @@ class Toolbox extends Component {
     const gens = Object.keys(vars._genStatus);
     gens.forEach(id => {
       if (vars._genStatus[id][key]) {
-        this.props.setStatus({forceOpen: {type: "generator", id: Number(id)}});
+        this.props.setStatus({dialogOpen: {type: "generator", id: Number(id)}});
       }
     });
 
     const mats = Object.keys(vars._matStatus);
     mats.forEach(id => {
       if (vars._matStatus[id][key]) {
-        this.props.setStatus({forceOpen: {type: "materializer", id: Number(id)}});
+        this.props.setStatus({dialogOpen: {type: "materializer", id: Number(id)}});
       }
     });
   }
@@ -104,7 +104,7 @@ class Toolbox extends Component {
     const {children, toolboxVisible} = this.props;
     const {profile} = this.props;
     const formattersAll = this.props.formatters;
-    const {variables, localeDefault, localeSecondary, forceOpen, toolboxDialogOpen} = this.props.status;
+    const {variables, localeDefault, localeSecondary, dialogOpen} = this.props.status;
 
     const dataLoaded = profile;
 
@@ -126,7 +126,7 @@ class Toolbox extends Component {
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(d => Object.assign({}, {type: "generator"}, d))
       .filter(this.filterFunc.bind(this))
-      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "generator" && toolboxDialogOpen.id === d.id);
+      .filter(d => !dialogOpen || dialogOpen.type === "generator" && dialogOpen.id === d.id);
 
     if (this.props.status.profilesLoaded) generators = [attrGen].concat(generators);
 
@@ -134,17 +134,17 @@ class Toolbox extends Component {
       .sort((a, b) => a.ordering - b.ordering)
       .map(d => Object.assign({}, {type: "materializer"}, d))
       .filter(this.filterFunc.bind(this))
-      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "materializer" && toolboxDialogOpen.id === d.id);
+      .filter(d => !dialogOpen || dialogOpen.type === "materializer" && dialogOpen.id === d.id);
 
     const formatters = formattersAll
       .sort((a, b) => a.name.localeCompare(b.name))
       .filter(this.filterFunc.bind(this))
-      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "formatter" && toolboxDialogOpen.id === d.id);
+      .filter(d => !dialogOpen || dialogOpen.type === "formatter" && dialogOpen.id === d.id);
 
     const selectors = profile.selectors
       .sort((a, b) => a.title.localeCompare(b.title))
       .filter(this.filterFunc.bind(this))
-      .filter(d => !toolboxDialogOpen || toolboxDialogOpen.type === "selector" && toolboxDialogOpen.id === d.id);
+      .filter(d => !dialogOpen || dialogOpen.type === "selector" && dialogOpen.id === d.id);
 
     // If a search filter causes no results, hide the entire grouping. However, if
     // the ORIGINAL data has length 0, always show it, so the user can add the first one.
@@ -155,7 +155,7 @@ class Toolbox extends Component {
 
 
     return (
-      <aside className={`cms-toolbox ${toolboxVisible ? "is-visible" : "is-hidden"}${toolboxDialogOpen ? " has-open-dialog" : ""}`}>
+      <aside className={`cms-toolbox ${toolboxVisible ? "is-visible" : "is-hidden"}${dialogOpen ? " has-open-dialog" : ""}`}>
 
         {children} {/* the toggle toolbox button */}
 
@@ -209,12 +209,12 @@ class Toolbox extends Component {
           </ul>
         }
 
-        {/* Hide the panels if not detailView - but SHOW them if forceOpen is set, which means
+        {/* Hide the panels if not detailView - but SHOW them if dialogOpen is set, which means
           * that someone has clicked an individual variable and wants to view its editor
           */}
-        <div className={`cms-toolbox-deck-wrapper${detailView || forceOpen ? "" : " is-hidden"}`}>
+        <div className={`cms-toolbox-deck-wrapper${detailView || dialogOpen ? "" : " is-hidden"}`}>
 
-          {(showGenerators || forceOpen) &&
+          {(showGenerators || dialogOpen) &&
             <Deck
               title="Generators"
               entity="generator"
@@ -234,7 +234,7 @@ class Toolbox extends Component {
             />
           }
 
-          {(showMaterializers || forceOpen) &&
+          {(showMaterializers || dialogOpen) &&
             <Deck
               title="Materializers"
               entity="materializer"

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -87,14 +87,14 @@ class Toolbox extends Component {
     const gens = Object.keys(vars._genStatus);
     gens.forEach(id => {
       if (vars._genStatus[id][key]) {
-        this.props.setStatus({dialogOpen: {type: "generator", id: Number(id)}});
+        this.props.setStatus({dialogOpen: {type: "generator", id: Number(id), force: true}});
       }
     });
 
     const mats = Object.keys(vars._matStatus);
     mats.forEach(id => {
       if (vars._matStatus[id][key]) {
-        this.props.setStatus({dialogOpen: {type: "materializer", id: Number(id)}});
+        this.props.setStatus({dialogOpen: {type: "materializer", id: Number(id), force: true}});
       }
     });
   }

--- a/packages/cms/src/components/interface/Toolbox.jsx
+++ b/packages/cms/src/components/interface/Toolbox.jsx
@@ -72,10 +72,10 @@ class Toolbox extends Component {
 
   filterFunc(d) {
     const {query} = this.state;
-    const {forceOpen, forceID, forceType} = this.props.status;
+    const {forceOpen} = this.props.status;
     const fields = ["name", "description", "title"];
     const matched = fields.map(f => d[f] !== undefined ? d[f].toLowerCase().includes(query) : false).some(d => d);
-    const opened = d.type === forceType && d.id === forceID && forceOpen;
+    const opened = forceOpen && d.type === forceOpen.type && d.id === forceOpen.id;
     return matched || opened;
   }
 
@@ -87,14 +87,14 @@ class Toolbox extends Component {
     const gens = Object.keys(vars._genStatus);
     gens.forEach(id => {
       if (vars._genStatus[id][key]) {
-        this.props.setStatus({forceID: Number(id), forceType: "generator", forceOpen: true});
+        this.props.setStatus({forceOpen: {type: "generator", id: Number(id)}});
       }
     });
 
     const mats = Object.keys(vars._matStatus);
     mats.forEach(id => {
       if (vars._matStatus[id][key]) {
-        this.props.setStatus({forceID: Number(id), forceType: "materializer", forceOpen: true});
+        this.props.setStatus({forceOpen: {type: "materializer", id: Number(id)}});
       }
     });
   }

--- a/packages/cms/src/reducers/formatters.js
+++ b/packages/cms/src/reducers/formatters.js
@@ -5,7 +5,7 @@ export default (formatters = [], action) => {
     case "FORMATTER_NEW":
       return formatters.concat([action.data]);
     case "FORMATTER_UPDATE":
-      return action.data;
+      return action.data.formatters;
     case "FORMATTER_DELETE":
       return action.data;
     default: return formatters;

--- a/packages/cms/src/reducers/resources.js
+++ b/packages/cms/src/reducers/resources.js
@@ -14,7 +14,7 @@ export default (resources = {}, action) => {
       return Object.assign({}, resources, {formatterFunctions});
     case "FORMATTER_UPDATE": 
       action.locales.forEach(locale => {
-        formatterFunctions[locale] = funcifyFormatterByLocale(action.data, locale);
+        formatterFunctions[locale] = funcifyFormatterByLocale(action.data.formatters, locale);
       });
       return Object.assign({}, resources, {formatterFunctions});
     case "FORMATTER_DELETE": 

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -34,6 +34,10 @@ const extractVariables = (obj, variablesUsed = []) => {
 */
 
 export default (status = {}, action) => {
+  
+  const success = {id: action.data.id, status: "SUCCESS"};
+  const error = {id: action.data.id, status: "ERROR"};
+  
   switch (action.type) {
     // Basic assign
     case "STATUS_SET": 
@@ -62,22 +66,22 @@ export default (status = {}, action) => {
     case "GENERATOR_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "generator", forceOpen: true});
     case "GENERATOR_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, justUpdated: {type: "generator", ...success}});
     case "MATERIALIZER_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "materializer", forceOpen: true});
     case "MATERIALIZER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, justUpdated: {type: "materializer", ...success}});
     case "SELECTOR_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "selector", forceOpen: true});
     case "SELECTOR_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, justUpdated: {type: "selector", ...success}});
     case "SELECTOR_DELETE": 
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
     case "FORMATTER_NEW": 
       return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "formatter", forceOpen: true});
     // Updating a formatter means that some formatter logic changed. Bump the diffcounter.
     case "FORMATTER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter, justUpdated: {type: "formatter", ...success}});
     case "FORMATTER_DELETE": 
       return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
     case "VARIABLES_FETCH":
@@ -93,7 +97,7 @@ export default (status = {}, action) => {
       return Object.assign({}, status, newStatus);
     // Updating sections could mean the title was updated. Bump a "diffcounter" that the Navbar tree can listen for to jigger a render
     case "SECTION_UPDATE": 
-      return Object.assign({}, status, {diffCounter: action.diffCounter});
+      return Object.assign({}, status, {diffCounter: action.diffCounter, justUpdated: {type: "section", ...success}});
     // When the user adds a new dimension, set a status that we are waiting for members to finish populating
     case "SEARCH_LOADING": 
       return Object.assign({}, status, {searchLoading: true});
@@ -132,10 +136,37 @@ export default (status = {}, action) => {
     // This is to ensure that subsequent error messages freshly fire, even if they are the "same" error
     case "CLEAR_UPDATED": 
       return Object.assign({}, status, {justUpdated: false});
+    // Note: some of the update events occur above
+    case "PROFILE_UPDATE":
+      return Object.assign({}, status, {justUpdated: {type: "profile", ...success}});
+    case "PROFILE_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "profile", ...error}});
+    case "SECTION_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "section", ...error}});
+    case "GENERATOR_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "generator", ...error}});
+    case "MATERIALIZER_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "materializer", ...error}});
+    case "FORMATTER_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "formatter", ...error}});
+    case "SELECTOR_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "selector", ...error}});
     case "SECTION_SUBTITLE_UPDATE":
-      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", id: action.data.id, status: "SUCCESS"}});
+      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", ...success}});
     case "SECTION_SUBTITLE_ERROR":
-      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", id: action.data.id, status: "ERROR"}});
+      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", ...error}});
+    case "SECTION_STAT_UPDATE":
+      return Object.assign({}, status, {justUpdated: {type: "section_stat", ...success}});
+    case "SECTION_STAT_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "section_stat", ...error}});
+    case "SECTION_DESCRIPTION_UPDATE":
+      return Object.assign({}, status, {justUpdated: {type: "section_description", ...success}});
+    case "SECTION_DESCRIPTION_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "section_description", ...error}});
+    case "SECTION_VISUALIZATION_UPDATE":
+      return Object.assign({}, status, {justUpdated: {type: "section_visualization", ...success}});
+    case "SECTION_VISUALIZATION_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "section_visualization", ...error}});
     default: return status;
   }
 };

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -131,6 +131,15 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {fetchingSectionPreview: true});
     case "SECTION_PREVIEW_SET":
       return Object.assign({}, status, {sectionPreview: action.data, fetchingSectionPreview: false});
+    // Auto-open Text Cards
+    case "SECTION_SUBTITLE_NEW":
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_subtitle", id: action.data.id}, forceOpen: {type: "section_subtitle", id: action.data.id}});
+    case "SECTION_STAT_NEW":
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_stat", id: action.data.id}, forceOpen: {type: "section_stat", id: action.data.id}});
+    case "SECTION_DESCRIPTION_NEW":
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_description", id: action.data.id}, forceOpen: {type: "section_description", id: action.data.id}});
+    case "SECTION_VISUALIZATION_NEW":
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_visualization", id: action.data.id}, forceOpen: {type: "section_visualization", id: action.data.id}});
     // Update Events
     // When an update attempt starts, clear the justUpdated variable, which will then be refilled with SUCCESS or ERROR.
     // This is to ensure that subsequent error messages freshly fire, even if they are the "same" error
@@ -152,19 +161,19 @@ export default (status = {}, action) => {
     case "SELECTOR_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "selector", ...error}});
     case "SECTION_SUBTITLE_UPDATE":
-      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_subtitle", ...success}});
     case "SECTION_SUBTITLE_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_subtitle", ...error}});
     case "SECTION_STAT_UPDATE":
-      return Object.assign({}, status, {justUpdated: {type: "section_stat", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_stat", ...success}});
     case "SECTION_STAT_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_stat", ...error}});
     case "SECTION_DESCRIPTION_UPDATE":
-      return Object.assign({}, status, {justUpdated: {type: "section_description", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_description", ...success}});
     case "SECTION_DESCRIPTION_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_description", ...error}});
     case "SECTION_VISUALIZATION_UPDATE":
-      return Object.assign({}, status, {justUpdated: {type: "section_visualization", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_visualization", ...success}});
     case "SECTION_VISUALIZATION_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_visualization", ...error}});
     default: return status;

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -35,8 +35,8 @@ const extractVariables = (obj, variablesUsed = []) => {
 
 export default (status = {}, action) => {
   
-  const success = {id: action.data.id, status: "SUCCESS"};
-  const error = {id: action.data.id, status: "ERROR"};
+  const success = action && action.data && action.data.id ? {id: action.data.id, status: "SUCCESS"} : {};
+  const error = action && action.data && action.data.id ? {id: action.data.id, status: "ERROR"} : {};
   
   switch (action.type) {
     // Basic assign

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -127,6 +127,15 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {fetchingSectionPreview: true});
     case "SECTION_PREVIEW_SET":
       return Object.assign({}, status, {sectionPreview: action.data, fetchingSectionPreview: false});
+    // Update Events
+    // When an update attempt starts, clear the justUpdated variable, which will then be refilled with SUCCESS or ERROR.
+    // This is to ensure that subsequent error messages freshly fire, even if they are the "same" error
+    case "CLEAR_UPDATED": 
+      return Object.assign({}, status, {justUpdated: false});
+    case "SECTION_SUBTITLE_UPDATE":
+      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", id: action.data.id, status: "SUCCESS"}});
+    case "SECTION_SUBTITLE_ERROR":
+      return Object.assign({}, status, {justUpdated: {type: "section_subtitle", id: action.data.id, status: "ERROR"}});
     default: return status;
   }
 };

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -64,26 +64,26 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {justCreated: {type: "storysection", id: action.data.id, story_id: action.data.story_id}});
     // When toolbox items are added, force them open for editing. When they are updated, close them.
     case "GENERATOR_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "generator", id: action.data.id}, forceOpen: {type: "generator", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "generator", id: action.data.id}});
     case "GENERATOR_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "generator", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "generator", ...success}});
     case "MATERIALIZER_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "materializer", id: action.data.id}, forceOpen: {type: "materializer", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "materializer", id: action.data.id}});
     case "MATERIALIZER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "materializer", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "materializer", ...success}});
     case "SELECTOR_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "selector", id: action.data.id}, forceOpen: {type: "selector", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "selector", id: action.data.id}});
     case "SELECTOR_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "selector", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "selector", ...success}});
     case "SELECTOR_DELETE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+      return Object.assign({}, status, {dialogOpen: false});
     case "FORMATTER_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "formatter", id: action.data.id}, forceOpen: {type: "formatter", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "formatter", id: action.data.id}});
     // Updating a formatter means that some formatter logic changed. Bump the diffcounter.
     case "FORMATTER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, diffCounter: action.diffCounter, justUpdated: {type: "formatter", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, diffCounter: action.diffCounter, justUpdated: {type: "formatter", ...success}});
     case "FORMATTER_DELETE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, diffCounter: action.diffCounter});
+      return Object.assign({}, status, {dialogOpen: false, diffCounter: action.diffCounter});
     case "VARIABLES_FETCH":
       return Object.assign({}, status, {fetchingVariables: action.data});
     case "VARIABLES_FETCHED":
@@ -115,12 +115,12 @@ export default (status = {}, action) => {
     case "GENERATOR_DELETE": 
       return Object.assign({}, status, {
         justDeleted: {type: "generator", id: action.data.id, parent_id: action.data.parent_id},
-        toolboxDialogOpen: false, forceOpen: false
+        dialogOpen: false
       });
     case "MATERIALIZER_DELETE": 
       return Object.assign({}, status, {
         justDeleted: {type: "materializer", id: action.data.id, parent_id: action.data.parent_id},
-        toolboxDialogOpen: false, forceOpen: false
+        dialogOpen: false
       });
     case "STORY_DELETE": 
       return Object.assign({}, status, {justDeleted: {type: "story", id: action.data.id}, currentStoryPid: false});
@@ -133,22 +133,22 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {sectionPreview: action.data, fetchingSectionPreview: false});
     // Auto-open Text Cards
     case "SECTION_SUBTITLE_NEW":
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_subtitle", id: action.data.id}, forceOpen: {type: "section_subtitle", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_subtitle", id: action.data.id}});
     case "SECTION_STAT_NEW":
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_stat", id: action.data.id}, forceOpen: {type: "section_stat", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_stat", id: action.data.id}});
     case "SECTION_DESCRIPTION_NEW":
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_description", id: action.data.id}, forceOpen: {type: "section_description", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_description", id: action.data.id}});
     case "SECTION_VISUALIZATION_NEW":
-      return Object.assign({}, status, {toolboxDialogOpen: {type: "section_visualization", id: action.data.id}, forceOpen: {type: "section_visualization", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_visualization", id: action.data.id}});
     // Clear force/toolbox states on delete
     case "SECTION_SUBTITLE_DELETE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+      return Object.assign({}, status, {dialogOpen: false});
     case "SECTION_STAT_DELETE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+      return Object.assign({}, status, {dialogOpen: false});
     case "SECTION_DESCRIPTION_DELETE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+      return Object.assign({}, status, {dialogOpen: false});
     case "SECTION_VISUALIZATION_DELETE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+      return Object.assign({}, status, {dialogOpen: false});
     // Update Events
     // When an update attempt starts, clear the justUpdated variable, which will then be refilled with SUCCESS or ERROR.
     // This is to ensure that subsequent error messages freshly fire, even if they are the "same" error
@@ -170,19 +170,19 @@ export default (status = {}, action) => {
     case "SELECTOR_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "selector", ...error}});
     case "SECTION_SUBTITLE_UPDATE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_subtitle", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "section_subtitle", ...success}});
     case "SECTION_SUBTITLE_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_subtitle", ...error}});
     case "SECTION_STAT_UPDATE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_stat", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "section_stat", ...success}});
     case "SECTION_STAT_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_stat", ...error}});
     case "SECTION_DESCRIPTION_UPDATE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_description", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "section_description", ...success}});
     case "SECTION_DESCRIPTION_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_description", ...error}});
     case "SECTION_VISUALIZATION_UPDATE":
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "section_visualization", ...success}});
+      return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "section_visualization", ...success}});
     case "SECTION_VISUALIZATION_ERROR":
       return Object.assign({}, status, {justUpdated: {type: "section_visualization", ...error}});
     default: return status;

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -64,21 +64,21 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {justCreated: {type: "storysection", id: action.data.id, story_id: action.data.story_id}});
     // When toolbox items are added, force them open for editing. When they are updated, close them.
     case "GENERATOR_NEW": 
-      return Object.assign({}, status, {dialogOpen: {type: "generator", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "generator", id: action.data.id, force: true}});
     case "GENERATOR_UPDATE": 
       return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "generator", ...success}});
     case "MATERIALIZER_NEW": 
-      return Object.assign({}, status, {dialogOpen: {type: "materializer", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "materializer", id: action.data.id, force: true}});
     case "MATERIALIZER_UPDATE": 
       return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "materializer", ...success}});
     case "SELECTOR_NEW": 
-      return Object.assign({}, status, {dialogOpen: {type: "selector", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "selector", id: action.data.id, force: true}});
     case "SELECTOR_UPDATE": 
       return Object.assign({}, status, {dialogOpen: false, justUpdated: {type: "selector", ...success}});
     case "SELECTOR_DELETE": 
       return Object.assign({}, status, {dialogOpen: false});
     case "FORMATTER_NEW": 
-      return Object.assign({}, status, {dialogOpen: {type: "formatter", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "formatter", id: action.data.id, force: true}});
     // Updating a formatter means that some formatter logic changed. Bump the diffcounter.
     case "FORMATTER_UPDATE": 
       return Object.assign({}, status, {dialogOpen: false, diffCounter: action.diffCounter, justUpdated: {type: "formatter", ...success}});
@@ -133,13 +133,13 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {sectionPreview: action.data, fetchingSectionPreview: false});
     // Auto-open Text Cards
     case "SECTION_SUBTITLE_NEW":
-      return Object.assign({}, status, {dialogOpen: {type: "section_subtitle", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_subtitle", id: action.data.id, force: true}});
     case "SECTION_STAT_NEW":
-      return Object.assign({}, status, {dialogOpen: {type: "section_stat", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_stat", id: action.data.id, force: true}});
     case "SECTION_DESCRIPTION_NEW":
-      return Object.assign({}, status, {dialogOpen: {type: "section_description", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_description", id: action.data.id, force: true}});
     case "SECTION_VISUALIZATION_NEW":
-      return Object.assign({}, status, {dialogOpen: {type: "section_visualization", id: action.data.id}});
+      return Object.assign({}, status, {dialogOpen: {type: "section_visualization", id: action.data.id, force: true}});
     // Clear force/toolbox states on delete
     case "SECTION_SUBTITLE_DELETE":
       return Object.assign({}, status, {dialogOpen: false});

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -64,26 +64,26 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {justCreated: {type: "storysection", id: action.data.id, story_id: action.data.story_id}});
     // When toolbox items are added, force them open for editing. When they are updated, close them.
     case "GENERATOR_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "generator", forceOpen: true});
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "generator", id: action.data.id}, forceOpen: {type: "generator", id: action.data.id}});
     case "GENERATOR_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, justUpdated: {type: "generator", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "generator", ...success}});
     case "MATERIALIZER_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "materializer", forceOpen: true});
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "materializer", id: action.data.id}, forceOpen: {type: "materializer", id: action.data.id}});
     case "MATERIALIZER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, justUpdated: {type: "materializer", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "materializer", ...success}});
     case "SELECTOR_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "selector", forceOpen: true});
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "selector", id: action.data.id}, forceOpen: {type: "selector", id: action.data.id}});
     case "SELECTOR_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, justUpdated: {type: "selector", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, justUpdated: {type: "selector", ...success}});
     case "SELECTOR_DELETE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
     case "FORMATTER_NEW": 
-      return Object.assign({}, status, {toolboxDialogOpen: true, forceID: action.data.id, forceType: "formatter", forceOpen: true});
+      return Object.assign({}, status, {toolboxDialogOpen: {type: "formatter", id: action.data.id}, forceOpen: {type: "formatter", id: action.data.id}});
     // Updating a formatter means that some formatter logic changed. Bump the diffcounter.
     case "FORMATTER_UPDATE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter, justUpdated: {type: "formatter", ...success}});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, diffCounter: action.diffCounter, justUpdated: {type: "formatter", ...success}});
     case "FORMATTER_DELETE": 
-      return Object.assign({}, status, {toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false, diffCounter: action.diffCounter});
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false, diffCounter: action.diffCounter});
     case "VARIABLES_FETCH":
       return Object.assign({}, status, {fetchingVariables: action.data});
     case "VARIABLES_FETCHED":
@@ -115,12 +115,12 @@ export default (status = {}, action) => {
     case "GENERATOR_DELETE": 
       return Object.assign({}, status, {
         justDeleted: {type: "generator", id: action.data.id, parent_id: action.data.parent_id},
-        toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false
+        toolboxDialogOpen: false, forceOpen: false
       });
     case "MATERIALIZER_DELETE": 
       return Object.assign({}, status, {
         justDeleted: {type: "materializer", id: action.data.id, parent_id: action.data.parent_id},
-        toolboxDialogOpen: false, forceID: false, forceType: false, forceOpen: false
+        toolboxDialogOpen: false, forceOpen: false
       });
     case "STORY_DELETE": 
       return Object.assign({}, status, {justDeleted: {type: "story", id: action.data.id}, currentStoryPid: false});

--- a/packages/cms/src/reducers/status.js
+++ b/packages/cms/src/reducers/status.js
@@ -140,6 +140,15 @@ export default (status = {}, action) => {
       return Object.assign({}, status, {toolboxDialogOpen: {type: "section_description", id: action.data.id}, forceOpen: {type: "section_description", id: action.data.id}});
     case "SECTION_VISUALIZATION_NEW":
       return Object.assign({}, status, {toolboxDialogOpen: {type: "section_visualization", id: action.data.id}, forceOpen: {type: "section_visualization", id: action.data.id}});
+    // Clear force/toolbox states on delete
+    case "SECTION_SUBTITLE_DELETE":
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+    case "SECTION_STAT_DELETE":
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+    case "SECTION_DESCRIPTION_DELETE":
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
+    case "SECTION_VISUALIZATION_DELETE":
+      return Object.assign({}, status, {toolboxDialogOpen: false, forceOpen: false});
     // Update Events
     // When an update attempt starts, clear the justUpdated variable, which will then be refilled with SUCCESS or ERROR.
     // This is to ensure that subsequent error messages freshly fire, even if they are the "same" error


### PR DESCRIPTION
Closes #901
Closes #793 

This PR refactors the Redux create and update path for all entities. This has two major benefits:

- On write errors, don't close window. Allows user to save/rescue their work (#901)
- Unifies auto-open logic so that all entities, not just Toolbox entities, open after creation (#793)