### PR TITLE
[cms] adds request duration to cms generators

### DIFF
--- a/examples/api/cmsTestRoute.js
+++ b/examples/api/cmsTestRoute.js
@@ -20,7 +20,7 @@ module.exports = function(app) {
     ]}).end();
   });
 
-  app.post("/api/cms/customAttributes/:pid", (req, res) => {
+  app.post("/api/cms/customAttributes/:pid", async(req, res) => {
     const pid = parseInt(req.params.pid, 10); // eslint-disable-line
     const {variables, locale} = req.body; // eslint-disable-line
     const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables; // eslint-disable-line
@@ -31,6 +31,11 @@ module.exports = function(app) {
       return res.json({
         capName: name1.toUpperCase()
       });
+    }
+
+    if (pid === 2) {
+      // await new Promise(r => setTimeout(r, 5000));
+      return res.json({});
     }
     else return res.json({});
   });

--- a/packages/cms/src/components/cards/VariableCard.css
+++ b/packages/cms/src/components/cards/VariableCard.css
@@ -26,6 +26,18 @@
   }
 }
 
+.cms-card-status-ok {
+  color: darkgreen;
+}
+
+.cms-card-status-warning {
+  color: #cc7000;
+}
+
+.cms-card-status-danger {
+  @mixin error-text;
+}
+
 .cms-console-warning {
   margin-top: 1px;
   margin-left: 5px;

--- a/packages/cms/src/components/cards/VariableCard.jsx
+++ b/packages/cms/src/components/cards/VariableCard.jsx
@@ -27,7 +27,8 @@ class VariableCard extends Component {
       alertObj: false,
       isDirty: false,
       dupes: [],
-      size: 0
+      size: 0,
+      duration: false
     };
   }
 
@@ -93,11 +94,13 @@ class VariableCard extends Component {
     let displayData, secondaryDisplayData = {};
     let dupes = [];
     let size = 0;
+    let duration = false;
     if (type === "generator") {
       displayData = variables._genStatus[id];
       if (localeSecondary) {
         secondaryDisplayData = secondaryVariables._genStatus[id];
       }
+      if (variables._genStatus.durations) duration = variables._genStatus.durations[id];
     }
     else if (type === "materializer") {
       displayData = variables._matStatus[id];
@@ -118,7 +121,7 @@ class VariableCard extends Component {
         size = JSON.stringify(theseVars).length;
       }
     }
-    this.setState({displayData, secondaryDisplayData, dupes, size});
+    this.setState({displayData, secondaryDisplayData, dupes, size, duration});
   }
 
   maybeDuplicate() {
@@ -199,7 +202,7 @@ class VariableCard extends Component {
   render() {
     const {attr, readOnly, minData, type, showReorderButton, variables} = this.props;
     const {localeDefault, localeSecondary} = this.props.status;
-    const {displayData, secondaryDisplayData, isOpen, alertObj, dupes, size} = this.state;
+    const {displayData, secondaryDisplayData, isOpen, alertObj, dupes, size, duration} = this.state;
 
     let description = "";
     let showDesc = false;
@@ -260,6 +263,17 @@ class VariableCard extends Component {
       usesConsole = true;
     }
 
+    let status = "ok";
+    if (duration) {
+      if (duration >= 500 && duration <= 5000) {
+        status = "warning";
+      }
+      else if (duration > 5000) {
+        status = "danger";
+      }
+    }
+
+
     return (
       <Fragment>
         <Card {...cardProps} key="c">
@@ -299,6 +313,11 @@ class VariableCard extends Component {
           {usesConsole && 
             <p className="cms-card-error u-font-xxs u-margin-top-xs">
               <Icon className="cms-card-error-icon" icon="warning-sign" /> Warning: Remove <pre className="cms-console-warning">console.log</pre>.
+            </p>
+          }
+          {duration && 
+            <p className={`cms-card-error cms-card-status-${status} u-font-xxs u-margin-top-xs`}>
+              <Icon className="cms-card-error-icon" icon="time" /> {`Duration: ${duration} ms.`}
             </p>
           }
         </Card>


### PR DESCRIPTION
Adds request duration to CMS generators:

![image](https://user-images.githubusercontent.com/1714292/89474419-8f9e6000-d753-11ea-862c-543f70c0e282.png)

Picture is slightly inaccurate, current windows are:
- ok: 0-500ms
- warning: 500-5000ms
- danger: 5000ms+ 

Makes use of axios interceptors for timing. Someday I should allow for sorting based on problem factors (big payloads, long durations). That work will be tracked in issue #1084.

Closes #1083