### PR TITLE
Updated Local Installation Steps in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A reusable react environment, and components for creating visualization engines.
 - [Create Canon](./packages/create-canon/) - Package for create the boilerplate code for a new Canon app.
 - [CMS](./packages/cms/) - Content Management System for Canon sites
 - [Canon Logic Layer](./packages/canon-logiclayer/) - a REST API that simplifies queries to a mondrian cube using shorthand and introspective logic.
-- [VisBuilder](/packages/vizbuilder) - a dynamic chart builder engine component.
+- [VizBuilder](/packages/vizbuilder) - a dynamic chart builder engine component.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ A reusable react environment, and components for creating visualization engines.
 | [/packages/logiclayer](./packages/logiclayer/) | [@datawheel/canon-logiclayer](https://www.npmjs.com/package/@datawheel/canon-logiclayer) | [![npm version](https://badge.fury.io/js/%40datawheel%2Fcanon-logiclayer.svg)](https://badge.fury.io/js/%40datawheel%2Fcanon-logiclayer) | [changelog](./packages/logiclayer/CHANGELOG.md) |
 | [/packages/vizbuilder](./packages/vizbuilder/) | [@datawheel/canon-vizbuilder](https://www.npmjs.com/package/@datawheel/canon-vizbuilder) | [![npm version](https://badge.fury.io/js/%40datawheel%2Fcanon-vizbuilder.svg)](https://badge.fury.io/js/%40datawheel%2Fcanon-vizbuilder) | [changelog](./packages/vizbuilder/CHANGELOG.md) |
 
+## Summaries
+
+- [Canon Core](./packages/core/) - Reusable React environment and components for creating visualization engines.
+- [Create Canon](./packages/create-canon/) - Package for create the boilerplate code for a new Canon app.
+- [CMS](./packages/cms/) - Content Management System for Canon sites
+- [Canon Logic Layer](./packages/canon-logiclayer/) - a REST API that simplifies queries to a mondrian cube using shorthand and introspective logic.
+- [VisBuilder](/packages/vizbuilder) - a dynamic chart builder engine component.
+
+
 ## License
 
 &copy; 2020 Datawheel, LLC. Licensed under GPLv3.

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -28,7 +28,9 @@ Content Management System for Canon sites.
 
 ## Why?
 
-Datawheel makes sites with lots of profiles, which requires lots of templating support. Content creators and translators need to be able to author and update page templates easily. Canon CMS allows users to:
+Building websites can be hard, especially when they need to display _tons_ of information. For a company like Datawheel, an organization that needs to build maintainable sites that can showcase data from thousands of data "members," the creation of *data-agnostic, dynamic templates* that can render beautiful web pages (or "profiles") is crucial. The Canon CMS fulfills this need by giving content creators and translators the tools they need to be able to author and update page templates easily.
+
+Canon CMS allows users to:
 
 - Hit an endpoint to receive a data payload
 - Turn that payload into variables using javascript
@@ -48,7 +50,7 @@ Canon CMS is a package for `canon`. These instructions assume you have installed
 
 #### 2) Configure the database models in the `canon.js` file
 
-Canon CMS uses the `canon`-level user model to handle authentication and edit permissions, in addition to some other models to store the content. You must configure these modules manually on the application's `canon.js` file:
+Canon CMS uses the `canon`-level user model to handle authentication and edit permissions, in addition to some other models to store the content of the CMS templates. You must configure these modules manually on the application's `canon.js` file:
 
 ```js
 module.exports = {
@@ -90,8 +92,6 @@ Canon CMS requires a `canon-cms` specific env var for the current location of yo
 export CANON_CMS_CUBES=https://tesseract-url.com/tesseract
 ```
 
-By default, the CMS will only be enabled on development environments. If you wish to enable the CMS on production, see the `CANON_CMS_ENABLE` in [Environment Variables](#environment-variables) below.
-
 In summary, your env vars should now look like this:
 ```sh
 export CANON_API=http://localhost:3300
@@ -101,7 +101,13 @@ export CANON_DB_CONNECTION_STRING=postgresql://dbuser:dbpass@dbhost:dbport/dbnam
 export CANON_CMS_CUBES=https://tesseract-url.com/tesseract
 ```
 
-Remember the `CANON_DB_CONNECTION_STRING` is up to you, depending on how did you configure the DB on the `canon.js` file.
+Remember the actual value of `CANON_DB_CONNECTION_STRING` is up to you as it depends on how you configured your Postgres database. on the `canon.js` file.
+
+By default, the CMS will only be enabled on development environments. If you wish to enable the CMS on production, see the `CANON_CMS_ENABLE` in [Environment Variables](#environment-variables) below.
+
+#### 5) (Optional) Add Proxy for Local Tesseract Instance
+
+Your `CANON_CMS_CUBES` variable will (obviously) differ based on your project. If you are developing against a _local instance of tesseract_, you will likely need to add a simple proxy to bypass CORS errors from requesting data between different ports.  To do this, you will need to add a file called `local-proxy.js` in the `/api/` directory in the root level of your project (create one if you don't have one). The file should then look like [this](https://gist.github.com/greenrhyno/018042999a0deab501529224764c0fa4).
 
 #### 4) Add the Builder Component to a route
 ```jsx

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -101,7 +101,7 @@ export CANON_DB_CONNECTION_STRING=postgresql://dbuser:dbpass@dbhost:dbport/dbnam
 export CANON_CMS_CUBES=https://tesseract-url.com/tesseract
 ```
 
-Remember the actual value of `CANON_DB_CONNECTION_STRING` is up to you as it depends on how you configured your Postgres database. on the `canon.js` file.
+Remember the actual value of `CANON_DB_CONNECTION_STRING` is up to you as it depends on how you configured your Postgres database.
 
 By default, the CMS will only be enabled on development environments. If you wish to enable the CMS on production, see the `CANON_CMS_ENABLE` in [Environment Variables](#environment-variables) below.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,10 +1,11 @@
 # Canon
-Reusable React environment and components for creating visualization engines.
+Canon is a reusable React environment and set of components for creating visualization engines.
 
 ![](https://github.com/datawheel/canon/raw/master/docs/bang.png)
 
 #### Contents
 * [Setup and Installation](#setup-and-installation)
+* [Running Development Server](#running-development-server)
 * [Deployment](#deployment)
 * [Header/Meta Information](#header-meta-information)
 * [Page Routing](#page-routing)
@@ -42,22 +43,13 @@ Reusable React environment and components for creating visualization engines.
 
 ## Setup and Installation
 
-Canon is published on NPM, and should be installed just like any other node package. After creating a package.json file (try `npm init`), install Canon like this:
+Canon is published on NPM, and comes with an initializer package that creates an empty Canon project.  This script will generate a new Canon app with some basic scaffolding and boilerplate code and will setup a basic backend server (written in Node.js Express) and a frontend application (written in React/Redux). To create a new Canon app, simply create a new root folder for your project, navigate to that directory, and run:
 
 ```bash
-npm i @datawheel/canon-core
+npm init @datawheel/canon
 ```
-
-Once installed, run the following command to create some initial scaffolding:
-
-```bash
-npx canon-setup
-```
-
-Now that the necessary files are in place, simply run `npm run dev` to spin up the development server. Once the process finished "Bundling Client Webpack", visit `https://localhost:3300` in the browser and view your beautiful Hello World!
 
 All React components are stored in the `app/` directory, with the main entry component being `app/App.jsx`. Here is the initial scaffolding you should see in your project folder:
-* `.vscode/` - VSCode editor settings for code linting
 * `app/` - majority of the front-end site code
   * `components/` - components that are used by multiple pages
   * `pages/` - page-specific components (like the homepage and profiles)
@@ -69,9 +61,16 @@ All React components are stored in the `app/` directory, with the main entry com
   * `routes.jsx` - hook ups for all of the page routes
   * `style.yml` - global color and style variables
 * `static/` - static files used by the site like images and PDFs
-* `.eslintrc` - javascript style rules used for consistent coding
-* `.gitignore` - development files to exclude from the git repository
+* `typings` - directory of types to define types of certain variables
 * `canon.js` - contains any canon settings/modifications (empty by default)
+* `.vscode/` - VSCode editor settings for code linting
+* `.env` - a file of environment variables needed to properly configure the app
+* `.gitignore` - development files to exclude from the git repository
+
+## Running Development Server
+
+Now that the necessary files are in place, you can run `npm run dev` to spin up the development server. Once the process finished "Bundling Client Webpack", visit `https://localhost:3300` in the browser and view your beautiful Hello World!
+
 
 ---
 


### PR DESCRIPTION
Made some small edits to update/enhance the Canon docs.

Included changes:
- added summaries to root level README for packages (for the noobs like myself)
- made some edits to the purpose statement of the Canon CMS (@jhmullen let me know if you hate it and I can revert it)
- added small section for detailing how to bypass CORS issues with simple proxy when connecting a Canon app to a local Tesseract instance
- updated described Canon boilerplate to match current create-canon output