### PR TITLE
Adds per-route HTTP status code support

### DIFF
--- a/examples/app/routes.jsx
+++ b/examples/app/routes.jsx
@@ -27,7 +27,7 @@ export default function RouteCreate() {
       <Route path="/:lang/profile/:slug/:id/:slug2/:id2/:slug3/:id3" component={Profile} />
       <Route path="/:lang/profilesearch" component={ProfileSearch} />
 
-      <Route path="*" component={Error} />
+      <Route path="*" component={Error} status={404} />
 
     </Route>
   );

--- a/examples/package.json
+++ b/examples/package.json
@@ -22,7 +22,7 @@
     "@datawheel/canon-cms": "workspace:*",
     "@datawheel/canon-core": "workspace:*",
     "@datawheel/canon-logiclayer": "*",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "d3plus-react": "^1.0.0",
     "d3plus-text": "^1.0.1",
     "d3plus-viz": "^1.0.3",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -47,7 +47,7 @@
     "@datawheel/olap-client": "^2.0.0-alpha.2",
     "@google-cloud/storage": "5.3.0",
     "@google-cloud/translate": "^6.0.3",
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "base58": "^2.0.1",
     "brace": "^0.11.1",
     "buble": "^0.19.3",
@@ -87,11 +87,11 @@
     "sharp": "^0.25.3"
   },
   "devDependencies": {
-    "@datawheel/canon-core": "workspace:^0.20.0",
-    "@datawheel/canon-logiclayer": "workspace:^0.4.0"
+    "@datawheel/canon-core": "workspace:^0.21.0",
+    "@datawheel/canon-logiclayer": "workspace:^0.5.0"
   },
   "peerDependencies": {
-    "@datawheel/canon-core": "^0.19.3"
+    "@datawheel/canon-core": "^0.21.0"
   },
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "@loadable/webpack-plugin": "^5.13.0",
     "@nuxtjs/friendly-errors-webpack-plugin": "^2.1.0",
     "@researchgate/react-intersection-observer": "^1.2.0",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.1.0",
     "bcrypt-nodejs": "0.0.3",

--- a/packages/core/src/server.jsx
+++ b/packages/core/src/server.jsx
@@ -127,6 +127,11 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
       if (err) res.status(500).json(err);
       else if (redirect) res.redirect(302, `${redirect.basename}${redirect.pathname}${redirect.hash}${redirect.search}`);
       else if (props) {
+        // get the `status` property for the last matched route
+        const routeStatus = props.routes
+          .map(route => route.status * 1)
+          .filter(code => !isNaN(code) && code > 200)
+          .pop();
 
         // detects components wrapped in @loadable/component,
         // and forces the load in order to detect needs
@@ -174,6 +179,10 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
                     const error = initialState.data[key] ? initialState.data[key].error : null;
                     if (error && typeof error === "number" && error > status) status = error;
                   }
+                }
+                // eslint-disable-next-line eqeqeq
+                if (routeStatus != null) {
+                  status = routeStatus;
                 }
 
                 let jsx;

--- a/packages/logiclayer/package.json
+++ b/packages/logiclayer/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.28.1",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "d3-array": "^2.11.0",
     "d3-collection": "^1.0.4",
     "d3plus-common": "^1.0.2",
