### PR TITLE
adds redirects to clientside

### DIFF
--- a/packages/core/src/client.jsx
+++ b/packages/core/src/client.jsx
@@ -19,6 +19,7 @@ import {middleware as reduxMiddleware} from "$app/store";
 import configureStore from "./storeConfig";
 import {LOADING_END, LOADING_START} from "./consts";
 import preRenderMiddleware from "./middlewares/preRenderMiddleware";
+import maybeRedirect from "./helpers/maybeRedirect";
 import styles from "$app/style.yml";
 
 /**
@@ -151,6 +152,8 @@ function renderMiddleware() {
               preRenderMiddleware(store, newProps)
                 .then(() => {
                   store.dispatch({type: LOADING_END});
+                  const idRedirect = maybeRedirect(query, props, store.getState());
+                  if (idRedirect) props.router.push(idRedirect);
                   postRender();
                 });
             });

--- a/packages/core/src/helpers/maybeRedirect.js
+++ b/packages/core/src/helpers/maybeRedirect.js
@@ -1,0 +1,27 @@
+/**
+ * Helper function for building redirect links. When a cms need returns a canonRedirect key,
+ * build a new URL that uses slugs instead of ids and return that URL for 301 redirects (or false, if not)
+ */
+module.exports = (query, props, initialState) => {
+  // Needs may return a special canonRedirect key. If they do so, process a redirect, using the variables provided
+  // in those objects as variables to substitute in the routes.
+  const redirects = Object.values(initialState.data).filter(d => d.canonRedirect);
+  // If the query contains ?redirect=true, a redirect has already occurred. To avoid redirect loops, ensure this value is unset
+  if (!query.redirect && redirects.length > 0) {
+    // If any needs provided redirect keys, combine them into one object.
+    const variables = redirects.reduce((acc, d) => ({...acc, ...d.canonRedirect}), {});
+    // Use variables given by the canonRedirect key, but fall back on given params (to cover for unprovided keys, like :lang)
+    const params = {...props.params, ...variables};
+    // Not sure if this is a reliable way to get which route this is.
+    let route = props.routes[1].path;
+    // Sort the keys to be "integers first," i.e., slug<int> before slug.
+    // This ensures that the swaps are processed "outside-in" (descending), and ":slug" doesn't match INSIDE ":slug2"
+    Object.keys(params).sort(a => (/\d/).test(a) ? -1 : 1).forEach(key => {
+      route = route.replace(new RegExp(`[(]{0,1}\/:${key}[)]{0,1}`), params[key] ? `/${params[key]}` : "");
+    });
+    // Pass a ?redirect flag, to avoid a redirect loop
+    // return res.redirect(301, `${route}?redirect=true`);
+    return `${route}?redirect=true`;
+  }
+  else return false;
+};

--- a/packages/core/src/server.jsx
+++ b/packages/core/src/server.jsx
@@ -12,6 +12,7 @@ import createRoutes from "$app/routes";
 import {initialState as appInitialState} from "$app/store";
 import preRenderMiddleware from "./middlewares/preRenderMiddleware";
 import pretty from "pretty";
+import maybeRedirect from "./helpers/maybeRedirect";
 
 import CanonProvider from "./CanonProvider";
 
@@ -153,25 +154,9 @@ export default function(defaultStore = appInitialState, headerConfig, reduxMiddl
               .then(() => {
 
                 const initialState = store.getState();
-                // Needs may return a special canonRedirect key. If they do so, process a redirect, using the variables provided
-                // in those objects as variables to substitute in the routes.
-                const redirects = Object.values(initialState.data).filter(d => d.canonRedirect);
-                // If the query contains ?redirect=true, a redirect has already occurred. To avoid redirect loops, ensure this value is unset
-                if (!req.query.redirect && redirects.length > 0) {
-                  // If any needs provided redirect keys, combine them into one object.
-                  const variables = redirects.reduce((acc, d) => ({...acc, ...d.canonRedirect}), {});
-                  // Use variables given by the canonRedirect key, but fall back on given params (to cover for unprovided keys, like :lang)
-                  const params = {...props.params, ...variables};
-                  // Not sure if this is a reliable way to get which route this is.
-                  let route = props.routes[1].path;
-                  // Sort the keys to be "integers first," i.e., slug<int> before slug.
-                  // This ensures that the swaps are processed "outside-in" (descending), and ":slug" doesn't match INSIDE ":slug2"
-                  Object.keys(params).sort(a => (/\d/).test(a) ? -1 : 1).forEach(key => {
-                    route = route.replace(new RegExp(`[(]{0,1}\/:${key}[)]{0,1}`), params[key] ? `/${params[key]}` : "");
-                  });
-                  // Pass a ?redirect flag, to avoid a redirect loop
-                  return res.redirect(301, `${route}?redirect=true`);
-                }
+
+                const idRedirect = maybeRedirect(req.query, props, initialState);
+                if (idRedirect) return res.redirect(301, idRedirect);
 
                 let status = 200;
                 for (const key in initialState.data) {


### PR DESCRIPTION
301 redirects were only implemented server side, so local hrefs weren't properly forwarding. 

This PR abstracts the redirect logic to an external helper file, and implements it in client.jsx.

@davelandry I'm using `router.push` client side if I determine that a redirect is necessary. This works in my testing, can you let me know if I should be doing something different here?