### PR TITLE
adds SubGrouping section type and SubNav behavior

### DIFF
--- a/examples/api/cmsTestRoute.js
+++ b/examples/api/cmsTestRoute.js
@@ -10,7 +10,7 @@ module.exports = function(app) {
       {id: "beta",  x: 6, y: 13}
     ]}).end();
   });
-  
+
   app.get("/api/test2", (req, res) => {
     res.json({data: [
       {uid: "3123", name: "jimmy", x: 13},
@@ -20,31 +20,31 @@ module.exports = function(app) {
     ]}).end();
   });
 
-  app.post("/api/cms/customAttributes/:pid", async(req, res) => {
-    const pid = parseInt(req.params.pid, 10); // eslint-disable-line
-    const {variables, locale} = req.body; // eslint-disable-line
-    const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables; // eslint-disable-line
-    /**
-     * Make axios calls and return your compiled data as a single JS Object.
-     */
+  // app.post("/api/cms/customAttributes/:pid", async(req, res) => {
+  //   const pid = parseInt(req.params.pid, 10); // eslint-disable-line
+  //   const {variables, locale} = req.body; // eslint-disable-line
+  //   const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables; // eslint-disable-line
+  //   /**
+  //    * Make axios calls and return your compiled data as a single JS Object.
+  //    */
 
-    return res.json({
-      iAmMassachusetts: name1 === "Massachusetts" ? true : false
-    });
-    
-    /*
-    if (pid === 49) {
-      return res.json({
-        capName: name1.toUpperCase()
-      });
-    }
+  //   return res.json({
+  //     iAmMassachusetts: name1 === "Massachusetts" ? true : false
+  //   });
 
-    if (pid === 2) {
-      // await new Promise(r => setTimeout(r, 5000));
-      return res.json({});
-    }
-    else return res.json({});
-    */
-  });
+  //   /*
+  //   if (pid === 49) {
+  //     return res.json({
+  //       capName: name1.toUpperCase()
+  //     });
+  //   }
+
+  //   if (pid === 2) {
+  //     // await new Promise(r => setTimeout(r, 5000));
+  //     return res.json({});
+  //   }
+  //   else return res.json({});
+  //   */
+  // });
 
 };

