### PR TITLE
Issue 1095 redirects

### DIFF
--- a/examples/app/routes.jsx
+++ b/examples/app/routes.jsx
@@ -22,9 +22,9 @@ export default function RouteCreate() {
       <Route path="/cms" component={Builder} />
       <Route path="/login" component={Login} />
       <Route path="/signup" component={SignUp} />
-      <Route path="/profile/:slug/:id" component={Profile} />
-      <Route path="/profile/:slug/:id/:slug2/:id2" component={Profile} />
-      <Route path="/profile/:slug/:id/:slug2/:id2/:slug3/:id3" component={Profile} />
+      <Route path="/:lang/profile/:slug/:id" component={Profile} />
+      <Route path="/:lang/profile/:slug/:id(/:slug2)(/:id2)" component={Profile} />
+      <Route path="/:lang/profile/:slug/:id/:slug2/:id2/:slug3/:id3" component={Profile} />
 
       <Route path="*" component={Error} />
 

--- a/examples/app/routes.jsx
+++ b/examples/app/routes.jsx
@@ -23,7 +23,7 @@ export default function RouteCreate() {
       <Route path="/login" component={Login} />
       <Route path="/signup" component={SignUp} />
       <Route path="/:lang/profile/:slug/:id" component={Profile} />
-      <Route path="/:lang/profile/:slug/:id(/:slug2)(/:id2)" component={Profile} />
+      <Route path="/:lang/profile/:slug/:id/:slug2/:id2" component={Profile} />
       <Route path="/:lang/profile/:slug/:id/:slug2/:id2/:slug3/:id3" component={Profile} />
 
       <Route path="*" component={Error} />

--- a/packages/cms/src/api/mortarRoute.js
+++ b/packages/cms/src/api/mortarRoute.js
@@ -591,11 +591,16 @@ module.exports = function(app) {
         const originalDims = collate(req.query);
         const error = `Page request was made using ids [${originalDims.map(d => d.id).join()}]. Redirecting.`;
         if (verbose) console.log(error);
-        const redirectData = dims.reduce((acc, d, i) => acc.concat({
-          slug: d.slug,
-          memberSlug: foundMembers[i].slug
-        }), []);
-        return res.json({error, errorCode: 301, redirectData});
+        const canonRedirect = dims.reduce((acc, d, i) => {
+          if (i === 0) {
+            acc.slug = d.slug;
+            acc.id = foundMembers[i].slug;
+          }
+          acc[`slug${i + 1}`] = d.slug;
+          acc[`id${i + 1}`] = foundMembers[i].slug;
+          return acc;
+        }, {});
+        return res.json({error, errorCode: 301, canonRedirect});
       }
       // todo - catch for no neighbors ?
       returnObject.neighbors = [];

--- a/packages/cms/src/components/Profile.jsx
+++ b/packages/cms/src/components/Profile.jsx
@@ -27,8 +27,10 @@ class Profile extends Component {
     if (profile.error) {
       const {error, errorCode} = profile;
       if (errorCode === 301) {
-        const link = linkify(router, profile.redirectData, locale);
-        return <Redirect to={link} />;
+        // console.log("got", profile);
+        return <div>no</div>;
+        // const link = linkify(router, profile.redirectData, locale);
+        // return <Redirect to={link} />;
       }
       const errorMessages = {
         404: "Page Not Found"

--- a/packages/cms/src/components/Profile.jsx
+++ b/packages/cms/src/components/Profile.jsx
@@ -5,6 +5,8 @@ import {fetchData} from "@datawheel/canon-core";
 import PropTypes from "prop-types";
 import ProfileRenderer from "./ProfileRenderer";
 import {NonIdealState} from "@blueprintjs/core";
+import {Redirect} from "react-router";
+import linkify from "../utils/linkify";
 import "./Profile.css";
 
 class Profile extends Component {
@@ -20,10 +22,14 @@ class Profile extends Component {
   }
 
   render() {
-    const {profile, formatters, locale} = this.props;
+    const {profile, formatters, locale, router} = this.props;
 
     if (profile.error) {
       const {error, errorCode} = profile;
+      if (errorCode === 301) {
+        const link = linkify(router, profile.redirectData, locale);
+        return <Redirect to={link} />;
+      }
       const errorMessages = {
         404: "Page Not Found"
       };

--- a/packages/cms/src/components/Profile.jsx
+++ b/packages/cms/src/components/Profile.jsx
@@ -22,16 +22,10 @@ class Profile extends Component {
   }
 
   render() {
-    const {profile, formatters, locale, router} = this.props;
+    const {profile, formatters, locale} = this.props;
 
     if (profile.error) {
       const {error, errorCode} = profile;
-      if (errorCode === 301) {
-        // console.log("got", profile);
-        return <div>no</div>;
-        // const link = linkify(router, profile.redirectData, locale);
-        // return <Redirect to={link} />;
-      }
       const errorMessages = {
         404: "Page Not Found"
       };

--- a/packages/cms/src/components/Profile.jsx
+++ b/packages/cms/src/components/Profile.jsx
@@ -5,8 +5,6 @@ import {fetchData} from "@datawheel/canon-core";
 import PropTypes from "prop-types";
 import ProfileRenderer from "./ProfileRenderer";
 import {NonIdealState} from "@blueprintjs/core";
-import {Redirect} from "react-router";
-import linkify from "../utils/linkify";
 import "./Profile.css";
 
 class Profile extends Component {

--- a/packages/cms/src/utils/linkify.js
+++ b/packages/cms/src/utils/linkify.js
@@ -12,7 +12,7 @@ const extractProfiles = router => {
       const bLength = bPairs ? bPairs.length : 0;
       return bLength - aLength;
     });
-    profiles = [];  
+    profiles = [];
     // for each route in routes.jsx
     routes.forEach(route => {
       // turn its id/slug pattern into an array like ["/:slug/", ":id/", ":slug2/", ":id2"]
@@ -49,11 +49,11 @@ module.exports = (router, profile, locale = "en") => {
           .replace(reId, p.memberSlug ? p.memberSlug : p.id)
           .replace(/\:(lang|language|locale|lng)/g, locale);
       });
-      return link;  
+      return link;
     }
     else return "#";
   }
   else {
     return "#";
-  }  
+  }
 };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,6 +10,7 @@ Reusable React environment and components for creating visualization engines.
 * [Page Routing](#page-routing)
   * [Window Location](#window-location)
   * [Code Splitting](#code-splitting)
+  * [Custom Redirects](#custom-redirects)
 * [Hot Module Reloading](#hot-module-reloading)
 * [Redux Store](#redux-store)
 * [Localization](#localization)
@@ -203,6 +204,16 @@ const About = chunkify(/* #__LOADABLE__ */ () => import(/* webpackChunkName: "ab
 const Background = chunkify(/* #__LOADABLE__ */ () => import(/* webpackChunkName: "about" */ "./pages/docs/Background.jsx"));
 const Glossary = chunkify(/* #__LOADABLE__ */ () => import(/* webpackChunkName: "about" */ "./pages/docs/Glossary.jsx"));
 ```
+
+### Custom Redirects
+
+React Router v3 uses `routes.jsx` to organize page routing. Often, you will see pages routed using colons for params, such as `/page/:id`. This is especially true of the CMS, which uses `:slug` and `:id` in this fashion to match with the profile slug and the member id.
+
+Typically, redirects are handled by using router `<Redirect />` directly in `routes.jsx`, allowing for a permanent redirect of a static page. However, as many canon pages make use of `needs`, it may be necessary to process a dynamic redirect, determined by the results of the `need`.
+
+To make use of these custom redirects, ensure that your `need` returns an object that includes a specially named key: `canonRedirect`. In this key, place any NEW override variables you would like to use, keyed exactly as their appearance in the routes.jsx file (such as `:slug` or `:id`).
+
+This functionality is used by the CMS to redirect profiles from their numeric `id` (such as `25`) to their vanity slug (such as `Massachusetts`). When the profile route determines that the user has provided an `id`, it returns an object with a `canonRedirect` that provides the vanity slug via the `id` key. The custom redirect code then performs a `301` redirect, using the lookup object provided by `canonRedirect` to determine the new route.
 
 ---
 

--- a/packages/core/src/server.jsx
+++ b/packages/core/src/server.jsx
@@ -158,7 +158,7 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
                   const params = {...props.params, ...variables};
                   // Not sure if this is a reliable way to get which route this is.
                   let route = props.routes[1].path;
-                  Object.keys(params).forEach(key => {
+                  Object.keys(params).sort(a => (/\d/).test(a) ? -1 : 1).forEach(key => {
                     if (route.includes(`(/:${key})`)) {
                       route = route.replace(`(/:${key})`, params[key] ? `/${params[key]}` : "");
                     }

--- a/packages/core/src/server.jsx
+++ b/packages/core/src/server.jsx
@@ -147,9 +147,10 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
             preRenderMiddleware(store, newProps)
               .then(() => {
 
+                const initialState = store.getState();
                 // Needs may return a special canonRedirect key. If they do so, process a redirect, using the variables provided
                 // in those objects as variables to substitute in the routes.
-                const redirects = Object.values(store.getState().data).filter(d => d.canonRedirect);
+                const redirects = Object.values(initialState.data).filter(d => d.canonRedirect);
                 // If the query contains ?redirect=true, a redirect has already occurred. To avoid redirect loops, ensure this value is unset
                 if (!req.query.redirect && redirects.length > 0) {
                   // If any needs provided redirect keys, combine them into one object.
@@ -181,7 +182,6 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
                   .join("") : "";
 
                 let status = 200;
-                const initialState = store.getState();
                 for (const key in initialState.data) {
                   if ({}.hasOwnProperty.call(initialState.data, key)) {
                     const error = initialState.data[key] ? initialState.data[key].error : null;

--- a/packages/core/src/server.jsx
+++ b/packages/core/src/server.jsx
@@ -150,6 +150,7 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
                 // Needs may return a special canonRedirect key. If they do so, process a redirect, using the variables provided
                 // in those objects as variables to substitute in the routes.
                 const redirects = Object.values(store.getState().data).filter(d => d.canonRedirect);
+                // If the query contains ?redirect=true, a redirect has already occurred. To avoid redirect loops, ensure this value is unset
                 if (!req.query.redirect && redirects.length > 0) {
                   // If any needs provided redirect keys, combine them into one object.
                   const variables = redirects.reduce((acc, d) => ({...acc, ...d.canonRedirect}), {});

--- a/packages/core/src/server.jsx
+++ b/packages/core/src/server.jsx
@@ -159,13 +159,10 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
                   const params = {...props.params, ...variables};
                   // Not sure if this is a reliable way to get which route this is.
                   let route = props.routes[1].path;
+                  // Sort the keys to be "integers first," i.e., slug<int> before slug.
+                  // This ensures that the swaps are processed "outside-in" (descending), and ":slug" doesn't match INSIDE ":slug2"
                   Object.keys(params).sort(a => (/\d/).test(a) ? -1 : 1).forEach(key => {
-                    if (route.includes(`(/:${key})`)) {
-                      route = route.replace(`(/:${key})`, params[key] ? `/${params[key]}` : "");
-                    }
-                    else if (route.includes(`:${key}`)) {
-                      route = route.replace(`:${key}`, params[key]);
-                    }
+                    route = route.replace(new RegExp(`[(]{0,1}\/:${key}[)]{0,1}`), params[key] ? `/${params[key]}` : "");
                   });
                   // Pass a ?redirect flag, to avoid a redirect loop
                   return res.redirect(301, `${route}?redirect=true`);


### PR DESCRIPTION
Adds dynamic redirects to canon-core, and implements them automatically in the cms. This will require a minor release of both.

In Core, `needs` can now return a `canonRedirect` object, which contains values to swap in to the routes vars, such as `:slug` or `:id`. Docs are included in canon-core README.

In CMS, all profile ids now 301 permanent redirect to vanity slugs, making use of the above code. 

Closes #1095 