### PR TITLE
[cms] hero search bugfixes

### DIFF
--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -244,9 +244,10 @@ class ProfileSearch extends Component {
 
   resetSearch() {
     this.setState({
-      query: "",
-      results: false
-    });
+      filterProfiles: false,
+      query: ""
+    },
+    this.onFilterLevel.bind(this, false));
   }
 
   onFocus() {

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -78,21 +78,32 @@ class Hero extends Component {
   }
 
   spanifyTitle(title) {
+
     const {profile} = this.props;
     const {variables} = profile;
+
     // stories don't have variables
-    if (!variables) return title;
-    const {name1, name2} = variables;
-    // some titles have <> signs in them. encode them, so the span doesn't break.
-    const fixHTML = d => d ? d.replace(/\</g, "&lt;").replace(/\>/g, "&gt;") : d;
-    if (title) {
-      return title
-        .replace(name1, `<span class="cp-hero-heading-dimension" title=${fixHTML(name1)} onClick=titleClick(0)>${fixHTML(name1)}</span>`)
-        .replace(name2, `<span class="cp-hero-heading-dimension" title=${fixHTML(name2)} onClick=titleClick(1)>${fixHTML(name2)}</span>`);
+    if (variables && title) {
+
+      const names = [variables.name1, variables.name2];
+
+      // must swap names completely out, longest to shortest, to protect against
+      // titles within other titles (ie. "Brazil Nuts from Brazil")
+      const swappedTitle = names.sort((a, b) => b.length - a.length)
+        .reduce((t, name) => t.replace(name, `{{name${names.indexOf(name) + 1}}}`), title);
+
+      // some titles have <> signs in them. encode them, so the span doesn't break.
+      const fixHTML = d => d ? d.replace(/\</g, "&lt;").replace(/\>/g, "&gt;") : d;
+
+      return swappedTitle.replace(/\{\{name([0-2])\}\}/g, (str, i) => {
+        const name = names[i - 1];
+        return `<span class="cp-hero-heading-dimension" title=${fixHTML(name)} onClick=titleClick(${i - 1})>${fixHTML(name)}</span>`;
+      });
+
     }
-    else {
-      return title;
-    }
+
+    return title;
+
   }
 
   render() {

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -272,6 +272,7 @@ class Hero extends Component {
             filters={true}
             inputFontSize="lg"
             display="grid"
+            showExamples={true}
             {...searchProps}
           />
         </Dialog>

--- a/packages/cms/src/utils/formatters/stripHTML.js
+++ b/packages/cms/src/utils/formatters/stripHTML.js
@@ -1,8 +1,24 @@
+// Internal list of HTML entities for escaping.
+const entities = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": "\"",
+  "&#x27;": "'",
+  "&#x60;": "`",
+  "&nbsp;": ""
+};
+
+const source = `(?:${ Object.keys(entities).join("|")  })`;
+const testRegexp = RegExp(source);
+const replaceRegexp = RegExp(source, "g");
+
 /**
 * Converts html tags to spaces, then removes redundant spaces
 */
 function stripHTML(n) {
-  return String(n).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  const s = String(n).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  return testRegexp.test(s) ? s.replace(replaceRegexp, match => entities[match]) : s;
 }
 
 module.exports = stripHTML;


### PR DESCRIPTION
 * adds basic HTML entity stripping to stripHTML formatter - fixes `&nbsp;` appearing in OEC Hero search input (5463989)
 * fixes bug in Hero spanifyTitle with titles within other titles - fixes "Brazil Nuts in Brazil" (4a7fd8b)
 * enables showExamples in the default Hero ProfileSearch - thought this was nice behavior (708faa6)
 * resets ProfileSearch filters when clicking the "X" button - requested by OEC (a4d910b)