### PR TITLE
[cms/core] ProfileSearch improvements

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -575,6 +575,10 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   availableProfiles={[]} // limit the type of profile results to show (ie. ["hs92", "country"])
   columnOrder={[]} // the order of the "columns" display (ie. ["hs92", "country"])
   columnTitles={{}} // overrides for the default column titles (ie. {hs92: "Products"})
+  defaultCubes={false} // default cube names (comma-separate) to use when mounting the component
+  defaultLevels={false} // default level names (comma-separate) to use when mounting the component
+  defaultProfiles={false} // default profile IDs (comma-separate) to use when mounting the component
+  defaultQuery={""} // default search query to use when mounting the component
   display={"list"} // available options are "list", "columns", and "grid"
   filters={false} // enables a set of nested profile, hierarchy, and cube filters
   filterCubeTitle={cubeName => cubeName} // cube title used for filters (allows for grouping cubes with matching labels)

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -387,7 +387,7 @@ class ProfileSearch extends Component {
           <li key="filters-all"
             className={`cms-profilesearch-filters-profile${!filterProfiles ? " active" : ""}`}
             onClick={() => this.setState({filterProfiles: false}, this.onFilterLevel.bind(this, false))}
-            dangerouslySetInnerHTML={{__html: filterProfileTitle({label: "All"})}} />
+            dangerouslySetInnerHTML={{__html: filterProfileTitle({label: t("CMS.Search.All")})}} />
           { profileGroups.map(g => {
             const profileIds = g[1].map(p => p.id);
             return <li key={`filters-${profileIds.join("-")}`}

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -72,13 +72,13 @@ class ProfileSearch extends Component {
     super(props);
     this.state = {
       active: false,
-      filterCubes: false,
-      filterProfiles: false,
-      filterLevels: false,
+      filterCubes: props.defaultCubes,
+      filterProfiles: props.defaultProfiles,
+      filterLevels: props.defaultLevels,
       id: uuid(),
       loading: false,
       profiles: false,
-      query: "",
+      query: props.defaultQuery,
       results: false,
       timeout: 0
     };
@@ -97,7 +97,7 @@ class ProfileSearch extends Component {
     if (query.cubes) queryArgs.filterCubes = query.cubes;
 
     if (Object.keys(queryArgs).length) this.setState(queryArgs, showExamples ? this.onChange.bind(this) : undefined);
-    else if (showExamples) this.onChange.bind(this)();
+    else if (showExamples || this.state.query.length) this.onChange.bind(this)();
 
     select(document).on(`mousedown.${id}`, event => {
       const {active} = this.state;
@@ -427,7 +427,7 @@ class ProfileSearch extends Component {
               ? (() => {
 
                 if (!results.grouped.length) {
-                  return <NonIdealState key="empty" icon="zoom-out" title={t("CMS.Search.No results", {query})} />;
+                  return <NonIdealState key="empty" icon="zoom-out" title={t("CMS.Search.No results", {query, interpolation: {escapeValue: false}})} />;
                 }
 
                 else {
@@ -500,6 +500,10 @@ ProfileSearch.defaultProps = {
   availableProfiles: [],
   columnOrder: [],
   columnTitles: {},
+  defaultCubes: false,
+  defaultProfiles: false,
+  defaultLevels: false,
+  defaultQuery: "",
   display: "list",
   filters: false,
   filterCubeTitle: d => d,

--- a/packages/cms/src/components/sections/Hero.css
+++ b/packages/cms/src/components/sections/Hero.css
@@ -218,6 +218,7 @@
 .bp3-dialog.cp-hero-search {
   background: var(--white);
   padding: var(--gutter-md) var(--gutter-md) 0;
+  width: 85%;
   & .cms-profilesearch {
     height: 75vh;
   }

--- a/packages/core/src/i18n/canon.js
+++ b/packages/core/src/i18n/canon.js
@@ -53,6 +53,7 @@ export default {
       "Download Page as PDF": "Download Page as PDF"
     },
     "Search": {
+      "All": "All",
       "Empty": "Please enter a search term",
       "Loading": "Loading results...",
       "No results": "No results matching \"{{query}}\"",


### PR DESCRIPTION
* adds ProfileSearch "All" text to default canon i18n translations (closes #1199)
* adds default props to ProfileSearch and fixes encoding error in query display
* uses ProfileSearch filters in Hero search (closes #1186)