### PR TITLE
[cms] Adds fallback value for `CANON_CMS_CUBES`

### DIFF
--- a/packages/cms/src/api/imageRoute.js
+++ b/packages/cms/src/api/imageRoute.js
@@ -5,7 +5,7 @@ const jwt = require("jsonwebtoken");
 
 const verbose = yn(process.env.CANON_CMS_LOGGING);
 const envLoc = process.env.CANON_LANGUAGE_DEFAULT || "en";
-let cubeRoot = process.env.CANON_CMS_CUBES;
+let cubeRoot = process.env.CANON_CMS_CUBES || "localhost";
 if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 
 const {OLAP_PROXY_SECRET, CANON_CMS_MINIMUM_ROLE} = process.env;

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -44,7 +44,7 @@ const PORT = process.env.CANON_PORT || 3300;
 const NODE_ENV = process.env.NODE_ENV || "development";
 const REQUESTS_PER_SECOND = process.env.CANON_CMS_REQUESTS_PER_SECOND ? parseInt(process.env.CANON_CMS_REQUESTS_PER_SECOND, 10) : 20;
 const GENERATOR_TIMEOUT = process.env.CANON_CMS_GENERATOR_TIMEOUT ? parseInt(process.env.CANON_CMS_GENERATOR_TIMEOUT, 10) : 5000;
-let cubeRoot = process.env.CANON_CMS_CUBES;
+let cubeRoot = process.env.CANON_CMS_CUBES || "localhost";
 if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 
 const canonVars = {

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -26,7 +26,7 @@ const validLicenses = ["4", "5", "7", "8", "9", "10"];
 const validLicensesString = validLicenses.join();
 const bucket = process.env.CANON_CONST_STORAGE_BUCKET;
 
-let cubeRoot = CANON_CMS_CUBES;
+let cubeRoot = CANON_CMS_CUBES || "localhost";
 if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
 
 const catcher = e => {

--- a/packages/cms/src/utils/populateSearch.js
+++ b/packages/cms/src/utils/populateSearch.js
@@ -14,7 +14,8 @@ if (!LANGUAGES.includes(envLoc)) LANGUAGES.push(envLoc);
 // in populateSearch will be made from the default language content.
 LANGUAGES.sort(a => a === envLoc ? -1 : 1);
 
-const {CANON_CMS_CUBES, OLAP_PROXY_SECRET, CANON_CMS_MINIMUM_ROLE} = process.env;
+const {OLAP_PROXY_SECRET, CANON_CMS_MINIMUM_ROLE} = process.env;
+const CANON_CMS_CUBES = process.env.CANON_CMS_CUBES || "localhost";
 
 /**
  * There is not a fully-featured way for olap-client to know the difference between a


### PR DESCRIPTION
In the canon example app, failing to set `CANON_CMS_CUBES` env var caused the load to fail. Add fallbacks so users can build with no env vars at all.