### PR TITLE
[cms] adds warning to broken dropdowns

### DIFF
--- a/packages/cms/src/components/editors/VariableEditor.jsx
+++ b/packages/cms/src/components/editors/VariableEditor.jsx
@@ -349,6 +349,7 @@ class VariableEditor extends Component {
           {/* visibility */}
           {["generator", "materializer", "visualization"].includes(type) &&
             <VisibleSelector
+              type="generator"
               hideCustom={["generator", "materializer"].includes(type)}
               variables={["generator"].includes(type) ? magicVariables : variables}
               value={data.allowed !== undefined ? data.allowed : "always"}

--- a/packages/cms/src/components/interface/VisibleSelector.css
+++ b/packages/cms/src/components/interface/VisibleSelector.css
@@ -31,6 +31,22 @@
   }
 }
 
+.cms-visible-selector-group {
+  display: flex;
+}
+
+.cms-visible-icon {
+  padding-left: 10px;
+  padding-top: 10px;
+  filter: drop-shadow(4px 4px .25rem rgba(0, 0, 0, .3));
+}
+
+.cms-visible-popover {
+  opacity: 1;
+  width: 350px;
+  padding: 15px;
+}
+
 .cms-visible-selector-fieldset .cms-visible-selector-checkbox-label {
   display: block !important;
   margin-top: -0.5em;

--- a/packages/cms/src/profile/SectionEditor.jsx
+++ b/packages/cms/src/profile/SectionEditor.jsx
@@ -12,6 +12,7 @@ import TextButtonGroup from "../components/fields/TextButtonGroup";
 
 import Deck from "../components/interface/Deck";
 import Dialog from "../components/interface/Dialog";
+import VisibleSelector from "../components/interface/VisibleSelector";
 import PreviewHeader from "../components/interface/PreviewHeader";
 import SelectorUsage from "../components/interface/SelectorUsage";
 
@@ -193,16 +194,13 @@ class SectionEditor extends Component {
             />
 
             {/* visibility select */}
-            <Select
-              label="Visible"
-              namespace="cms"
-              fontSize="xs"
-              inline
-              value={minDataState.allowed || "always"}
+            <VisibleSelector
+              type="section"
+              variables={variables[localeDefault] || {}}
+              value={minDataState.allowed}
               onChange={this.changeField.bind(this, "allowed", true)}
-            >
-              {varOptions}
-            </Select>
+              hideCustom={true}
+            />
 
             {/* icon select */}
             <Select


### PR DESCRIPTION
Fixing this while passing through.

TextCards have advanced overrides for `allowed`, for custom string-based alloweds. There is no way here to catch for user error, as the user may have chosen to write `variableThatWontExistUntilSome[[Selector]]Happens` as their variable.

However, Generators and Sections do not currently support custom alloweds. They could, but in the interest of simplifying the interface, these top-level entities shouldn't need custom alloweds (famous last words?).

![image](https://user-images.githubusercontent.com/1714292/96044977-4cd9c200-0e3f-11eb-8b6f-5637f8fa7e41.png)
(Current allowed for sections - no custom)

This PR simply adds a text warning if the variable has been deleted out from underneath the allowed. Though this situation is possible/correct for advanced setups, I am simply trying to help new users avoid pitfalls with messages like this.

![image](https://user-images.githubusercontent.com/1714292/96045150-8e6a6d00-0e3f-11eb-95fc-40c3a296a80d.png)
