### PR TITLE
[cms] Custom Attributes endpoint

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -516,6 +516,8 @@ If you would like to inject your own custom variables into the Attributes genera
 
 You can determine the profile pid of a given profile by checking the URL in the CMS (e.g. `http://localhost:3300/?tab=profiles&profile=49`). The POST endpoint will receive the contents of the Attributes generator in the POST body as `variables`, as well as the current `locale`. 
 
+Keep in mind that this will need to run every time a front-end profile loads, and also every time a generator or materializer is saved on the backend CMS (as it would need the variables from this endpoint to run). As a rule, try not to put any majorly heavy requests in here as it necessarily "blocks" the rest of the generator/materalizer execution.
+
 ---
 
 ## Advanced Visualization Techniques

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -488,6 +488,34 @@ If the pieces are the same, one parameter may be used:
 
 `&slugs=Product`
 
+### Custom Attributes
+
+The fixed "Attributes" includes basic information about the currently selected member, like dimension, id, and hierarchy. This is useful because it is run *before* other generators, and can therefore be used both in subsequent `variables` object and also in API calls, using the `<bracket>` syntax.
+
+If you would like to inject your own custom variables into the Attributes generator, create an endpoint in your canon API folder:
+
+```
+  app.post("/api/cms/customAttributes/:pid", (req, res) => {
+    const pid = parseInt(req.params.pid, 10); 
+    const {variables, locale} = req.body; 
+    const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables; 
+    
+    /**
+     * Make axios calls, run JS, and return your compiled data as a single JS Object. Use the pid 
+     * give in params to return different attributes for different profiles. 
+     */
+    
+    if (pid === 49) {
+      return res.json({
+        capitalName: name1.toUpperCase()
+      });
+    }
+    else return res.json({});
+  });
+```
+
+You can determine the profile pid of a given profile by checking the URL in the CMS (e.g. `http://localhost:3300/?tab=profiles&profile=49`). The POST endpoint will receive the contents of the Attributes generator in the POST body as `variables`, as well as the current `locale`. 
+
 ---
 
 ## Advanced Visualization Techniques

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -502,7 +502,7 @@ If you would like to inject your own custom variables into the Attributes genera
     
     /**
      * Make axios calls, run JS, and return your compiled data as a single JS Object. Use the pid 
-     * give in params to return different attributes for different profiles. 
+     * given in params to return different attributes for different profiles. 
      */
     
     if (pid === 49) {

--- a/packages/cms/api/testRoute.js
+++ b/packages/cms/api/testRoute.js
@@ -20,4 +20,15 @@ module.exports = function(app) {
     ]}).end();
   });
 
+  app.post("/api/cms/magic/:pid", (req, res) => {
+    const {pid} = req.params; // eslint-disable-line
+    const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = req.body; // eslint-disable-line
+    /**
+     * Make axios calls and return your compiled data as a single JS Object.
+     */
+    return res.json({
+      capName: name1.toUpperCase()
+    });
+  });
+
 };

--- a/packages/cms/api/testRoute.js
+++ b/packages/cms/api/testRoute.js
@@ -21,14 +21,18 @@ module.exports = function(app) {
   });
 
   app.post("/api/cms/magic/:pid", (req, res) => {
-    const {pid} = req.params; // eslint-disable-line
-    const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = req.body; // eslint-disable-line
+    const pid = parseInt(req.params.pid, 10); // eslint-disable-line
+    const {variables, locale} = req.body; // eslint-disable-line
+    const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables; // eslint-disable-line
     /**
      * Make axios calls and return your compiled data as a single JS Object.
      */
-    return res.json({
-      capName: name1.toUpperCase()
-    });
+    if (pid === 49) {
+      return res.json({
+        capName: name1.toUpperCase()
+      });
+    }
+    else return res.json({});
   });
 
 };

--- a/packages/cms/api/testRoute.js
+++ b/packages/cms/api/testRoute.js
@@ -20,7 +20,7 @@ module.exports = function(app) {
     ]}).end();
   });
 
