### PR TITLE
[cms] adds filtering to profilesearch

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -480,6 +480,9 @@ If you would prefer to build your own search component, the DeepSearch API is av
 |`query`|Query to search for|
 |`locale`|Language for results|
 |`limit`|Maximum number of results to return|
+|`profile`|Restrict results to a profile, must be an integer profile id or a profile slug (unary profiles only)|
+|`dimension`|Restrict results by dimension|
+|`hierarchy`|Restrict results by hierarchy (comma separated)|
 |`min_confidence`|Confidence threshold (Deepsearch Only)|
 
 Results will be returned in a response object that includes metadata on the results. Matching members separated by profile can be found in the `profiles` key of the response object. A single grouped list of all matching profiles can be found in the `grouped` key of the response object.

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -347,6 +347,22 @@ module.exports = function(app) {
         where.locale = locale;
         const contentRows = await db.search_content.findAll({where}).catch(catcher);
         searchWhere.contentId = Array.from(new Set(contentRows.map(r => r.id)));
+        // If the user has specified a profile by slug or id, restrict the search results to that profile's members
+        if (req.query.profile) {
+          // using "slug" here is not 100% correct, as profiles can be bilateral, and therefore have two slugs.
+          // However, for the more common unilateral case, allow "single-slug" lookup for convenience.
+          const metaWhere = !isNaN(req.query.profile) ? {profile_id: req.query.profile} : {slug: req.query.profile};
+          const thisMeta = await db.profile_meta.findOne({where: metaWhere});
+          if (thisMeta) {
+            searchWhere.cubeName = thisMeta.cubeName;
+            searchWhere.dimension = thisMeta.dimension;
+            searchWhere.hierarchy = thisMeta.levels;
+          }
+        }
+        // Also allow the user to directly limit searches by dimension and comma separated hierarchy (levels)
+        // Note that this can happen in conjunction with the req.query.profile limitation above, as overrides.
+        if (req.query.dimension) searchWhere.dimension = req.query.dimension.split(",");
+        if (req.query.hierarchy) searchWhere.hierarchy = req.query.hierarchy.split(",");
         let rows = await db.search.findAll({
           include: [{model: db.image, include: [{association: "content"}]}, {association: "content"}],
           // when a limit is provided, it is for EACH dimension, but this initial rowsearch is for a flat member list.
@@ -398,7 +414,7 @@ module.exports = function(app) {
       const relevantResults = groupedMeta.reduce((acc, group, i) => {
         acc[i] = [];
         group.forEach(m => {
-          const theseResults = results.results[m.dimension] ? results.results[m.dimension].filter(d => d.metadata.cube_name === m.cubeName) : false;
+          const theseResults = results.results[m.dimension] ? results.results[m.dimension].filter(d => d.metadata.cube_name === m.cubeName && m.levels.includes(d.metadata.hierarchy)) : false;
           if (theseResults) {
             acc[i] = acc[i].concat(theseResults
               .map(r => ({


### PR DESCRIPTION
Adds the ability to specify `dimension`, `hierarchy`, and `profile` as params in profileSearch. `profile` accepts either an integer `id`, or for unary profiles, the profile `slug` for convenience.

Also handles an issue where levels were not being enforced in search results.

Closes #1089 
Closes #1092 