--- a/examples/api/customAttributes.js
+++ b/examples/api/customAttributes.js
@@ -1,0 +1,190 @@
+const axios = require("axios");
+const yn = require("yn");
+const {CANON_CONST_BASE} = process.env;
+const verbose = yn(process.env.CANON_CMS_LOGGING);
+const BASE_API = `${CANON_CONST_BASE}data.jsonrecords`;
+
+const catcher = error => {
+  if (verbose) console.error("Custom Attribute Error:", error);
+  return [];
+};
+module.exports = function(app) {
+
+  app.post("/api/cms/customAttributes/:pid", async(req, res) => {
+    const pid = req.params.pid * 1;
+    const {cache} = app.settings;
+    const {variables, locale} = req.body;
+    const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, parents1} = variables;
+
+    switch (pid) {
+      // Geo profile
+      case 1:
+        const isNation = hierarchy1 === "Nacion" ? true : false;
+        const isDepartment = hierarchy1 === "Departamento" ? true : false;
+        const isProvince = hierarchy1 === "Provincia" ? true : false;
+        const isDistrict = hierarchy1 === "Distrito" ? true : false;
+
+        const isNationOrDepartment = ["Nacion", "Departamento"].includes(hierarchy1) ? true : false;
+        const isNationOrProvince = ["Nacion", "Provincia"].includes(hierarchy1) ? true : false;
+        const isNationOrDepartmentOrProvince = ["Nacion", "Departamento", "Provincia"].includes(hierarchy1) ? true : false;
+        const isDepartmentOrProvince = ["Departamento", "Provincia"].includes(hierarchy1) ? true : false;
+
+        return res.json({
+          isNation,
+          isDepartment,
+          isProvince,
+          isDistrict,
+          isNationOrDepartment,
+          isNationOrProvince,
+          isNationOrDepartmentOrProvince,
+          isDepartmentOrProvince
+        });
+
+        // CITE profile
+
+      case 4:
+        const citeParams = {
+          cube: "dimension_cite",
+          drilldowns: "CITE",
+          measures: "Variable conteo",
+          properties: "Categoria",
+          [hierarchy1]: id1
+        };
+
+        const citeData = await axios
+          .get(BASE_API, {params: citeParams})
+          .then(resp => resp.data.data)
+          .catch(catcher);
+
+        const citeCategory = citeData[0].Categoria;
+        const isPublicCite = citeCategory === "público" ? true : false;
+        const isPrivateCite = !isPublicCite;
+
+        const citeAgroindustrialParams = {
+          cube: "itp_cite_mercado_interno_agroindustrial",
+          drilldowns: "CITE",
+          measures: "Produccion"
+        };
+
+        const citeCamelidoParams = {
+          cube: "itp_cite_mercado_interno_camelido",
+          drilldowns: "CITE",
+          measures: "Produccion"
+        };
+
+        const citeCueroCalzadoParams = {
+          cube: "itp_cite_mercado_interno_cuero",
+          drilldowns: "CITE",
+          measures: "Produccion"
+        };
+
+        const citePesqueroParams = {
+          cube: "itp_cite_mercado_interno_pesquero",
+          drilldowns: "CITE",
+          measures: "Desembarque"
+        };
+
+        const isAgroindustrialOrProductiveCite = await axios
+          .get(BASE_API, {params: citeAgroindustrialParams})
+          .then(resp => {
+            const data = resp.data.data;
+
+            const citeList = data.map(d => d["CITE ID"]);
+            const isAgroindustrialOrProductiveCite = citeList.includes(id1 * 1) ? true : false;
+
+            return isAgroindustrialOrProductiveCite;
+          })
+          .catch(catcher);
+
+        const isCamelido = await axios
+          .get(BASE_API, {params: citeCamelidoParams})
+          .then(resp => {
+            const data = resp.data.data;
+
+            const citeList = data.map(d => d["CITE ID"]);
+            const isCamelido = citeList.includes(id1 * 1) ? true : false;
+
+            return isCamelido;
+          })
+          .catch(catcher);
+
+
+        const isCueroYCalzado = await axios
+          .get(BASE_API, {params: citeCueroCalzadoParams})
+          .then(resp => {
+            const data = resp.data.data;
+
+            const citeList = data.map(d => d["CITE ID"]);
+            const isCueroYCalzado = citeList.includes(id1 * 1) ? true : false;
+
+            return isCueroYCalzado;
+          })
+          .catch(catcher);
+
+        const isPesquero = await axios
+          .get(BASE_API, {params: citePesqueroParams})
+          .then(resp => {
+            const data = resp.data.data;
+
+            const citeList = data.map(d => d["CITE ID"]);
+            const isPesquero = citeList.includes(id1 * 1) ? true : false;
+
+            return isPesquero;
+          })
+          .catch(catcher);
+
+        return res.json({
+          citeCategory,
+          isPublicCite,
+          isPrivateCite,
+          isAgroindustrialOrProductiveCite,
+          isCamelido,
+          isCueroYCalzado,
+          isPesquero
+        });
+
+      // Industry profile
+      case 5:
+        const industryDictionary = {
+          A: 1,
+          B: 2,
+          C: 3,
+          D: 4,
+          F: 5,
+          G: 6,
+          H: 7,
+          S: 8
+        };
+
+        const enaveIndustryDictionary = {
+          A: 1,
+          G: 2,
+          J: 3,
+          F: 4,
+          D: 5,
+          K: 6,
+          I: 7,
+          C: 8,
+          B: 9,
+          S: 10,
+          H: 11
+        };
+
+        const customHierarchy = "Industria";
+        const customId = industryDictionary[id1] || false;
+
+        const enaveHierarchy = "Industria";
+        const enaveId = enaveIndustryDictionary[id1] || false;
+
+        return res.json({
+          customHierarchy,
+          customId,
+          enaveHierarchy,
+          enaveId
+        });
+
+      default:
+        return res.json({});
+    }
+  });
+};