-  app.post("/api/cms/magic/:pid", (req, res) => {
+  app.post("/api/cms/customAttributes/:pid", (req, res) => {
     const pid = parseInt(req.params.pid, 10); // eslint-disable-line
     const {variables, locale} = req.body; // eslint-disable-line
     const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables; // eslint-disable-line

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -284,7 +284,7 @@ export function fetchVariables(config) {
     const locales = [localeDefault];
     if (localeSecondary) locales.push(localeSecondary);
     
-    const magicURL = `/api/cms/magic/${currentPid}`;
+    const magicURL = `/api/cms/customAttributes/${currentPid}`;
     const attributesByLocale = {};
     for (const thisLocale of locales) {
       const theseAttributes = attify(previews.map(d => d.searchObj), thisLocale);

--- a/packages/cms/src/actions/profiles.js
+++ b/packages/cms/src/actions/profiles.js
@@ -195,7 +195,7 @@ export function setVariables(newVariables) {
 
 /** */
 export function resetPreviews() { 
-  return function(dispatch, getStore) {
+  return async function(dispatch, getStore) {
     const {currentPid, pathObj} = getStore().cms.status;
     const {profiles} = getStore().cms;
     const thisProfile = profiles.find(p => p.id === currentPid);
@@ -225,28 +225,27 @@ export function resetPreviews() {
       return axios.get(url);
     });
     const previews = [];
-    Promise.all(requests).then(resps => {
-      resps.forEach((resp, i) => {
-        // If our result doesn't return for some reason, scaffold out a mostly-blank result with the first group's first meta
-        const newPreview = {slug: groupedMeta[i][0].slug, id: "", name: "", memberSlug: "", searchObj: {}};
-        if (resp && resp.data && resp.data.results && resp.data.results[0]) {
-          const result = resp.data.results[0];
-          // Because any given dimension has many variants, we must use the returned member to find out which one we're on.
-          const thisGroup = groupedMeta[i];
-          const matchingMeta = thisGroup.find(meta => meta.dimension === result.dimension && meta.cubeName === result.cubeName);
-          if (matchingMeta) {
-            newPreview.slug = matchingMeta.slug;
-            newPreview.id = result.id;
-            newPreview.name = result.name;
-            newPreview.memberSlug = result.slug;
-            newPreview.searchObj = result;
-          }
+    const resps = await Promise.all(requests).catch(catcher);
+    resps.forEach((resp, i) => {
+      // If our result doesn't return for some reason, scaffold out a mostly-blank result with the first group's first meta
+      const newPreview = {slug: groupedMeta[i][0].slug, id: "", name: "", memberSlug: "", searchObj: {}};
+      if (resp && resp.data && resp.data.results && resp.data.results[0]) {
+        const result = resp.data.results[0];
+        // Because any given dimension has many variants, we must use the returned member to find out which one we're on.
+        const thisGroup = groupedMeta[i];
+        const matchingMeta = thisGroup.find(meta => meta.dimension === result.dimension && meta.cubeName === result.cubeName);
+        if (matchingMeta) {
+          newPreview.slug = matchingMeta.slug;
+          newPreview.id = result.id;
+          newPreview.name = result.name;
+          newPreview.memberSlug = result.slug;
+          newPreview.searchObj = result;
         }
-        previews.push(newPreview);
-      });
-      const newPathObj = Object.assign({}, pathObj, {previews});
-      dispatch({type: "STATUS_SET", data: {previews, pathObj: newPathObj}});
+      }
+      previews.push(newPreview);
     });
+    const newPathObj = Object.assign({}, pathObj, {previews});
+    dispatch({type: "STATUS_SET", data: {previews, pathObj: newPathObj}});
   };
 }
 
@@ -257,7 +256,7 @@ export function resetPreviews() {
  * variables object in a hash that is keyed by the profile id.
  */
 export function fetchVariables(config) { 
-  return async function(dispatch, getStore) {    
+  return async function(dispatch, getStore) { 
     dispatch({type: "VARIABLES_FETCH", data: "Generators"});
     const {previews, localeDefault, localeSecondary, currentPid} = getStore().cms.status;
     const {auth} = getStore();
@@ -284,15 +283,24 @@ export function fetchVariables(config) {
 
     const locales = [localeDefault];
     if (localeSecondary) locales.push(localeSecondary);
+    
+    const magicURL = `/api/cms/magic/${currentPid}`;
+    const attributesByLocale = {};
     for (const thisLocale of locales) {
-      const attributes = attify(previews.map(d => d.searchObj), thisLocale);
+      const theseAttributes = attify(previews.map(d => d.searchObj), thisLocale);
       if (getStore().env.CANON_LOGINS && auth.user) {
         const {password, salt, ...user} = auth.user; // eslint-disable-line
-        attributes.user = user;
+        theseAttributes.user = user;
         // Bubble up userRole for easy access in front end (for hiding sections based on role)
-        attributes.userRole = user.role;
+        theseAttributes.userRole = user.role;
       }
+      const magicResp = await axios.post(magicURL, {variables: theseAttributes, locale: thisLocale}).catch(() => ({data: {}}));
+      attributesByLocale[thisLocale] = theseAttributes;
+      if (typeof magicResp.data === "object") attributesByLocale[thisLocale] = {...attributesByLocale[thisLocale], ...magicResp.data};
+    }
 
+    for (const thisLocale of locales) {
+      const attributes = attributesByLocale[thisLocale];
       let paramString = previews.reduce((acc, p, i) => `${acc}&slug${i + 1}=${p.slug}&id${i + 1}=${p.id}`, "");
       if (config && (config.type === "materializer" || config.type === "generator")) paramString += `&${config.type}=${config.id}`;
       if (!config || config && config.type === "generator") {

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -301,6 +301,13 @@ module.exports = function(app) {
       if (resp && resp.data && resp.data.data && resp.data.data.length > 0) {
         smallAttr.parents = resp.data.data;
       }
+      // Fetch Custom Magic Generator
+      const magicURL = `${ req.protocol }://${ req.headers.host }/api/cms/magic/${pid}`;
+      const magicResp = await axios.post(magicURL, smallAttr).catch(catcher);
+      if (magicResp) {
+        smallAttr = {...smallAttr, ...magicResp.data};
+      }
+
     }
     const genObj = id ? {where: {id}} : {where: {profile_id: pid}};
     let generators = await db.generator.findAll(genObj).catch(catcher);

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -302,7 +302,7 @@ module.exports = function(app) {
         smallAttr.parents = resp.data.data;
       }
       // Fetch Custom Magic Generator
-      const magicURL = `${ req.protocol }://${ req.headers.host }/api/cms/magic/${pid}`;
+      const magicURL = `${ req.protocol }://${ req.headers.host }/api/cms/customAttributes/${pid}`;
       const magicResp = await axios.post(magicURL, {variables: smallAttr, locale}).catch(() => ({data: {}}));
       if (typeof magicResp.data === "object") {
         smallAttr = {...smallAttr, ...magicResp.data};

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -303,8 +303,8 @@ module.exports = function(app) {
       }
       // Fetch Custom Magic Generator
       const magicURL = `${ req.protocol }://${ req.headers.host }/api/cms/magic/${pid}`;
-      const magicResp = await axios.post(magicURL, smallAttr).catch(catcher);
-      if (magicResp) {
+      const magicResp = await axios.post(magicURL, {variables: smallAttr, locale}).catch(() => ({data: {}}));
+      if (typeof magicResp.data === "object") {
         smallAttr = {...smallAttr, ...magicResp.data};
       }
 


### PR DESCRIPTION
Allows users to create a customAttributes endpoint at `/api/cms/customAttributes/:pid` to inject customized variables into the Attributes generator.

This allows arbitrary axios/js to be run AFTER the magic generator has retrieved the id/dimension/hierarchy but BEFORE the rest of the generators and materializers run. The user can then inject whatever variables they want, for use in subsequent `variables` operations or using `<brackets>` in API calls.

Though this makes an "internal call" to an api route, because it is a `POST`, no special considerations are needed when it comes to caching.

More information is available in the README.