### PR TITLE
ProfileSearch faceted search and other enhancements

### DIFF
--- a/examples/app/App.css
+++ b/examples/app/App.css
@@ -21,7 +21,6 @@ body {
       }
       & ul {
         & li{
-          margin: 10px 0;
           & code {
             margin-bottom: 0px;
           }

--- a/examples/app/pages/cms/Search.jsx
+++ b/examples/app/pages/cms/Search.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 import {hot} from "react-hot-loader/root";
-import {ProfileSearch} from "@datawheel/canon-cms";
+import {ProfileSearch, ProfileTile} from "@datawheel/canon-cms";
 // import axios from "axios";
 
 /** */
@@ -70,6 +70,15 @@ class Search extends Component {
           // filterHierarchyTitle={d => `<i>${d}</i>`}
           // filterProfileTitle={content => `<i>${(content.label || "Unnamed").replace(/\<[\/p]{1,2}\>/g, "")}</i>`}
           formatResults={dataFormat}
+          renderListItem={(result, i, link, title, subtitle) =>
+            <li key={`r-${i}`} className="cms-profilesearch-list-item">
+              <a href={link} className="cms-profilesearch-list-item-link">
+                {title}
+                <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
+              </a>
+            </li>}
+          renderTile={(result, i, tileProps) => <ProfileTile key={`r-${i}`} {...tileProps} data={result} />}
+          // renderTile={(result, i, tileProps) => <div>Ceci n'est pas une tuile.</div>}
           showExamples={true}
         />
       </div>

--- a/examples/app/pages/cms/Search.jsx
+++ b/examples/app/pages/cms/Search.jsx
@@ -64,10 +64,13 @@ class Search extends Component {
         <ProfileSearch
           availableProfiles={oecProfiles}
           display="grid"
-          filterCubeTitle={d => d.replace(/^trade_s_([a-z]{3}).*$/, "$1").replace(/^suelos_sue[0-9]{2}(.*)$/, "$1").toUpperCase()}
+          filters={true}
+          filterCubeTitle={d => `<i>${d.replace(/^trade_s_([a-z]{3}).*$/, "$1").replace(/^suelos_sue[0-9]{2}(.*)$/, "$1").toUpperCase()}</i>`}
+          // filterDimensionTitle={d => `<i>${d}</i>`}
+          // filterHierarchyTitle={d => `<i>${d}</i>`}
+          // filterProfileTitle={content => `<i>${(content.label || "Unnamed").replace(/\<[\/p]{1,2}\>/g, "")}</i>`}
           formatResults={dataFormat}
           showExamples={true}
-          showFilters={true}
         />
       </div>
     );

--- a/examples/app/pages/cms/Search.jsx
+++ b/examples/app/pages/cms/Search.jsx
@@ -1,16 +1,54 @@
 import React, {Component} from "react";
 import {hot} from "react-hot-loader/root";
 import {ProfileSearch} from "@datawheel/canon-cms";
-import axios from "axios";
+// import axios from "axios";
 
 /** */
 async function dataFormat(resp) {
-  console.log("dataFormat", resp);
-  const res = await axios.get("https://datausa.io/api/home");
-  console.log("async", res);
-  resp.data.grouped = [];
+  // console.log("dataFormat", resp);
+  // const res = await axios.get("https://datausa.io/api/home");
+  // console.log("async", res);
+  // resp.data.grouped = [];
   return resp;
 }
+
+
+let oecProfiles = [
+  "country",
+  "hs92",
+
+  "bilateral-country/partner",
+  "bilateral-country",
+  "partner",
+
+  "bilateral-product/reporter",
+  "bilateral-product",
+  "reporter"
+];
+
+const subtitles = {
+  subnational_chn: "China",
+  subnational_deu: "Germany",
+  subnational_esp: "Spain",
+  subnational_fra: "France",
+  subnational_jpn: "Japan",
+  subnational_rus: "Russia",
+  subnational_usa_state: "United States",
+  subnational_usa_district: "US District",
+  subnational_usa_port: "US Port",
+  subnational_gbr: "United Kingdom",
+  subnational_can: "Canada",
+  subnational_bra_municipality: "Brazil",
+  subnational_bra_state: "Brazil",
+  subnational_tur: "Turkey",
+  subnational_bol: "Bolivia",
+  subnational_zaf: "South Africa",
+  subnational_ecu: "Ecuador",
+  subnational_col: "Colombia",
+  subnational_ind: "India"
+};
+
+oecProfiles = oecProfiles.concat(Object.keys(subtitles));
 
 class Search extends Component {
 
@@ -23,7 +61,14 @@ class Search extends Component {
         <p>TO-DO</p>
         <h2>React Component</h2>
         <p>When needing user interaction, use the <code className="bp3-code">ProfileSearch</code> component to display the results of a query:</p>
-        <ProfileSearch formatResults={dataFormat} />
+        <ProfileSearch
+          availableProfiles={oecProfiles}
+          display="grid"
+          filterCubeTitle={d => d.replace(/^trade_s_([a-z]{3}).*$/, "$1").replace(/^suelos_sue[0-9]{2}(.*)$/, "$1").toUpperCase()}
+          formatResults={dataFormat}
+          showExamples={true}
+          showFilters={true}
+        />
       </div>
     );
 

--- a/examples/app/pages/cms/Search.jsx
+++ b/examples/app/pages/cms/Search.jsx
@@ -1,6 +1,16 @@
 import React, {Component} from "react";
 import {hot} from "react-hot-loader/root";
 import {ProfileSearch} from "@datawheel/canon-cms";
+import axios from "axios";
+
+/** */
+async function dataFormat(resp) {
+  console.log("dataFormat", resp);
+  const res = await axios.get("https://datausa.io/api/home");
+  console.log("async", res);
+  resp.data.grouped = [];
+  return resp;
+}
 
 class Search extends Component {
 
@@ -13,7 +23,7 @@ class Search extends Component {
         <p>TO-DO</p>
         <h2>React Component</h2>
         <p>When needing user interaction, use the <code className="bp3-code">ProfileSearch</code> component to display the results of a query:</p>
-        <ProfileSearch />
+        <ProfileSearch formatResults={dataFormat} />
       </div>
     );
 

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -531,7 +531,8 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   availableProfiles={[]} // limit the type of profile results to show (ie. ["hs92", "country"])
   columnOrder={[]} // the order of the "columns" display (ie. ["hs92", "country"])
   columnTitles={{}} // overrides for the default column titles (ie. {hs92: "Products"})
-  display={"list"} // available options are "list" or "columns"
+  display={"list"} // available options are "list", "columns", and "grid"
+  filters={false} // enables a set of nested profile, hierarchy, and cube filters
   filterCubeTitle={cubeName => cubeName} // cube title used for filters (allows for grouping cubes with matching labels)
   filterDimensionTitle={dimension => dimension} // dimension title used for filters (allows for grouping dimensions with matching labels)
   filterHierarchyTitle={hierarchy => hierarchy} // hierarchy title used for filters (allows for grouping hierarchies with matching labels)
@@ -543,6 +544,14 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   minQueryLength={1} // when the search query is below this number, no API requests will be made
   placeholder={"Search..."} // the placeholder text in the input element
   position={"static"} // either "static" or "absolute" (for a pop-up result window)
+  renderListItem={(result, i, link, title, subtitle) =>
+    <li key={`r-${i}`} className="cms-profilesearch-list-item">
+      <a href={link} className="cms-profilesearch-list-item-link">
+        {title}
+        <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
+      </a>
+    </li>} // component that is rendered when display is "list"
+  renderTile={(result, i, tileProps) => <ProfileTile key={`r-${i}`} {...tileProps} data={result} />} // component that is rendered when display is "columns" or "grid"
   subtitleFormat={result => result.memberHierarchy} // overrides for the default result subtitles
   showExamples={false} // setting this to `true` will display results when no query has been entered
   showFilters={false} // show a faceted search underneath the input box

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -532,6 +532,7 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   columnOrder={[]} // the order of the "columns" display (ie. ["hs92", "country"])
   columnTitles={{}} // overrides for the default column titles (ie. {hs92: "Products"})
   display={"list"} // available options are "list" or "columns"
+  formatResults={resp => resp} // callback function to modify the JSON response used for rendering
   inputFontSize={"xxl"} // the CSS size for the input box ("sm", "md", "lg", "xl", "xxl")
   joiner={"&"} // the character used when joining titles in multi-dimensional profiles
   limit={10} // how many results to show

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -532,6 +532,10 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   columnOrder={[]} // the order of the "columns" display (ie. ["hs92", "country"])
   columnTitles={{}} // overrides for the default column titles (ie. {hs92: "Products"})
   display={"list"} // available options are "list" or "columns"
+  filterCubeTitle={cubeName => cubeName} // cube title used for filters (allows for grouping cubes with matching labels)
+  filterDimensionTitle={dimension => dimension} // dimension title used for filters (allows for grouping dimensions with matching labels)
+  filterHierarchyTitle={hierarchy => hierarchy} // hierarchy title used for filters (allows for grouping hierarchies with matching labels)
+  filterProfileTitle={(content, meta) => content.label} // profile title used for filters (allows for grouping profiles with matching labels)
   formatResults={resp => resp} // callback function to modify the JSON response used for rendering
   inputFontSize={"xxl"} // the CSS size for the input box ("sm", "md", "lg", "xl", "xxl")
   joiner={"&"} // the character used when joining titles in multi-dimensional profiles
@@ -541,6 +545,7 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   position={"static"} // either "static" or "absolute" (for a pop-up result window)
   subtitleFormat={result => result.memberHierarchy} // overrides for the default result subtitles
   showExamples={false} // setting this to `true` will display results when no query has been entered
+  showFilters={false} // show a faceted search underneath the input box
 />
 ```
 
@@ -552,8 +557,9 @@ If you would prefer to build your own search component, the DeepSearch API is av
 |`locale`|Language for results|
 |`limit`|Maximum number of results to return|
 |`profile`|Restrict results to a profile, must be an integer profile id or a profile slug (unary profiles only)|
-|`dimension`|Restrict results by dimension|
+|`dimension`|Restrict results by dimension (comma separated)|
 |`hierarchy`|Restrict results by hierarchy (comma separated)|
+|`cubeName`|Restrict results by source cube name (comma separated)|
 |`min_confidence`|Confidence threshold (Deepsearch Only)|
 
 Results will be returned in a response object that includes metadata on the results. Matching members separated by profile can be found in the `profiles` key of the response object. A single grouped list of all matching profiles can be found in the `grouped` key of the response object.

--- a/packages/cms/src/api/cmsRoute.js
+++ b/packages/cms/src/api/cmsRoute.js
@@ -248,6 +248,29 @@ module.exports = function(app) {
     return res.json(profiles);
   });
 
+  /**
+   * Returns a list of profiles including both the meta and content associations
+   * for the current language. Primarily used by the ProfileSearch component.
+   */
+  app.get("/api/cms/profiles", async(req, res) => {
+    let meta = await db.profile.findAll({
+      include: [
+        {association: "meta", separate: true},
+        {association: "content", separate: true}
+      ]
+    }).catch(catcher);
+    meta = meta.map(m => m.toJSON());
+    const locale = req.query.locale ? req.query.locale : envLoc;
+    meta.forEach(m => {
+      if (m.content instanceof Array) {
+        m.content = m.content.find(c => c.locale === locale) ||
+          m.content.find(c => c.locale === envLoc) ||
+           m[0];
+      }
+    });
+    res.json(meta);
+  });
+
   app.get("/api/cms/formatter", async(req, res) => {
     const formatters = await db.formatter.findAll().catch(catcher);
     res.json(formatters);

--- a/packages/cms/src/components/fields/ProfileColumns.css
+++ b/packages/cms/src/components/fields/ProfileColumns.css
@@ -4,14 +4,13 @@
   @mixin list-reset;
   display: flex;
   flex-wrap: wrap;
-  width: calc(100% + var(--gutter-lg)); /* offset column margin */
+  width: 100%;
 
   & .cms-profilecolumn {
     @mixin list-reset;
     flex: 1 0 calc(25% - var(--gutter-lg));
     min-width: 10rem;
     max-width: 100%;
-    margin-right: var(--gutter-lg);
     position: relative;
     padding-bottom: var(--gutter-lg);
 
@@ -27,14 +26,14 @@
       height: var(--nav-height);
       padding: 1rem 0;
       /* hide tiles as they pass through */
-      background-color: var(--white);
+      background-color: var(--light-2);
     }
 
     /* "column" layout */
     & .cms-profilecolumn-list {
       column-width: 14rem;
-      column-gap: var(--gutter);
-      padding: 0;
+      column-gap: var(--gutter-sm);
+      padding: var(--gutter-xs);
     }
 
   }

--- a/packages/cms/src/components/fields/ProfileColumns.jsx
+++ b/packages/cms/src/components/fields/ProfileColumns.jsx
@@ -6,7 +6,7 @@ class ProfileColumns extends Component {
 
   render() {
 
-    const {columnFormat, columnTitles, data, joiner, tileProps} = this.props;
+    const {columnFormat, columnTitles, data, joiner, renderTile, tileProps} = this.props;
 
     return (
       <ul key="columns" className="cms-profilecolumns">
@@ -16,8 +16,7 @@ class ProfileColumns extends Component {
             <li key={`p-${i}`} className="cms-profilecolumn">
               { data.length > 1 && <h3 className="cms-profilecolumn-title" dangerouslySetInnerHTML={{__html: columnTitles[profile] || datum[0].map(columnFormat).join(joiner)}} /> }
               <ul className="cms-profilecolumn-list">
-                {datum.map((result, j) =>
-                  <ProfileTile key={`r-${j}`} {...tileProps} data={result} />)}
+                {datum.map((result, j) => renderTile(result, j, tileProps))}
               </ul>
             </li>
           );
@@ -34,6 +33,9 @@ ProfileColumns.defaultProps = {
   columnTitles: {},
   data: [],
   joiner: " & ",
+  renderTile(result, i, tileProps) {
+    return <ProfileTile key={`r-${i}`} {...tileProps} data={result} />;
+  },
   tileProps: {}
 };
 

--- a/packages/cms/src/components/fields/ProfileColumns.jsx
+++ b/packages/cms/src/components/fields/ProfileColumns.jsx
@@ -14,7 +14,7 @@ class ProfileColumns extends Component {
           const profile = datum[0].map(d => d.slug).join("/");
           return (
             <li key={`p-${i}`} className="cms-profilecolumn">
-              <h3 className="cms-profilecolumn-title" dangerouslySetInnerHTML={{__html: columnTitles[profile] || datum[0].map(columnFormat).join(joiner)}} />
+              { data.length > 1 && <h3 className="cms-profilecolumn-title" dangerouslySetInnerHTML={{__html: columnTitles[profile] || datum[0].map(columnFormat).join(joiner)}} /> }
               <ul className="cms-profilecolumn-list">
                 {datum.map((result, j) =>
                   <ProfileTile key={`r-${j}`} {...tileProps} data={result} />)}

--- a/packages/cms/src/components/fields/ProfileSearch.css
+++ b/packages/cms/src/components/fields/ProfileSearch.css
@@ -25,6 +25,12 @@
         z-index: 2;
       }
     }
+    &.cms-profilesearch-container-static {
+      background-color: var(--light-2);
+      & .bp3-non-ideal-state {
+        min-height: 50vh;
+      }
+    }
   }
 
   & .cp-input-label {
@@ -199,6 +205,63 @@
       }
     }
 
+  }
+
+  & .cms-profilesearch-filters-profiles {
+    @mixin list-reset;
+    text-align: center;
+    & .cms-profilesearch-filters-profile {
+      display: inline-block;
+      padding: var(--gutter-xs);
+      &.active {
+        font-weight: bold;
+        text-decoration: underline;
+      }
+    }
+  }
+
+  & .cms-profilesearch-filters-dimensions {
+    & .cms-profilesearch-filters-levels {
+      @mixin list-reset;
+      display: inline-block;
+      & .cms-profilesearch-filters-dimension {
+        display: inline-block;
+        font-size: var(--font-xs);
+        padding: var(--gutter-xs);
+        &.active {
+          background-color: var(--light-2);
+          font-weight: bold;
+          text-decoration: underline;
+        }
+      }
+      & .cms-profilesearch-filters-level {
+        display: inline-block;
+        font-size: var(--font-xs);
+        padding: var(--gutter-xs);
+        &.active {
+          background-color: var(--light-2);
+          font-weight: bold;
+          text-decoration: underline;
+        }
+      }
+      &:not(:first-child) {
+        margin-left: var(--gutter-sm);
+      }
+    }
+  }
+
+  /* "grid" layout */
+  & .cms-profilesearch-grid {
+    @mixin list-reset;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    & .cms-profilesearch-tile {
+      flex: 1 1 auto;
+      margin: var(--gutter-xs);
+      max-width: 350px;
+      min-width: 250px;
+    }
   }
 
   /* "list" layout */

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -195,11 +195,9 @@ class ProfileSearch extends Component {
         timeout: setTimeout(() => {
 
           axios.get(url)
+            .then(resp => url === this.state.loading ? formatResults(resp) : false)
             .then(resp => {
-              if (url === this.state.loading) {
-                resp = formatResults(resp);
-                this.setState({results: resp.data, loading: false});
-              }
+              if (resp) this.setState({results: resp.data, loading: false});
             })
             .catch(() => {});
 

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -313,13 +313,14 @@ class ProfileSearch extends Component {
       const groupedDimensions = group(merge(activeProfile[1].map(p => p.meta)), d => filterDimensionTitle(d.dimension));
       const dimensions = Array.from(groupedDimensions, ([key, value]) => {
 
+        const dimensions = unique(value.map(d => d.dimension));
         const sortedCubes = Array.from(group(value.map(d => d.cubeName), filterCubeTitle), d => unique(d[1]).join(",")).sort((a, b) => filterCubeTitle(a).localeCompare(filterCubeTitle(b)));
         const cubes = unique(value.map(d => d.cubeName));
-        if (cubes.length > 1) return {dimension: key, cubes, sortedCubes};
+        if (cubes.length > 1) return {dimensions, title: key, cubes, sortedCubes};
 
         const levelSets = value.map(v => v.levels);
         const levels = unique(merge(levelSets));
-        return {dimension: key, levels, sortedLevels: levels.slice().sort((a, b) => max(levelSets, s => s.indexOf(a)) - max(levelSets, s => s.indexOf(b)))};
+        return {dimensions, title: key, levels, sortedLevels: levels.slice().sort((a, b) => max(levelSets, s => s.indexOf(a)) - max(levelSets, s => s.indexOf(b)))};
 
       });
       activeDimensions = dimensions.filter(d => (d.levels || d.cubes).length > 1);
@@ -364,38 +365,38 @@ class ProfileSearch extends Component {
         { profiles && filters ? <ul className="cms-profilesearch-filters-profiles">
           <li key="filters-all"
             className={`cms-profilesearch-filters-profile${!filterProfiles ? " active" : ""}`}
-            onClick={() => this.setState({filterProfiles: false}, this.onFilterLevel.bind(this, false))}>
-            All
-          </li>
+            onClick={() => this.setState({filterProfiles: false}, this.onFilterLevel.bind(this, false))}
+            dangerouslySetInnerHTML={{__html: filterProfileTitle({label: "All"})}} />
           { profileGroups.map(g => {
             const profileIds = g[1].map(p => p.id);
             return <li key={`filters-${profileIds.join("-")}`}
               className={`cms-profilesearch-filters-profile${profileIds.join(",") === filterProfiles ? " active" : ""}`}
-              onClick={() => this.setState({filterProfiles: profileIds.join(",")}, this.onFilterLevel.bind(this, false))}>
-              { g[0] }
-            </li>;
+              onClick={() => this.setState({filterProfiles: profileIds.join(",")}, this.onFilterLevel.bind(this, false))}
+              dangerouslySetInnerHTML={{__html: g[0]}} />;
           }) }
         </ul> : null }
         { activeDimensions ? <div className="cms-profilesearch-filters-dimensions">
-          { activeDimensions.map(d => <ul key={`filters-dimension-${d.dimension}`} className="cms-profilesearch-filters-levels">
+          { activeDimensions.map(d => <ul key={`filters-dimension-${d.dimensions.join(",").replace(/\s/g, "-")}`} className="cms-profilesearch-filters-levels">
             { d.levels
-              ? <li className={`cms-profilesearch-filters-dimension${ filterLevels && filterLevels.includes(d.levels.join(",")) ? " active" : ""}`} onClick={this.onFilterLevel.bind(this, false)}>
-                { d.dimension }:
-              </li>
-              : <li className={`cms-profilesearch-filters-dimension${ filterCubes && filterCubes.includes(d.cubes.join(",")) ? " active" : ""}`} onClick={this.onFilterLevel.bind(this, false)}>
-                { d.dimension }:
-              </li>}
+              ? <li className={`cms-profilesearch-filters-dimension${ filterLevels && filterLevels.includes(d.levels.join(",")) ? " active" : ""}`}
+                onClick={this.onFilterLevel.bind(this, false)}
+                dangerouslySetInnerHTML={{__html: d.title}} />
+              : <li className={`cms-profilesearch-filters-dimension${ filterCubes && filterCubes.includes(d.cubes.join(",")) ? " active" : ""}`}
+                onClick={this.onFilterLevel.bind(this, false)}
+                dangerouslySetInnerHTML={{__html: d.title}} />}
             {d.sortedLevels
-              ? d.sortedLevels.map(l => <li key={`filters-level-${l}`}
-                className={`cms-profilesearch-filters-level${ filterLevels && !filterLevels.includes(d.levels.join(",")) && filterLevels.includes(l) ? " active" : "" }`}
-                onClick={this.onFilterLevel.bind(this, l)}>
-                { filterHierarchyTitle(l) }
-              </li>)
-              : d.sortedCubes.map(l => <li key={`filters-level-${l}`}
-                className={`cms-profilesearch-filters-level${ filterCubes && !filterCubes.includes(d.cubes.join(",")) && filterCubes.includes(l) ? " active" : "" }`}
-                onClick={this.onFilterLevel.bind(this, l)}>
-                { filterCubeTitle(l.split(",")[0]) }
-              </li>)}
+              ? d.sortedLevels.map(l =>
+                <li key={`filters-level-${l}`}
+                  className={`cms-profilesearch-filters-level${ filterLevels && !filterLevels.includes(d.levels.join(",")) && filterLevels.includes(l) ? " active" : "" }`}
+                  onClick={this.onFilterLevel.bind(this, l)}
+                  dangerouslySetInnerHTML={{__html: filterHierarchyTitle(l)}} />
+              )
+              : d.sortedCubes.map(l =>
+                <li key={`filters-level-${l}`}
+                  className={`cms-profilesearch-filters-level${ filterCubes && !filterCubes.includes(d.cubes.join(",")) && filterCubes.includes(l) ? " active" : "" }`}
+                  onClick={this.onFilterLevel.bind(this, l)}
+                  dangerouslySetInnerHTML={{__html: filterCubeTitle(l.split(",")[0])}} />
+              )}
           </ul>) }
         </div> : null }
 

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -296,6 +296,8 @@ class ProfileSearch extends Component {
       inputFontSize,
       joiner,
       position,
+      renderListItem,
+      renderTile,
       subtitleFormat,
       t
     } = this.props;
@@ -419,7 +421,7 @@ class ProfileSearch extends Component {
 
                       return (
                         <ul key="grid" className="cms-profilesearch-grid">
-                          {gridProfiles.map((data, j) => <ProfileTile key={`r-${j}`} {...{joiner, subtitleFormat, data}} />)}
+                          {gridProfiles.map((data, j) => renderTile(data, j, {joiner, subtitleFormat}))}
                         </ul>
                       );
 
@@ -438,21 +440,20 @@ class ProfileSearch extends Component {
                           return aIndex - bIndex;
                         })
                         .map(profile => results.profiles[profile] || []);
-                      return <ProfileColumns columnFormat={subtitleFormat} columnTitles={columnTitles} joiner={joiner} tileProps={{joiner, subtitleFormat}} data={columnProfiles} />;
+                      return <ProfileColumns columnFormat={subtitleFormat} columnTitles={columnTitles} joiner={joiner} renderTile={renderTile} tileProps={{joiner, subtitleFormat}} data={columnProfiles} />;
 
                     default:
                       const listProfiles = (results.grouped || [])
                         .filter(d => !availableProfiles.length || availableProfiles.includes(d[0].slug));
                       return (
                         <ul key="list" className="cms-profilesearch-list">
-                          {listProfiles.map((result, j) =>
-                            <li key={`r-${j}`} className="cms-profilesearch-list-item">
-                              <Link to={linkify(router, result, locale)} className="cms-profilesearch-list-item-link">
-                                {result.map(d => formatTitle(d.name)).join(joiner)}
-                                <div className="cms-profilesearch-list-item-sub u-font-xs">{result.map(subtitleFormat).join(joiner)}</div>
-                              </Link>
-                            </li>
-                          )}
+                          {listProfiles.map((result, j) => renderListItem(
+                            result,
+                            j,
+                            linkify(router, result, locale),
+                            result.map(d => formatTitle(d.name)).join(joiner),
+                            result.map(subtitleFormat).join(joiner)
+                          ))}
                         </ul>
                       );
                   }
@@ -502,6 +503,17 @@ ProfileSearch.defaultProps = {
   minQueryLength: 1,
   placeholder: "Search...",
   position: "static",
+  renderListItem(result, i, link, title, subtitle) {
+    return <li key={`r-${i}`} className="cms-profilesearch-list-item">
+      <Link to={link} className="cms-profilesearch-list-item-link">
+        {title}
+        <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
+      </Link>
+    </li>;
+  },
+  renderTile(result, i, tileProps) {
+    return <ProfileTile key={`r-${i}`} {...tileProps} data={result} />;
+  },
   showExamples: false,
   subtitleFormat: d => d.memberHierarchy
 };

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import {hot} from "react-hot-loader/root";
 import {connect} from "react-redux";
 import {withNamespaces} from "react-i18next";
 import PropTypes from "prop-types";
@@ -7,11 +8,16 @@ import axios from "axios";
 import "./ProfileSearch.css";
 import linkify from "../../utils/linkify";
 import {formatTitle} from "../../utils/profileTitleFormat";
+import stripHTML from "../../utils/formatters/stripHTML";
+import groupMeta from "../../utils/groupMeta";
 import {Icon, NonIdealState, Spinner} from "@blueprintjs/core";
 import {uuid} from "d3plus-common";
+import {group, max, merge, min} from "d3-array";
 import {select} from "d3-selection";
+import {unique} from "d3plus-common";
 import styles from "style.yml";
 import ProfileColumns from "./ProfileColumns";
+import ProfileTile from "./ProfileTile";
 
 /** used for up/down arrow movement */
 function findSibling(elem, dir = "next") {
@@ -66,8 +72,12 @@ class ProfileSearch extends Component {
     super(props);
     this.state = {
       active: false,
+      filterCubes: false,
+      filterProfiles: false,
+      filterLevels: false,
       id: uuid(),
       loading: false,
+      profiles: false,
       query: "",
       results: false,
       timeout: 0
@@ -157,6 +167,11 @@ class ProfileSearch extends Component {
 
     }, false);
 
+    axios.get("/api/cms/profiles")
+      .then(resp => resp.data.filter(p => p.visible))
+      .then(profiles => this.setState({profiles}))
+      .catch(() => {});
+
   }
 
   scrollToLink(elem) {
@@ -170,7 +185,7 @@ class ProfileSearch extends Component {
 
   onChange(e) {
 
-    const {timeout} = this.state;
+    const {filterCubes, filterLevels, filterProfiles, timeout} = this.state;
     const {limit, minQueryLength, showExamples, formatResults, locale} = this.props;
 
     let query = e ? e.target.value : this.state.query;
@@ -183,7 +198,10 @@ class ProfileSearch extends Component {
     }
     else {
 
-      const url = `/api/profilesearch?query=${query}&limit=${limit}&locale=${locale}`;
+      let url = `/api/profilesearch?query=${query}&limit=${limit}&locale=${locale}`;
+      if (filterProfiles) url += `&profile=${filterProfiles}`;
+      if (filterLevels) url += `&hierarchy=${filterLevels}`;
+      if (filterCubes) url += `&cubeName=${filterCubes}`;
 
       // handle the query
       this.setState({
@@ -225,22 +243,87 @@ class ProfileSearch extends Component {
 
   }
 
+  onFilterLevel(filter) {
+    const newFilters = filter ? filter.split(",") : [false];
+    const {filterCubes, filterLevels, filterProfiles, profiles} = this.state;
+    const {filterDimensionTitle} = this.props;
+    let newCubes = [];
+    let newLevels = [];
+    const profileIds = filterProfiles ? filterProfiles.split(",").map(Number) : [];
+    const cubeNames = filterCubes ? filterCubes.split(",") : [];
+    const levelNames = filterLevels ? filterLevels.split(",") : [];
+    const activeMetas = merge(profiles
+      .filter(p => profileIds.includes(p.id))
+      .map(p => p.meta));
+    const hierarchyGroups = Array.from(group(activeMetas, d => filterDimensionTitle(d.dimension)), arr => [unique(merge(arr[1].map(a => a.levels))), unique(arr[1].map(a => a.cubeName))]);
+    hierarchyGroups.forEach(([l, c]) => {
+      newFilters.forEach(level => {
+        if (c.length > 1) {
+          const currCubes = c.find(x => cubeNames.includes(x));
+          if (c.includes(level)) newCubes.push(level);
+          else if (level && currCubes) newCubes.push(currCubes);
+          else newCubes = newCubes.concat(c);
+        }
+        else {
+          const currFilter = l.find(x => levelNames.includes(x));
+          if (l.includes(level)) newLevels.push(level);
+          else if (level && currFilter) newLevels.push(currFilter);
+          else newLevels = newLevels.concat(l);
+        }
+      });
+    });
+    this.setState({
+      filterCubes: unique(newCubes).join(","),
+      filterLevels: unique(newLevels).join(",")
+    }, this.onChange.bind(this));
+  }
+
   render() {
 
     const {router} = this.context;
-    const {active, loading, query, results} = this.state;
+    const {active, filterCubes, filterLevels, filterProfiles, loading, profiles, query, results} = this.state;
     const {locale, placeholder} = this.props;
     const {
       availableProfiles,
       columnTitles,
       display,
       columnOrder,
+      filters,
+      filterCubeTitle,
+      filterDimensionTitle,
+      filterHierarchyTitle,
+      filterProfileTitle,
       inputFontSize,
       joiner,
       position,
       subtitleFormat,
       t
     } = this.props;
+
+    let profileGroups = [];
+    if (profiles && filters) {
+      const filteredProfiles = (profiles || [])
+        .filter(d => !availableProfiles.length || availableProfiles.includes(d.meta[0].slug));
+      profileGroups = Array.from(group(filteredProfiles, d => filterProfileTitle(d.content, d.meta)))
+        .sort((a, b) => min(a[1], d => d.ordering) - min(b[1], d => d.ordering));
+    }
+    const activeProfile = profileGroups.find(g => g[1].map(p => p.id).join(",") === filterProfiles);
+    let activeDimensions;
+    if (activeProfile) {
+      const groupedDimensions = group(merge(activeProfile[1].map(p => p.meta)), d => filterDimensionTitle(d.dimension));
+      const dimensions = Array.from(groupedDimensions, ([key, value]) => {
+
+        const sortedCubes = Array.from(group(value.map(d => d.cubeName), filterCubeTitle), d => unique(d[1]).join(",")).sort((a, b) => filterCubeTitle(a).localeCompare(filterCubeTitle(b)));
+        const cubes = unique(value.map(d => d.cubeName));
+        if (cubes.length > 1) return {dimension: key, cubes, sortedCubes};
+
+        const levelSets = value.map(v => v.levels);
+        const levels = unique(merge(levelSets));
+        return {dimension: key, levels, sortedLevels: levels.slice().sort((a, b) => max(levelSets, s => s.indexOf(a)) - max(levelSets, s => s.indexOf(b)))};
+
+      });
+      activeDimensions = dimensions.filter(d => (d.levels || d.cubes).length > 1);
+    }
 
     return (
       <div className="cms-profilesearch">
@@ -278,6 +361,44 @@ class ProfileSearch extends Component {
           </button>
         </label>
 
+        { profiles && filters ? <ul className="cms-profilesearch-filters-profiles">
+          <li key="filters-all"
+            className={`cms-profilesearch-filters-profile${!filterProfiles ? " active" : ""}`}
+            onClick={() => this.setState({filterProfiles: false}, this.onFilterLevel.bind(this, false))}>
+            All
+          </li>
+          { profileGroups.map(g => {
+            const profileIds = g[1].map(p => p.id);
+            return <li key={`filters-${profileIds.join("-")}`}
+              className={`cms-profilesearch-filters-profile${profileIds.join(",") === filterProfiles ? " active" : ""}`}
+              onClick={() => this.setState({filterProfiles: profileIds.join(",")}, this.onFilterLevel.bind(this, false))}>
+              { g[0] }
+            </li>;
+          }) }
+        </ul> : null }
+        { activeDimensions ? <div className="cms-profilesearch-filters-dimensions">
+          { activeDimensions.map(d => <ul key={`filters-dimension-${d.dimension}`} className="cms-profilesearch-filters-levels">
+            { d.levels
+              ? <li className={`cms-profilesearch-filters-dimension${ filterLevels && filterLevels.includes(d.levels.join(",")) ? " active" : ""}`} onClick={this.onFilterLevel.bind(this, false)}>
+                { d.dimension }:
+              </li>
+              : <li className={`cms-profilesearch-filters-dimension${ filterCubes && filterCubes.includes(d.cubes.join(",")) ? " active" : ""}`} onClick={this.onFilterLevel.bind(this, false)}>
+                { d.dimension }:
+              </li>}
+            {d.sortedLevels
+              ? d.sortedLevels.map(l => <li key={`filters-level-${l}`}
+                className={`cms-profilesearch-filters-level${ filterLevels && !filterLevels.includes(d.levels.join(",")) && filterLevels.includes(l) ? " active" : "" }`}
+                onClick={this.onFilterLevel.bind(this, l)}>
+                { filterHierarchyTitle(l) }
+              </li>)
+              : d.sortedCubes.map(l => <li key={`filters-level-${l}`}
+                className={`cms-profilesearch-filters-level${ filterCubes && !filterCubes.includes(d.cubes.join(",")) && filterCubes.includes(l) ? " active" : "" }`}
+                onClick={this.onFilterLevel.bind(this, l)}>
+                { filterCubeTitle(l.split(",")[0]) }
+              </li>)}
+          </ul>) }
+        </div> : null }
+
         <div className={`cms-profilesearch-container cms-profilesearch-container-${position}`} key="container" ref={comp => this.resultContainer = comp}>
           {
             (position !== "absolute" || active) && results
@@ -289,6 +410,17 @@ class ProfileSearch extends Component {
 
                 else {
                   switch (display) {
+
+                    case "grid":
+
+                      const gridProfiles = (results.grouped || [])
+                        .filter(d => !availableProfiles.length || availableProfiles.includes(d[0].slug));
+
+                      return (
+                        <ul key="grid" className="cms-profilesearch-grid">
+                          {gridProfiles.map((data, j) => <ProfileTile key={`r-${j}`} {...{joiner, subtitleFormat, data}} />)}
+                        </ul>
+                      );
 
                     case "columns":
                       const filteredProfiles = Object.keys(results.profiles || {})
@@ -348,6 +480,21 @@ ProfileSearch.defaultProps = {
   columnOrder: [],
   columnTitles: {},
   display: "list",
+  filters: false,
+  filterCubeTitle: d => d,
+  filterDimensionTitle: d => d,
+  filterHierarchyTitle: d => d,
+  filterProfileTitle: (content, meta) => {
+    if (content && content.label && content.label !== "New Profile Label") {
+      return stripHTML(content.label);
+    }
+    else if (meta && meta.length) {
+      const groupedMeta = groupMeta(meta);
+      return groupedMeta.length > 0 ? groupedMeta.map(g => g[0] ? g[0].dimension || g[0].slug : "ERR_META").join(" / ") : "Unnamed";
+    }
+    else return "Unnamed";
+  },
+  formatResults: resp => resp,
   inputFontSize: "xxl",
   joiner: " & ",
   limit: 10,
@@ -355,11 +502,10 @@ ProfileSearch.defaultProps = {
   placeholder: "Search...",
   position: "static",
   showExamples: false,
-  subtitleFormat: d => d.memberHierarchy,
-  formatResults: resp => resp
+  subtitleFormat: d => d.memberHierarchy
 };
 
-ProfileSearch = withNamespaces()(ProfileSearch);
+ProfileSearch = withNamespaces()(hot(ProfileSearch));
 
 export default connect(state => ({
   locale: state.i18n.locale

--- a/packages/cms/src/components/interface/Navbar.jsx
+++ b/packages/cms/src/components/interface/Navbar.jsx
@@ -146,7 +146,7 @@ class Navbar extends Component {
     }
     else if (entity.meta && entity.meta.length) {
       const groupedMeta = groupMeta(entity.meta);
-      return groupedMeta.length > 0 ? groupedMeta.map(g => g[0] ? g[0].slug : "ERR_META").join(" / ") : "Unnamed";
+      return groupedMeta.length > 0 ? groupedMeta.map(g => g[0] ? g[0].dimension || g[0].slug : "ERR_META").join(" / ") : "Unnamed";
     }
     else return "Unnamed";
   }

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -250,11 +250,12 @@
       position: relative;
       text-align: center;
 
-      /* prevent the rightmost dropdown menu item, if 4 or more items, from getting cropped off the page */
-      &:last-of-type:hover:nth-child(n+4) .cp-subnav-group-list,
-      &:last-of-type:nth-child(n+4) .cp-subnav-group-list {
-        left: auto;
-        right: 0;
+      /* prevent the right half dropdown menu items from getting cropped off the page */
+      @for $n from 4 to 20 {
+        &:nth-child(n+$(n)):nth-last-child(-n+$(n)) .cp-subnav-group-list {
+          left: auto;
+          right: 0;
+        }
       }
     }
 


### PR DESCRIPTION
This PR mainly focuses on introducing faceted search to the `<ProfileSearch />` component, but also includes a few other small tweaks and fixes that crept in as I worked. Since there's been quite a few changes, it might be worth looking at specific commits to help review my changes. I've grouped the changes into the following areas:

## Faceted ProfileSearch
 * adds an `api/cms/profiles` endpoint which returns `meta` _and_ `content` for all profiles (5f8fce2)
 * adds cubeName filter to profileSearch (974dc97)
 * adds comma-separated support for the `profile` filter in profileSearch (974dc97)
 * adds `filters` to ProfileSearch, including 4 methods for labeling/organizing the search hierarchies (b16b2f7 and b484c1c)
 
## Other ProfileSearch Improvements
 * adds a new "grid" display option (b16b2f7)
 * adds renderListItem and renderTile props (03ef530)
 * hides column titles if only 1 column exists (f42945b)
 * adds async support to formatResults prop (3dc685f)
 * adds formatResults to docs in README (962515f)

## Other CMS Improvements
 * fixes right-overflow of log Subnav pop-up windows (31f35df)
 * fixes hierarchy filter in DeepSearch (974dc97)
 * improves fallback profile title logic in CMS NavBar (cde163a)
 * removes example App.css `<li>` styles that were interfering with ProfileSearch (58587e9)