--- a/examples/api/proxy.js
+++ b/examples/api/proxy.js
@@ -3,6 +3,7 @@ const axios = require("axios"),
       url = require("url");
 
 const {
+  CANON_CMS_CUBES,
   OLAP_PROXY_ENDPOINT,
   OLAP_PROXY_SECRET
 } = process.env;
@@ -82,6 +83,26 @@ module.exports = function(app) {
     };
 
     res.json(config);
+
+  });
+
+  app.get("/api/*", async(req, res) => {
+
+    const params = req.params[0];
+    const baseURL = url.resolve(CANON_CMS_CUBES, params);
+    const queryString = url.parse(req.url).query;
+    const fullURL = queryString ? `${baseURL}?${queryString}` : baseURL;
+
+    const data = await axios.get(fullURL)
+      .then(resp => resp.data)
+      .catch(error => {
+        const {response} = error;
+        const errorObject = Object.assign({}, response, {request: undefined});
+        res.status(response.status);
+        return errorObject;
+      });
+
+    res.send(data).end();
 
   });
 

--- a/examples/app/style.yml
+++ b/examples/app/style.yml
@@ -80,7 +80,7 @@ body-font-scale-xl:         "125%"   # 1rem = 20px (min-width: 1400px)
 
 # measurements
 nav-height:                 "50px"