@@ -25,10 +25,10 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@datawheel/canon-core": "workspace:^0.20.0"
+    "@datawheel/canon-core": "workspace:^0.21.0"
   },
   "peerDependencies": {
-    "@datawheel/canon-core": "^0.18.15"
+    "@datawheel/canon-core": "^0.21.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vizbuilder/package.json
+++ b/packages/vizbuilder/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@blueprintjs/core": "^3.22.3",
     "@blueprintjs/select": "^3.11.0",
-    "@datawheel/canon-core": "workspace:^0.20.0",
+    "@datawheel/canon-core": "workspace:^0.21.0",
     "@types/i18next": "^12.1.0",
     "@types/react-router": "^3.0.20",
     "lodash": "^4.17.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       '@datawheel/canon-cms': link:../packages/cms
       '@datawheel/canon-core': link:../packages/core
       '@datawheel/canon-logiclayer': link:../packages/logiclayer
-      axios: 0.19.2
+      axios: 0.21.1
       d3plus-react: 1.0.0_prop-types@15.7.2+react@16.14.0
       d3plus-text: 1.0.1
       d3plus-viz: 1.0.3
@@ -27,7 +27,7 @@ importers:
       '@datawheel/canon-cms': workspace:*
       '@datawheel/canon-core': workspace:*
       '@datawheel/canon-logiclayer': '*'
-      axios: ^0.19.2
+      axios: ^0.21.1
       d3plus-react: ^1.0.0
       d3plus-text: ^1.0.1
       d3plus-viz: ^1.0.3
@@ -41,7 +41,7 @@ importers:
       '@datawheel/olap-client': 2.0.0-alpha.4
       '@google-cloud/storage': 5.3.0
       '@google-cloud/translate': 6.1.0
-      axios: 0.18.1
+      axios: 0.21.1
       base58: 2.0.1
       brace: 0.11.1
       buble: 0.19.8
@@ -86,12 +86,12 @@ importers:
       '@blueprintjs/core': ^3.38.1
       '@blueprintjs/datetime': ^3.18.1
       '@blueprintjs/select': ^3.13.2
-      '@datawheel/canon-core': workspace:^0.20.0
-      '@datawheel/canon-logiclayer': workspace:^0.4.0
+      '@datawheel/canon-core': workspace:^0.21.0
+      '@datawheel/canon-logiclayer': workspace:^0.5.0
       '@datawheel/olap-client': ^2.0.0-alpha.2
       '@google-cloud/storage': 5.3.0
       '@google-cloud/translate': ^6.0.3
-      axios: ^0.18.0
+      axios: ^0.21.1
       base58: ^2.0.1
       brace: ^0.11.1
       buble: ^0.19.3
@@ -162,7 +162,7 @@ importers:
       '@loadable/webpack-plugin': 5.14.2_webpack@4.44.2
       '@nuxtjs/friendly-errors-webpack-plugin': 2.1.0_webpack@4.44.2
       '@researchgate/react-intersection-observer': 1.3.5_react-dom@16.13.1+react@16.13.1
-      axios: 0.19.2
+      axios: 0.21.1
       babel-eslint: 10.1.0
       babel-loader: 8.2.2_c31febe7af0b4cc47a0ace1c9cf75f8a
       bcrypt-nodejs: 0.0.3
@@ -285,7 +285,7 @@ importers:
       '@loadable/webpack-plugin': ^5.13.0
       '@nuxtjs/friendly-errors-webpack-plugin': ^2.1.0
       '@researchgate/react-intersection-observer': ^1.2.0
-      axios: ^0.19.2
+      axios: ^0.21.1
       babel-eslint: ^10.0.3
       babel-loader: ^8.1.0
       bcrypt-nodejs: 0.0.3
@@ -379,7 +379,7 @@ importers:
   packages/logiclayer:
     dependencies:
       '@blueprintjs/core': 3.38.2
-      axios: 0.19.2
+      axios: 0.21.1
       d3-array: 2.11.0
       d3-collection: 1.0.7
       d3plus-common: 1.0.2
@@ -391,8 +391,8 @@ importers:
       '@datawheel/canon-core': link:../core
     specifiers:
       '@blueprintjs/core': ^3.28.1
-      '@datawheel/canon-core': workspace:^0.20.0
-      axios: ^0.19.2
+      '@datawheel/canon-core': workspace:^0.21.0
+      axios: ^0.21.1
       d3-array: ^2.11.0
       d3-collection: ^1.0.4
       d3plus-common: ^1.0.2
@@ -427,7 +427,7 @@ importers:
     specifiers:
       '@blueprintjs/core': ^3.22.3
       '@blueprintjs/select': ^3.11.0
-      '@datawheel/canon-core': workspace:^0.20.0
+      '@datawheel/canon-core': workspace:^0.21.0
       '@datawheel/olap-client': ^1.3.2
       '@types/i18next': ^12.1.0
       '@types/react-router': ^3.0.20
@@ -2901,6 +2901,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  /axios/0.21.1:
+    dependencies:
+      follow-redirects: 1.13.2
+    dev: false
+    resolution:
+      integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   /babel-eslint/10.1.0:
     dependencies:
       '@babel/code-frame': 7.12.13
@@ -6163,6 +6169,17 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ahhGVAOmiYx6MkVmqgQJggukSgc=
+  /follow-redirects/1.13.2:
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
   /follow-redirects/1.5.10:
     dependencies:
       debug: 3.1.0


### PR DESCRIPTION
This PR enables setting a `status` property in a `<Route />` tag, to use that status code as the HTTP status code returned by the server when that route matches.
Should be used by default to set a 404 status code in match-all `NotFound` components.

Closes #1167 