### PR TITLE
fixes security hole in canon vars

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -745,20 +745,20 @@ It is necessary that users spin up an entire new database for any CMS migration.
 The user need configure two sets of environment variables, `OLD` and `NEW`.
 
 ```
-CANON_CONST_MIGRATION_OLD_DB_NAME
-CANON_CONST_MIGRATION_OLD_DB_USER
-CANON_CONST_MIGRATION_OLD_DB_PW
-CANON_CONST_MIGRATION_OLD_DB_HOST
+CANON_CMS_MIGRATION_OLD_DB_NAME
+CANON_CMS_MIGRATION_OLD_DB_USER
+CANON_CMS_MIGRATION_OLD_DB_PW
+CANON_CMS_MIGRATION_OLD_DB_HOST
 
-CANON_CONST_MIGRATION_NEW_DB_NAME
-CANON_CONST_MIGRATION_NEW_DB_USER
-CANON_CONST_MIGRATION_NEW_DB_PW
-CANON_CONST_MIGRATION_NEW_DB_HOST
+CANON_CMS_MIGRATION_NEW_DB_NAME
+CANON_CMS_MIGRATION_NEW_DB_USER
+CANON_CMS_MIGRATION_NEW_DB_PW
+CANON_CMS_MIGRATION_NEW_DB_HOST
 ```
 
 These variables represent the old db you are migration **from** and the new db you are migrating **to**.  The new db will be **wiped every time** you run the script - the idea here is that you are building a new db from scratch.
 
 🔥 WHATEVER DB YOU CONFIGURE AS **NEW** WILL BE COMPLETELY DESTROYED AND BUILT FROM SCRATCH 🔥
-🔥 DO NOT SET `CANON_CONST_MIGRATION_NEW_DB_*` TO A CURRENTLY IMPORTANT DB🔥
+🔥 DO NOT SET `CANON_CMS_MIGRATION_NEW_DB_*` TO A CURRENTLY IMPORTANT DB🔥
 
 After the migration is done, you can switch your dev environment to the new DB for testing, and eventually switch it to prod.

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.1.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.1.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const migrate = async() => {
 

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.11.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.11.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const populateSearch = require("../../src/utils/populateSearch");
 

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.12.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.12.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const migrate = async() => {
 

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.6.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.6.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const sectionInclude = [
   {association: "descriptions", separate: true},

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.7.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.7.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const locale = process.env.CANON_LANGUAGE_DEFAULT || "en";
 

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.8.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.8.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const migrate = async() => {
 

--- a/packages/cms/scripts/migration/canon-cms-migrate-0.9.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-0.9.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const migrate = async() => {
 

--- a/packages/cms/scripts/migration/canon-cms-migrate-legacy.js
+++ b/packages/cms/scripts/migration/canon-cms-migrate-legacy.js
@@ -3,8 +3,8 @@
 const utils = require("./migrationUtils.js");
 const {catcher, resetSequence, fetchOldModel, fetchNewModel} = utils;
 const shell = require("shelljs");
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
 
 const migrate = async() => {
 

--- a/packages/cms/scripts/migration/migrationUtils.js
+++ b/packages/cms/scripts/migration/migrationUtils.js
@@ -2,15 +2,15 @@ const Sequelize = require("sequelize");
 const fs = require("fs");
 const path = require("path");
 
-const oldDBName = process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
-const oldDBUser = process.env.CANON_CONST_MIGRATION_OLD_DB_USER;
-const oldDBPW = process.env.CANON_CONST_MIGRATION_OLD_DB_PW || null;
-const oldDBHost = process.env.CANON_CONST_MIGRATION_OLD_DB_HOST;
+const oldDBName = process.env.CANON_CMS_MIGRATION_OLD_DB_NAME || process.env.CANON_CONST_MIGRATION_OLD_DB_NAME;
+const oldDBUser = process.env.CANON_CMS_MIGRATION_OLD_DB_USER || process.env.CANON_CONST_MIGRATION_OLD_DB_USER;
+const oldDBPW = process.env.CANON_CMS_MIGRATION_OLD_DB_PW || process.env.CANON_CONST_MIGRATION_OLD_DB_PW || null;
+const oldDBHost = process.env.CANON_CMS_MIGRATION_OLD_DB_HOST || process.env.CANON_CONST_MIGRATION_OLD_DB_HOST;
 
-const newDBName = process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
-const newDBUser = process.env.CANON_CONST_MIGRATION_NEW_DB_USER;
-const newDBPW = process.env.CANON_CONST_MIGRATION_NEW_DB_PW || null;
-const newDBHost = process.env.CANON_CONST_MIGRATION_NEW_DB_HOST;
+const newDBName = process.env.CANON_CMS_MIGRATION_NEW_DB_NAME || process.env.CANON_CONST_MIGRATION_NEW_DB_NAME;
+const newDBUser = process.env.CANON_CMS_MIGRATION_NEW_DB_USER || process.env.CANON_CONST_MIGRATION_NEW_DB_USER;
+const newDBPW = process.env.CANON_CMS_MIGRATION_NEW_DB_PW || process.env.CANON_CONST_MIGRATION_NEW_DB_PW || null;
+const newDBHost = process.env.CANON_CMS_MIGRATION_NEW_DB_HOST || process.env.CANON_CONST_MIGRATION_NEW_DB_HOST;
 
 const dbold = new Sequelize(oldDBName, oldDBUser, oldDBPW, {host: oldDBHost, dialect: "postgres", define: {timestamps: true}, logging: () => {}});
 const dbnew = new Sequelize(newDBName, newDBUser, newDBPW, {host: newDBHost, dialect: "postgres", define: {timestamps: true}, logging: () => {}});


### PR DESCRIPTION
Closes #916

Putting db creds in `CANON_CONST_*` automatically promotes them to the redux store, which comes over the wire on pageload. Renames them to `CANON_CMS_*` to avoid this, while maintaining backwards compatibility. Updates readme.