-subnav-height:              "var(--nav-height)"
+subnav-height:              "100px"
 container-width:            "80rem" # 1280px
 hero-container-width:       "var(--container-width)"
 

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -196,6 +196,7 @@ class ProfileRenderer extends Component {
     sections.forEach(l => {
       if (l.type === "TextViz" || l.position === "sticky") l.type = "Default";
       if (l.type === "Column") l.type = "SingleColumn";
+      if (!l.slug) l.slug = `section-${l.id}`;
     });
 
     const groupableSections = ["SingleColumn"].concat(Object.keys(CustomSections)); // sections to be grouped together

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -313,7 +313,11 @@ class ProfileRenderer extends Component {
                   ? <Section
                     contents={innerGrouping[0]}
                     onSetVariables={this.onSetVariables.bind(this)}
-                    headingLevel={groupedSections.length === 1 || ii === 0 ? "h2" : "h3"}
+                    headingLevel={groupedSections.length === 1 || ii === 0
+                      ? "h2"
+                      : groupings.find(g => g[0].type.toLowerCase() === "subgrouping") &&
+                        innerGrouping[0].type.toLowerCase() !== "subgrouping" ? "h4"
+                        : "h3"}
                     loading={loading}
                     key={`${innerGrouping[0].slug}-${ii}`}
                     {...hideElements}
@@ -325,9 +329,10 @@ class ProfileRenderer extends Component {
                         contents={section}
                         onSetVariables={this.onSetVariables.bind(this)}
                         headingLevel={groupedSections.length === 1 || ii === 0
-                          ? iii === 0 ? "h2" : "h3"
-                          : "h4"
-                        }
+                          ? "h2"
+                          : groupings.find(g => g[0].type.toLowerCase() === "subgrouping") &&
+                            innerGrouping[0].type.toLowerCase() !== "subgrouping" ? "h4"
+                            : "h3"}
                         loading={loading}
                         key={`${section.slug}-${iii}`}
                         {...hideElements}

--- a/packages/cms/src/components/interface/Outline.css
+++ b/packages/cms/src/components/interface/Outline.css
@@ -47,7 +47,11 @@
   /* sizing */
   @mixin font-xs;
   display: block;
+  max-width: 300px;
   padding: 0.875em var(--gutter-md);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   /* theming */
   @mixin cms-nav-link-theme;
   transition:

--- a/packages/cms/src/components/sections/Section.jsx
+++ b/packages/cms/src/components/sections/Section.jsx
@@ -21,6 +21,7 @@ import Selector from "./components/Selector";
 
 import Default from "./Default";
 import Grouping from "./Grouping";
+import SubGrouping from "./SubGrouping";
 import MultiColumn from "./MultiColumn";
 import SingleColumn from "./SingleColumn";
 import Tabs from "./Tabs";
@@ -30,7 +31,7 @@ import * as CustomSections from "CustomSections";
 
 // used to construct component
 // NOTE: should be every Component in `components/sections/` except for Section (i.e., this component) and Hero (always rendered separately)
-const sectionTypes = {Default, Grouping, MultiColumn, SingleColumn, Tabs, ...CustomSections};
+const sectionTypes = {Default, Grouping, SubGrouping, MultiColumn, SingleColumn, Tabs, ...CustomSections};
 
 /** wrapper for all sections */
 class Section extends Component {

--- a/packages/cms/src/components/sections/SubGrouping.jsx
+++ b/packages/cms/src/components/sections/SubGrouping.jsx
@@ -1,0 +1,2 @@
+import Grouping from "./Grouping.jsx";
+export default class SubGrouping extends Grouping {}

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -25,14 +25,7 @@
   transition: transform 0.1s ease-out;
 }
 
-/* base theming from hero vars */
-.cp-subnav-link {
-  position: relative; /* contain the "border" */
-  color: var(--hero-text-color);
-  opacity: 0.75;
-  transition:
-    color 0.2s ease-out,
-    opacity 0.2s ease-out;
+.cp-subnav-item {
 
   /* "border" */
   &:after {
@@ -51,6 +44,31 @@
     transition: background-color 0.3s ease-out;
   }
 
+  /* current section */
+  &.is-active {
+
+    & .cp-subnav-link {
+      color: var(--accent);
+      opacity: 1;
+    }
+
+    &:after {
+      background-color: var(--accent);
+    }
+
+  }
+
+}
+
+/* base theming from hero vars */
+.cp-subnav-link {
+  position: relative; /* contain the "border" */
+  color: var(--hero-text-color);
+  opacity: 0.75;
+  transition:
+    color 0.2s ease-out,
+    opacity 0.2s ease-out;
+
   /* interactions */
   &:hover, &:focus {
     color: var(--hero-heading-color);
@@ -59,16 +77,6 @@
 
     & .cp-subnav-link-icon {
       transform: scale(1.125);
-    }
-  }
-
-  /* current section */
-  &.is-active {
-    color: var(--accent);
-    opacity: 1;
-
-    &:after {
-      background-color: var(--accent);
     }
   }
 
@@ -89,8 +97,9 @@
   /* position below nav bar on non-small screens */
   @mixin min-sm {
     /* positioning */
+    left: 0;
     position: absolute;
-    top: var(--subnav-height);
+    top: 100%;
   }
 
   /* hidden state */
@@ -191,6 +200,9 @@
 /* horizontal layout on big screens */
 @mixin min-sm {
   .cp-subnav {
+    display: flex;
+    flex-direction: column;
+    height: var(--subnav-height);
     padding: 0;
     top: calc(0px - var(--subnav-height));
     width: 100%;
@@ -207,30 +219,39 @@
 
     /* overflow list */
     & .cp-subnav-list {
-      height: var(--subnav-height);
+      align-items: stretch;
       display: flex;
+      flex: 1 1 auto;
+      justify-content: center;
       margin-left: 0;
       padding: 0 var(--gutter-sm);
-      margin-right: var(--gutter-sm);
       overflow: visible;
+      &.cp-subnav-secondary {
+        background-color: var(--dark-2);
+        & .cp-subnav-link {
+          color: var(--light-3);
+        }
+      }
     }
 
     /* equally spaced items where possible */
     & .cp-subnav-item {
-      flex: 1 0 auto;
+      align-items: center;
+      display: flex;
+      justify-content: center;
       position: relative;
       text-align: center;
 
-      /* prevent the rightmost menu item from getting cropped off the page */
-      &:last-of-type:hover .cp-subnav-group-list,
-      &:last-of-type .cp-subnav-group-list {
+      /* prevent the rightmost dropdown menu item, if 4 or more items, from getting cropped off the page */
+      &:last-of-type:hover:nth-child(n+4) .cp-subnav-group-list,
+      &:last-of-type:nth-child(n+4) .cp-subnav-group-list {
+        left: auto;
         right: 0;
       }
     }
 
     /* links fill the subnav height */
     & .cp-subnav-link {
-      line-height: var(--subnav-height);
       padding: 0 var(--gutter-sm);
     }
 

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -90,7 +90,7 @@
   @mixin min-sm {
     /* positioning */
     position: absolute;
-    top: var(--nav-height);
+    top: var(--subnav-height);
   }
 
   /* hidden state */

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -231,6 +231,14 @@
         & .cp-subnav-link {
           color: var(--light-3);
         }
+        & .cp-subnav-item.is-active {
+          &:after {
+            content: none;
+          }
+          & .cp-subnav-link {
+            color: var(--white);
+          }
+        }
       }
     }
 

--- a/packages/cms/src/components/sections/components/Subnav.jsx
+++ b/packages/cms/src/components/sections/components/Subnav.jsx
@@ -20,12 +20,15 @@ class Subnav extends Component {
 
   constructor(props) {
     super(props);
+    const sections = this.flattenSections(props.sections);
     this.state = {
       currSection: false,
+      currSubSection: false,
+      hasSubgroups: sections.some(s => s.children && s.children.some(c => c.children)),
       isOpen: false,
       top: false,
       fixed: false,
-      sections: this.flattenSections(props.sections)
+      sections
     };
     this.subnav = React.createRef();
     this.scrollBind = this.handleScroll.bind(this);
@@ -79,7 +82,24 @@ class Subnav extends Component {
       // we got groupings
       else {
         flattenedSections = sections
-          .map(s => ({...s[0][0], children: merge(s.slice(1))}))
+          .map(s => {
+            const subgroups = s.filter(d => d[0].type.toLowerCase() === "subgrouping");
+            let children = merge(subgroups.length ? subgroups : s.slice(1));
+            if (subgroups.length) {
+              children = children.map(subgroup => {
+                const obj = {...subgroup};
+                obj.children = [];
+                const currIndex = s.findIndex(d => d[0].id === obj.id);
+                for (let i = currIndex + 1; i < s.length; i++) {
+                  if (s[i][0].type.toLowerCase() === "subgrouping") break;
+                  obj.children.push(s[i]);
+                }
+                obj.children = merge(obj.children);
+                return obj;
+              });
+            }
+            return {...s[0][0], children};
+          })
           .filter(s => s.type.toLowerCase() === "grouping"); // only show groupings
       }
     }
@@ -89,8 +109,9 @@ class Subnav extends Component {
 
   /** crawl up the tree from the title and grab the section wrapper */
   getSectionWrapper(slug) {
-    const section = document.getElementById(slug);
-    return section ? section.parentNode.parentNode.parentNode : false;
+    let elem = document.getElementById(slug);
+    while (elem.className && !elem.className.includes("cp-section ") && elem.parentNode) elem = elem.parentNode;
+    return elem;
   }
 
   /** on scroll, determine whether subnav is fixed, and which section we're in */
@@ -100,7 +121,8 @@ class Subnav extends Component {
     if (sections) {
       throttle(() => {
         const {currSection, fixed} = this.state;
-        const screenTop = window.pageYOffset + pxToInt(styles["nav-height"] || "50px") * 2;
+        const topBorder = pxToInt(styles["nav-height"] || "50px") + pxToInt(styles["subnav-height"] || "50px");
+        const screenTop = window.pageYOffset + topBorder;
         const heroHeight = document.querySelector(".cp-hero").getBoundingClientRect().height;
 
         // determine whether subnav is fixed
@@ -112,27 +134,54 @@ class Subnav extends Component {
         }
 
         // deteremine which section we're in
-        let newSection = false;
+        let newSection = false, newSubSection = false;
         sections.forEach(section => {
           const elem = this.getSectionWrapper(section.slug);
           const top = elem ? elem.getBoundingClientRect().top : 1;
-          if (top <= pxToInt(styles["nav-height"] || "50px") * 2) {
+          if (top <= topBorder) {
             newSection = section;
           }
         });
 
+        if (newSection && newSection.children) {
+          newSection.children.forEach(section => {
+            const elem = this.getSectionWrapper(section.slug);
+            const top = elem ? elem.getBoundingClientRect().top : 1;
+            if (top <= topBorder) {
+              newSubSection = section;
+            }
+          });
+        }
+
         // update state only when changes detected
         if (currSection !== newSection) {
-          this.setState({currSection: newSection});
+          this.setState({currSection: newSection, currSubSection: newSubSection});
         }
       }, 30);
     }
   }
 
+  renderPopup(section) {
+    const {isOpen} = this.state;
+    return <ul className={`cp-subnav-group-list ${isOpen ? "is-open" : "is-closed"}`}>
+      { section.children.map(child =>
+        <li key={child.id} className="cp-subnav-group-item">
+          <AnchorLink
+            className="cp-subnav-group-link u-font-xs"
+            to={child.slug}
+          >
+            <Icon className="cp-subnav-group-link-icon" icon={child.icon && blueprintIcons.find(i => i === child.icon) ? child.icon : "dot"} />
+            {child.short && stripHTML(child.short) ? stripHTML(child.short) : stripHTML(child.title)}
+          </AnchorLink>
+        </li>
+      ) }
+    </ul>;
+  }
+
   render() {
     if (this.context.print) return null;
     const {children} = this.props;
-    const {currSection, fixed, isOpen, sections} = this.state;
+    const {currSection, currSubSection, fixed, hasSubgroups, isOpen, sections} = this.state;
 
     if (!sections || !Array.isArray(sections) || sections.length < 2) return null;
 
@@ -148,6 +197,31 @@ class Subnav extends Component {
 
           {sections.length ? <ol className="cp-subnav-list" key="l">
             {sections.map(section =>
+              <li className={`cp-subnav-item ${isOpen || currSection.slug === section.slug ? "is-active" : "is-inactive"}`} key={section.slug}
+                // onBlur={e => this.onBlur(e)}
+                // onClick={() => this.onFocusButton()}
+              >
+                <AnchorLink
+                  // onClick={() => this.setState({isOpen: !isOpen})}
+                  // onFocus={() => this.setState({isOpen: true})}
+                  ref={this.toggleButton}
+                  className={`cp-subnav-link ${sections.length >= 5 ? "u-font-xs" : "u-font-sm" }`}
+                  to={section.slug}
+                >
+                  {section.icon && blueprintIcons.find(i => i === section.icon) &&
+                    <Icon className="cp-subnav-link-icon" icon={section.icon} />
+                  }
+                  {section.short && stripHTML(section.short) ? stripHTML(section.short) : stripHTML(section.title)}
+                </AnchorLink>
+                { section.children && section.children.length && !hasSubgroups
+                  ? this.renderPopup.bind(this)(section)
+                  : null }
+              </li>
+            )}
+          </ol> : null}
+
+          {hasSubgroups && currSection ? <ol className="cp-subnav-list cp-subnav-secondary" key="s">
+            {(currSection ? currSection.children : []).map(section =>
               <li className="cp-subnav-item" key={section.slug}
                 // onBlur={e => this.onBlur(e)}
                 // onClick={() => this.onFocusButton()}
@@ -156,7 +230,7 @@ class Subnav extends Component {
                   // onClick={() => this.setState({isOpen: !isOpen})}
                   // onFocus={() => this.setState({isOpen: true})}
                   ref={this.toggleButton}
-                  className={`cp-subnav-link ${isOpen || currSection.slug === section.slug ? "is-active" : "is-inactive"} ${sections.length >= 5 ? "u-font-xs" : "u-font-sm" }`}
+                  className={`cp-subnav-link ${isOpen || currSubSection.slug === section.slug ? "is-active" : "is-inactive"} ${sections.length >= 5 ? "u-font-xs" : "u-font-sm" }`}
                   to={section.slug}
                 >
                   {section.icon && blueprintIcons.find(i => i === section.icon) &&
@@ -165,23 +239,11 @@ class Subnav extends Component {
                   {section.short && stripHTML(section.short) ? stripHTML(section.short) : stripHTML(section.title)}
                 </AnchorLink>
                 { section.children && section.children.length
-                  ? <ul className={`cp-subnav-group-list ${isOpen ? "is-open" : "is-closed"}`}>
-                    { section.children.map(child =>
-                      <li key={child.id} className="cp-subnav-group-item">
-                        <AnchorLink
-                          className="cp-subnav-group-link u-font-xs"
-                          to={child.slug}
-                        >
-                          <Icon className="cp-subnav-group-link-icon" icon={child.icon && blueprintIcons.find(i => i === child.icon) ? child.icon : "dot"} />
-                          {child.short && stripHTML(child.short) ? stripHTML(child.short) : stripHTML(child.title)}
-                        </AnchorLink>
-                      </li>
-                    ) }
-                  </ul>
+                  ? this.renderPopup.bind(this)(section)
                   : null }
               </li>
             )}
-          </ol> : ""}
+          </ol> : null}
         </nav>
 
         {/* prevent page jump */}

--- a/packages/cms/src/utils/sectionIconLookup.js
+++ b/packages/cms/src/utils/sectionIconLookup.js
@@ -2,11 +2,13 @@
  * Takes a section layout & returns the corresponding icon name
  */
 function sectionIconLookup(layout, position) {
+
   if (position === "sticky") return "pin";
   if (position === "modal") return "applications";
 
   if (layout === "Hero") return "mugshot";
   if (layout === "Grouping") return "caret-right";
+  if (layout === "SubGrouping") return "folder-open";
   if (layout === "Card") return "id-number";
   if (layout === "Column" || layout === "SingleColumn") return "horizontal-distribution";
   if (layout === "Columns" || layout === "MultiColumn") return "alignment-top";

--- a/packages/core/src/components/AnchorLink.jsx
+++ b/packages/core/src/components/AnchorLink.jsx
@@ -20,13 +20,17 @@ class AnchorLink extends Component {
         href={ `#${to}` }
         id={ id }
         dangerouslySetInnerHTML={dangerouslySetInnerHTML}
-        onClick={this.onClick.bind(this)}></a>;
+        onClick={this.onClick.bind(this)}
+        onBlur={this.props.onBlur}
+        onFocus={this.props.onFocus}></a>;
     }
     else {
       return <a className={className}
         href={ `#${to}` }
         id={ id }
-        onClick={this.onClick.bind(this)}>
+        onClick={this.onClick.bind(this)}
+        onBlur={this.props.onBlur}
+        onFocus={this.props.onFocus}>
         { children }
       </a>;
     }


### PR DESCRIPTION
Front-facing changes:
* adds a catch for missing section slugs in ProfileRenderer (`section-<id>`), which fixes SubNav breaking because of 1 missing slug and also fixes React key errors caused be `undefined` keys
* truncates long section titles with an ellipsis in the CMS ribbon design (Outline.css)
* adds new SubGrouping section type which extends Grouping
* fixes Subnav dropdown menu placement when `subnav-height` is different than `nav-height`
* updates headingLevel logic to include current SubGrouping hierarchy in ProfileRenderer (ie. `h2`/`h3`/`h4`)
* adds new 2nd row to SubNav when SubGroupings are present
* centers SubNav links (rather than stretching them to fit full width)
* detects top of section `<div>`, rather than top of `<a>`, when determining the "active" section for SubNav
* fixes SubNav scroll threshold error by correctly including `subnav-height` (rather than `nav-height * 2`)
* adds onBlur and onFocus support to core `<AnchorLink>` component
* hooks up keyboard navigation to SubNav and all sub-menus

Example app changes:
 * adds API test routes to example app for DataPeru (customAttributes and proxy)
 * changes example app `subnav-height` in style.yml

 Because I had to add something to `<AnchorLink>`, this PR will require a minor release to both canon-cms and canon-core (although nothing will break if a user hasn't done both updates, the canon-core update will just make keyboard navigation work).