### PR TITLE
[cms] small bugfixes

### DIFF
--- a/packages/cms/src/components/editors/VisualizationEditorUI.jsx
+++ b/packages/cms/src/components/editors/VisualizationEditorUI.jsx
@@ -168,6 +168,10 @@ class VisualizationEditorUI extends Component {
         }
       }
 
+      if (key === "data" && configObject.data.length === 1) {
+        configObject.data = configObject.data[0];
+      }
+
     });
 
     keys.forEach(key => {
@@ -192,16 +196,19 @@ class VisualizationEditorUI extends Component {
     // To build the tooltip, filter our methods to only the methods with tooltip: true
     // and ignote any groupBy keys which are already handled with the label.
     const tooltipKeys = methods
-      .filter(method => method.tooltip)
+      .filter(method => method.tooltip && object[method.key] !== "manual-none")
       .filter(method => object.groupBy ? object[method.key] !== stripID(object.groupBy[object.groupBy.length - 1]) : true)
       .map(d => d.key);
 
+
     // Set the appropriate tbody label and function for all
     // keys in the tooltipKeys array.
-    periodStringParse("tooltipConfig.tbody", tooltipKeys.map(k => {
-      const formatter = object.formatters ? object.formatters[k] : null;
-      return [object[k], `d => ${formatter ? `formatters.${formatter}(d["${object[k]}"])` : `d["${object[k]}"]`}`];
-    }));
+    if (tooltipKeys.length) {
+      periodStringParse("tooltipConfig.tbody", tooltipKeys.map(k => {
+        const formatter = object.formatters ? object.formatters[k] : null;
+        return [object[k], `d => ${formatter ? `formatters.${formatter}(d["${object[k]}"])` : `d["${object[k]}"]`}`];
+      }));
+    }
 
     const newLine = d => "\n".padEnd(d * 2 + 1, " ");
     const stringifyObject = (obj, depth = 0) => {

--- a/packages/cms/src/components/sections/components/Selector.jsx
+++ b/packages/cms/src/components/sections/components/Selector.jsx
@@ -115,7 +115,7 @@ class Selector extends Component {
       }
 
       // options under selectCutoff; button group
-      if (options.length <= selectCutoff) {
+      if (options.length <= selectCutoff && options.every(b => stripHTML(b.label || variables[b.option]).length < 40)) {
         return <ButtonGroup label={title} className="cp-selector-button-group" fontSize={fontSize}>
           {(print ? options.filter(b => b.option === activeValue) : options).map(b =>
             <Button

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -199,7 +199,7 @@
     &.is-fixed {
       position: fixed;
       z-index: 2;
-      top: var(--subnav-height);
+      top: var(--nav-height);
       height: var(--subnav-height);
       background-color: var(--hero-bg-color);
       box-shadow: 0 1px 0.25rem color(var(--black) a(0.333));


### PR DESCRIPTION
 - fixes bug with single length data vizzes in new simple-ui (7a07e89)
 - fixes "manual-none" appearing in tooltip tbody in new simple-ui (7a07e89)
 - adds string length cutoff to Selector radio/select switch, when any option is over 40 characters long, it switches the whole thing to a `<select>` (8d840db)
 - fixes incorrect Subnav top placement on scroll (b7a4e82)