### PR TITLE
[cms] Includes title attribute into cp-hero-heading-dimension span

### DIFF
--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -157,8 +157,8 @@ class Hero extends Component {
     const {name1, name2} = variables;
     if (title) {
       return title
-        .replace(name1, `<span class="cp-hero-heading-dimension" onClick=titleClick(0)>${name1}</span>`)
-        .replace(name2, `<span class="cp-hero-heading-dimension" onClick=titleClick(1)>${name2}</span>`);
+        .replace(name1, `<span class="cp-hero-heading-dimension" title=${name1} onClick=titleClick(0)>${name1}</span>`)
+        .replace(name2, `<span class="cp-hero-heading-dimension" title=${name2} onClick=titleClick(1)>${name2}</span>`);
     }
     else {
       return title;
@@ -210,11 +210,11 @@ class Hero extends Component {
 
     // heading & subhead(s)
     const heading = <div className="cp-hero-heading-wrapper">
-        <Parse El="h1" id={contents ? contents.slug : `${stripHTML(profile.title)}-hero`} className="cp-section-heading cp-hero-heading u-font-xxl">
-          {title}
-        </Parse>
-        {subtitleContent}
-      </div>;
+      <Parse El="h1" id={contents ? contents.slug : `${stripHTML(profile.title)}-hero`} className="cp-section-heading cp-hero-heading u-font-xxl">
+        {title}
+      </Parse>
+      {subtitleContent}
+    </div>;
 
 
     return (


### PR DESCRIPTION
On DataMX, For really-long product names, I setted the max number of lines along with a text overflow, but I would like to keep the ability to show the full name if any user is interested. This PR includes `title` tag on `cp-hero-heading-dimension`.

![image](https://user-images.githubusercontent.com/5233593/89554775-501c5600-d7dd-11ea-9370-2fef68758332.png)
