### PR TITLE
fixes d3plus nested dataFormat usage

### DIFF
--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -148,7 +148,6 @@ class Viz extends Component {
               let data;
               try {
                 data = vizProps.dataFormat(resp);
-                if (typeof data === "object" && !(data instanceof Array)) data = data.data || [];
               }
               catch (e) {
                 console.log("Error in dataFormat: ", e);


### PR DESCRIPTION
This 1 line is what was interfering with DataPerú's custom Sankey implementation, which returns nodes and links from the dataFormat function. That complex return object (containing a d3plus "data" key and nodes/links keys) was getting incorrectly flagged here as a Tesseract formatted data object (containing "data" and "source" keys).

The d3plus internal data loading logic has sort of leapfrogged this CMS catch in terms of intelligence detecting URLs, so by simply removing this we just lean on the d3plus internals (tested with the giant DataPeru geo profile).