### PR TITLE
[cms] fixes botched merge in mortar and search routes

### DIFF
--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -77,7 +77,8 @@ const rowToResult = (row, locale) => {
       cube_name: row.cubeName
     },
     id: row.slug,
-    keywords: content && content.keywords ? content.keywords.join : ""
+    keywords: content && content.keywords ? content.keywords.join : "",
+    attr: content && content.attr ? content.attr : {}
   };
 };
 
@@ -272,25 +273,6 @@ module.exports = function(app) {
     const locale = req.query.locale || process.env.CANON_LANGUAGE_DEFAULT || "en";
     const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
     let results = {};
-
-    // Convert a legacy-style search result into a scaffolded faked version of what the deepsearch API returns.
-    // This allows us to use the same collating code below, whether the results came from legacy or deepsearch.
-    const rowToResult = row => {
-      const content = row.content.find(c => c.locale === locale);
-      return {
-        name: content ? content.name : "",
-        confidence: row.zvalue,
-        metadata: {
-          id: row.id,
-          slug: row.slug,
-          hierarchy: row.hierarchy,
-          cube_name: row.cubeName
-        },
-        id: row.slug,
-        keywords: content && content.keywords ? content.keywords.join : "",
-        attr: content && content.attr ? content.attr : {}
-      };
-    };
 
     // If the user has provided no query, gather a sampling of top zvalue members for every possible profile
     if (!req.query.query || req.query.query === "") {

--- a/packages/cms/src/utils/prepareProfile.js
+++ b/packages/cms/src/utils/prepareProfile.js
@@ -126,9 +126,12 @@ module.exports = (rawProfile, variables, formatterFunctions, locale, query = {})
   // where we want them to.
   profile.sections.forEach(section => {
     section.selectors.forEach(selector => {
-      const {name} = selector;
+      const {name, options} = selector;
+      const selections = query[name] !== undefined ? query[name].split(",") : false;
       // If the user provided a selector in the query, AND if it's actually an option
-      if (query[name] && selector.options.map(o => o.option).includes(query[name])) {
+      // However, remember that a multi-select with a blank query param is valid
+      const isBlankMulti = selector.type === "multi" && selections.length === 1 && selections[0] === "";
+      if (selections && (selections.every(sel => options.map(o => o.option).includes(sel)) || isBlankMulti)) {
         selector.default = query[name];
       }
     });


### PR DESCRIPTION
This commit fixes a messed up merge here:

https://github.com/Datawheel/canon/commit/56a2d0e22da47acb9a577e8dde452f04251be6f2

Two major situations:

#### mortarRoute

In the "no roundtrips" branch, `prepareProfile.js` was written to unify server and client side profile generation. Separately on master, some adjustments and bugfixes were made to mortarRoute directly, such as handling empty multiselects for CDC. This resulted in the doubling of the profile prep code, which has now been deduped.

#### searchRoute

A refactor on one branch made `rowToResult` a global function, but a refactor on another branch added `attr` to the payload for a feature request. This commit fixes the merge by adding the `attr` return to the now unified, global function.

I hope I got everything here.🤞 