### PR TITLE
fixes keyboard navigation for subsequent Options panel open/close

### DIFF
--- a/packages/cms/src/components/Viz/Options.jsx
+++ b/packages/cms/src/components/Viz/Options.jsx
@@ -78,18 +78,6 @@ class Options extends Component {
     }
   }
 
-  listenForBlur() {
-    select(document).on("keydown", () =>
-      setTimeout(() => {
-        if (this.state.dialogOpen) {
-          if (document.activeElement.matches(".cp-section-heading") || document.activeElement.matches(".options-button")) {
-            this.setState({dialogOpen: false});
-          }
-        }
-      }, 20)
-    );
-  }
-
   onCSV() {
     const {title, dataAttachments} = this.props;
     const {results} = this.state;
@@ -299,7 +287,6 @@ class Options extends Component {
     }
 
     this.setState({dialogOpen: slug});
-    this.listenForBlur();
     const {results, loading} = this.state;
 
     if (slug === "view-table" && !results && !loading) {


### PR DESCRIPTION
A bug was found in PHLIP (and reproducable in the canon example app) where:
- keyboard tab navigation to highlight a Tab in Option.jsx
- press return to open the Dialog
- press esc to close the Dialog
- any subsequent return press causes the Dialog to quickly open/close

I'm really not sure why this blur function was added, but removing it solves this issue. 😅 