### PR TITLE
[cms] includes a div container for wrapping heading

### DIFF
--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -210,10 +210,12 @@ class Hero extends Component {
 
     // heading & subhead(s)
     const heading = <Fragment>
-      <Parse El="h1" id={contents ? contents.slug : `${stripHTML(profile.title)}-hero`} className="cp-section-heading cp-hero-heading u-font-xxl">
-        {title}
-      </Parse>
-      {subtitleContent}
+      <div className="cp-hero-heading-wrapper">
+        <Parse El="h1" id={contents ? contents.slug : `${stripHTML(profile.title)}-hero`} className="cp-section-heading cp-hero-heading u-font-xxl">
+          {title}
+        </Parse>
+        {subtitleContent}
+      </div>
     </Fragment>;
 
 
@@ -222,9 +224,7 @@ class Hero extends Component {
         <div className="cp-section-inner cp-hero-inner">
           {/* caption */}
           <div className="cp-section-content cp-hero-caption">
-            <div className="cp-hero-heading-wrapper">
-              {heading}
-            </div>
+            {heading}
             {statContent}
             {paragraphs}
             {sourceContent}

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -209,14 +209,12 @@ class Hero extends Component {
     }
 
     // heading & subhead(s)
-    const heading = <Fragment>
-      <div className="cp-hero-heading-wrapper">
+    const heading = <div className="cp-hero-heading-wrapper">
         <Parse El="h1" id={contents ? contents.slug : `${stripHTML(profile.title)}-hero`} className="cp-section-heading cp-hero-heading u-font-xxl">
           {title}
         </Parse>
         {subtitleContent}
-      </div>
-    </Fragment>;
+      </div>;
 
 
     return (

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -222,7 +222,9 @@ class Hero extends Component {
         <div className="cp-section-inner cp-hero-inner">
           {/* caption */}
           <div className="cp-section-content cp-hero-caption">
-            {heading}
+            <div className="cp-hero-heading-wrapper">
+              {heading}
+            </div>
             {statContent}
             {paragraphs}
             {sourceContent}


### PR DESCRIPTION
Currently, in DataMexico I was trying to implement a mockup done by Gaby, but I couldn't because heading didn't have a wrapper. 
![image](https://user-images.githubusercontent.com/5233593/84786263-83e7b600-afba-11ea-9162-0ca2049afad8.png)

This PR creates a div container for wrapping heading.
