### PR TITLE
Cms bugfix subnav reset

### DIFF
--- a/examples/app/style.yml
+++ b/examples/app/style.yml
@@ -80,7 +80,8 @@ body-font-scale-xl:         "125%"   # 1rem = 20px (min-width: 1400px)
 
 # measurements
 nav-height:                 "50px"
-subnav-height:              "100px"
+test-height: "100px"
+subnav-height:              "var(--test-height)"
 container-width:            "80rem" # 1280px
 hero-container-width:       "var(--container-width)"
 

--- a/packages/cms/src/components/sections/Section.css
+++ b/packages/cms/src/components/sections/Section.css
@@ -213,8 +213,4 @@
 /* button for resetting variables */
 .cp-var-reset-button {
   transition-property: color, border, background-color, box-shadow, opacity;
-
-  &[disabled] {
-    @mixin visually-hidden;
-  }
 }

--- a/packages/cms/src/components/sections/Section.jsx
+++ b/packages/cms/src/components/sections/Section.jsx
@@ -246,18 +246,16 @@ class Section extends Component {
     const sourceContent = <SourceGroup sources={sources} />;
 
     // reset button
-    const resetButton = <Button
+    const resetButton = showReset ? <Button
       onClick={this.resetVariables.bind(this)}
       className={`cp-var-reset-button ${layoutClass}-var-reset-button`}
       fontSize="xs"
       icon="undo"
       iconPosition="left"
-      disabled={!showReset}
-      fill={!showReset}
       key="var-reset-button"
     >
       {t("CMS.Section.Reset visualizations")}
-    </Button>;
+    </Button> : null;
 
     const componentProps = {
       slug,

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -195,6 +195,9 @@
   .cp-subnav {
     background-color: var(--hero-bg-color);
   }
+  .cp-subnav-secondary {
+    display: none;
+  }
 }
 
 /* horizontal layout on big screens */

--- a/packages/cms/src/components/sections/components/Subnav.jsx
+++ b/packages/cms/src/components/sections/components/Subnav.jsx
@@ -9,12 +9,27 @@ import {merge} from "d3-array";
 
 import throttle from "../../../utils/throttle";
 import blueprintIcons from "../../../utils/blueprintIcons";
-import pxToInt from "../../../utils/formatters/pxToInt";
 import stripHTML from "../../../utils/formatters/stripHTML";
 
 import styles from "style.yml";
 
 import "./Subnav.css";
+
+/**
+ * Finds a Number value for a given style.yml string variable. The cssVarRegex
+ * tests for nested CSS vars (ie. subnav-height: "var(--nav-height)") and resolves
+ * as deep as needed. Fallback return value is 0.
+ * @private
+ */
+function parseStyle(str) {
+  const cssVarRegex = /var\(--([A-z\-]+)\)/g;
+  let val = styles[str];
+  while (cssVarRegex.exec(val)) {
+    str = val.replace(/var\(--([A-z\-]+)\)/g, "$1");
+    val = styles[str];
+  }
+  return parseFloat(val) || 0;
+}
 
 class Subnav extends Component {
 
@@ -123,7 +138,7 @@ class Subnav extends Component {
     if (sections) {
       throttle(() => {
         const {currSection, currSubSection, fixed} = this.state;
-        const topBorder = pxToInt(styles["nav-height"] || "50px") + pxToInt(styles["subnav-height"] || "50px");
+        const topBorder = parseStyle(styles["nav-height"]) + parseStyle(styles["subnav-height"]);
         const screenTop = window.pageYOffset + topBorder;
         const heroHeight = document.querySelector(".cp-hero").getBoundingClientRect().height;
 


### PR DESCRIPTION
This PR makes three small changes to CMS components, specifically in `SubNav.jsx`, `SubNav.css`, and `Section.jsx`.
 - removes invisible "reset visualization" button element from DOM if it is disabled (currently, it renders an visually hidden DIV that James originally put in to prevent height jitter, but has caused more site-specific CSS problems than desired)
 - fixes mobile issue with SubNav secondary menus causing x-overflow (reported by Felipe in DataPeru)
 - fixes SubNav stickiness when height references another style.yml variable (DataMexico SubNav is currently broken because of this)