### PR TITLE
fixes IE dataAttachments

### DIFF
--- a/packages/cms/src/components/Viz/Options.jsx
+++ b/packages/cms/src/components/Viz/Options.jsx
@@ -129,18 +129,19 @@ class Options extends Component {
         requests.push(axios.get(url, {responseType: "blob"}));
       });
 
-      Promise.all(requests).then(responses => {
-        responses.forEach(response => {
-          if (response.status === 200 || response.status === 0) {
-            // Pull data, grab file name, and add to ZIP
-            const blob = new Blob([response.data], {type: response.data.type});
-            const dAName = response.request.responseURL.split("/").pop();
-            zip.file(`${dAName}`, blob, {binary: true});
-          }
-        });
-        zip.generateAsync({type: "blob"})
-          .then(content => saveAs(content, `${filename(title)}.zip`));
-      });
+      Promise.all(requests)
+        .then(responses => {
+          responses.forEach(response => {
+            if (response.status === 200 || response.status === 0) {
+              // Pull data, grab file name, and add to ZIP
+              const blob = new Blob([response.data], {type: response.data.type});
+              const dAName = response.config.url.split("/").pop();
+              zip.file(`${dAName}`, blob, {binary: true});
+            }
+          });
+          return zip.generateAsync({type: "blob"});
+        })
+        .then(content => saveAs(content, `${filename(title)}.zip`));
 
     }
     else {


### PR DESCRIPTION
The `dataAttachments` feature of visualizations, introduced in #1068, used `response.request.responseURL` to determine the filename of each attachment. The `responseURL` of the XMLHttpRequest spec is currently not supported in IE, resulting in an `undefined` error.

This PR switches the use of `responseURL` for `response.config.url`, which is more widely supported. I tested this in Chrome and IE 11, and can also confirm this fixes the problem in the CDC-PHA environment.