### PR TITLE
[vizbuilder] fixes big list of datasets on undefined table

### DIFF
--- a/packages/vizbuilder/src/store/cubes/selectors.js
+++ b/packages/vizbuilder/src/store/cubes/selectors.js
@@ -96,6 +96,8 @@ export const selectMeasureMap = createSelector(selectMeasureList, measures =>
  * for each table name.
  * @returns {Record<string, MeasureItem[]>}
  */
-export const selectMeasureMapByTable = createSelector(selectMeasureList, measures =>
-  groupBy(measures, measure => measure.tableId)
-);
+export const selectMeasureMapByTable = createSelector(selectMeasureList, measures => {
+  const dict = groupBy(measures, measure => measure.tableId);
+  dict.undefined = [];
+  return dict;
+});

--- a/packages/vizbuilder/src/store/query/selectors.js
+++ b/packages/vizbuilder/src/store/query/selectors.js
@@ -81,7 +81,7 @@ export const selectCube = createSelector(
 export const selectMeasureListForTable = createSelector(
   [selectMeasure, selectMeasureMapByTable],
   (measure, tableMeasureMap) =>
-    measure ? tableMeasureMap[`${measure.tableId}`] || [] : []
+    measure && measure.tableId ? tableMeasureMap[`${measure.tableId}`] || [] : []
 );
 
 /**


### PR DESCRIPTION
The issue was caused because the list of measures by tableName was being grouped directly using the property value, and all measures without it were being grouped on a `undefined` table.

Closes #1148