### PR TITLE
[cms] improve search legacy API to support special chars fixed #1061

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -421,7 +421,7 @@ Arguments are provided by url paramaters:
 
 |parameter|description|
 |---|---|
-|`q`|A string query which uses the SQL `LIKE` operator to search the `name` and `keywords` of the member|
+|`q`|A string query which uses the SQL `ILIKE` operator to search the `name` and `keywords` of the member. (For better results install `unaccent` package in your Postgres server running: `CREATE EXTENSION IF NOT EXISTS unaccent;`. [More info.](https://www.postgresql.org/docs/9.1/unaccent.html) )|
 |`dimension`|An exact-match string to filter results to members in the provided dimension|
 |`levels`|A comma-separated list of levels to filter results to members by the provided levels|
 |`cubeName`|An exact-match string to filter results to members from the provided cube|

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -301,8 +301,8 @@ module.exports = function(app) {
           const [unaccentResult, unaccentMetadata] = await db.query("SELECT * FROM pg_extension WHERE extname = 'unaccent';");
           unaccentExtensionInstalled = unaccentMetadata.rowCount >= 1;
           if (!unaccentExtensionInstalled) {
-            console.log("WARNING: Consider install 'unaccent' extension in Postgres server for better search results running: CREATE EXTENSION IF NOT EXISTS unaccent;");
-            console.log("Do not forget to restart this web application after extension were installed.");
+            console.log("WARNING: For better search results, Consider installing the 'unaccent' extension in Postgres by running: CREATE EXTENSION IF NOT EXISTS unaccent;");
+            console.log("Do not forget to restart the web application after installation.");
           }
         }
 

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -44,6 +44,9 @@ if (deepsearchAPI) deepsearchAPI = deepsearchAPI.replace(/\/$/, "");
 const f = (a, b) => [].concat(...a.map(d => b.map(e => [].concat(d, e))));
 const cartesian = (a, b, ...c) => b ? cartesian(f(a, b), ...c) : a;
 
+
+let unaccentExtensionInstalled;
+
 module.exports = function(app) {
 
   const {db} = app.settings;
@@ -290,6 +293,19 @@ module.exports = function(app) {
         if (results) results.origin = "deepsearch";
       }
       if (!deepsearchAPI || deepsearchAPI && !results) {
+
+        // Check just the first time if unaccent Extension is installed.
+        // If not launch a warning and use the fallback search.
+        // Install it running in the db: "CREATE EXTENSION IF NOT EXISTS unaccent;";
+        if (typeof unaccentExtensionInstalled === "undefined") {
+          const [unaccentResult, unaccentMetadata] = await db.query("SELECT * FROM pg_extension WHERE extname = 'unaccent';");
+          unaccentExtensionInstalled = unaccentMetadata.rowCount >= 1;
+          if (!unaccentExtensionInstalled) {
+            console.log("WARNING: Consider install 'unaccent' extension in Postgres server for better search results running: CREATE EXTENSION IF NOT EXISTS unaccent;");
+            console.log("Do not forget to restart this web application after extension were installed.");
+          }
+        }
+
         results = {};
         const {query} = req.query;
         const where = {};
@@ -297,9 +313,36 @@ module.exports = function(app) {
         const terms = query.split(" ");
         const orArray = [];
         terms.forEach(term => {
-          orArray.push({name: {[sequelize.Op.iLike]: `%${term}%`}});
-          orArray.push({keywords: {[sequelize.Op.overlap]: [query]}});
+
+          // Use unaccent extension from postgres if exists.
+          if (unaccentExtensionInstalled) {
+
+            // Where by name
+            orArray.push(
+              sequelize.where(
+                sequelize.fn("unaccent", sequelize.col("name")),
+                {[sequelize.Op.iLike]: sequelize.fn("concat", "%", sequelize.fn("unaccent", term), "%")})
+            );
+
+            // Where by keywords
+            orArray.push(
+              sequelize.where(
+                sequelize.fn("unaccent", sequelize.fn("array_to_string", sequelize.col("keywords"), " ", "")),
+                {[sequelize.Op.iLike]: sequelize.fn("concat", "%", sequelize.fn("unaccent", term), "%")})
+            );
+
+          }
+          else {
+            // Where by name: Use simple ilike query if unaccent extension doesn't exists.
+            orArray.push({name: {[sequelize.Op.iLike]: `%${term}%`}});
+          }
         });
+
+        // Where by keywords: Add simple overlap to look into keywords if unaccent extension doesn't exists.
+        if (!unaccentExtensionInstalled) {
+          orArray.push({keywords: {[sequelize.Op.overlap]: [query]}});
+        }
+
         where[sequelize.Op.or] = orArray;
         where.locale = locale;
         const contentRows = await db.search_content.findAll({where}).catch(catcher);
@@ -389,7 +432,7 @@ module.exports = function(app) {
       else {
         combinedResults = combinedResults.filter(d => {
           const ids = d.map(o => o.id);
-          return (new Set(ids)).size === ids.length;
+          return new Set(ids).size === ids.length;
         });
       }
 


### PR DESCRIPTION
- Use `unaccent` package from postgres. 
- Refactor in searchRoutes for `/api/profilesearch` endpoint.
- There is a test record with special chars in test database: `Horsés` and keywords `úúuu`,`èèè`,`test`,`lomas de zamorá`
- To test the name comparison try http://localhost:3300/api/profilesearch?query=horse or http://localhost:3300/api/profilesearch?query=horsé 
- Also I fixed the keywords comparison. To test it try: http://localhost:3300/api/profilesearch?query=úuu or http://localhost:3300/api/profilesearch?query=zamora

- Fallback to old code if `unaccent` package is not available.
- Warning message in log on first run if package is not available.
- The only instruction to update the database server is `CREATE EXTENSION IF NOT EXISTS unaccent;` 