### PR TITLE
Fix table passthru

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -434,6 +434,29 @@ This value is a variable from your list of variables whose truthiness determines
 
 This can be used to hide sections dynamically, list only certain select options for given members, or only run generators for certain members.
 
+#### Applying Styles
+
+React-table provides access to a `Cell` method, referenced [here](https://github.com/tannerlinsley/react-table/tree/v6#example), which allows the return of a JSX element for formatting purposes. However, CMS visualization definitions are written in ES6 and run client-side, and therefore cannot be transpiled into JSX. This architectural mismatch is a side effect of combining the d3plus style "plain old javascript" configuration with a JSX component, namely React-Table. The JSX parameters that React-Table wants can't always be provided by vanilla, untranspiled front-end js.
+
+However, if you need access to the `.styles` key of the cell object, a `cellStyle` method has been added to the column definition. This method is invoked inside the JSX callback, so you have may modify and return the object (ES6 only!)
+
+```js
+return {
+  columns: [
+    {Header: "custom", accessor: "id"},
+    {Header: "headers", accessor: "x", cellStyle: row => {
+      row.styles.color = "red";
+      row.value = row.value + "%";
+      return row;
+    }},
+    {Header: "testing", accessor: "y"}
+  ],
+  ...
+};
+```
+
+This `cellStyle` method operates much like the `Cell` method of react-table, but again, *you may not return a JSX element*. Make vanilla ES6 modifications to the object and return it.
+
 ---
 
 ## Custom Sections

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -158,7 +158,8 @@ class Table extends Component {
       Cell: cell => {
         if (obj.cellStyle) {
           try {
-            cell = obj.cellStyle(cell);
+            const newCell = obj.cellStyle(cell);
+            if (newCell) cell = newCell;  // the spec asks for a return value, but support editing by reference as well.
           }
           catch (e) {
             console.error("Error in cellStyle");

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -107,9 +107,10 @@ class Table extends Component {
   // render ungrouped column
   renderColumn = (obj, config) => {
     const {data, headerFormat, cellFormat} = config;
-    const col = typeof obj === "string" ? obj : obj.key;
+    const col = typeof obj === "string" ? obj : obj.accessor;
     const onClick = typeof obj === "object" ? obj.onClick : undefined;
-    const title = headerFormat ? headerFormat(col) : col;
+    const header = obj.Header ? obj.Header : obj.accessor;
+    const title = headerFormat ? headerFormat(header) : header;
 
     /** */
     function formatValue(cell, value) {
@@ -155,6 +156,7 @@ class Table extends Component {
       minWidth,
       maxWidth: minWidth < 100 ? minWidth : undefined,
       Cell: cell => {
+        if (obj.Cell) obj.Cell(cell);
         const html = formatValue(cell, cell.value);
         return <span className={`cp-table-cell-inner cp-table-cell-inner-${onClick ? "clickable" : "static"}`} onClick={onClick ? onClick.bind(this, cell.original) : undefined} dangerouslySetInnerHTML={{__html: html}} />;
       }
@@ -179,7 +181,7 @@ class Table extends Component {
 
     const tableStructure = columns.map(col => {
       // if the current column is a string alone, render the column
-      if (typeof col === "string" || typeof col === "object" && col.key) {
+      if (typeof col === "string" || typeof col === "object" && col.accessor) {
         return this.renderColumn(col, config);
       }
       else if (Array.isArray(col)) {

--- a/packages/cms/src/components/Viz/Table.jsx
+++ b/packages/cms/src/components/Viz/Table.jsx
@@ -156,7 +156,14 @@ class Table extends Component {
       minWidth,
       maxWidth: minWidth < 100 ? minWidth : undefined,
       Cell: cell => {
-        if (obj.Cell) obj.Cell(cell);
+        if (obj.cellStyle) {
+          try {
+            cell = obj.cellStyle(cell);
+          }
+          catch (e) {
+            console.error("Error in cellStyle");
+          }
+        }
         const html = formatValue(cell, cell.value);
         return <span className={`cp-table-cell-inner cp-table-cell-inner-${onClick ? "clickable" : "static"}`} onClick={onClick ? onClick.bind(this, cell.original) : undefined} dangerouslySetInnerHTML={{__html: html}} />;
       }
@@ -188,7 +195,12 @@ class Table extends Component {
         return this.renderGrouping(col, config);
       }
       else return {};
-    }).filter(Boolean); // handle malformed tables
+    }).filter(Boolean) // handle malformed tables
+      .map(d => {   // remove front-end styling method (irrelevant to react-table)
+        if (d.cellStyle) delete d.cellStyle;
+        return d;
+      });
+
 
     if (print && typeof window !== "undefined") {
       const totalWidth = sum(tableStructure, d => d.minWidth);


### PR DESCRIPTION
Fixes passthrough for `Header` in react-table, also adds a `cellStyle` callback to allow partial access to the `Cell` function