### PR TITLE
GDPR support

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -852,6 +852,8 @@ export CANON_LANGUAGE_DEFAULT="es"
 |`CANON_BASE_URL`|If hosting assets or running the server from a different location that the project folder, this variable can be used to define the base URL for all static assets. A `<base>` tag will be added to the start of the `<head>` tag.|`undefined`|
 |`CANON_GOOGLE_ANALYTICS`|The unique Google Analytics ID for the project (ex. `"UA-########-#"`). This also supports comma-separated values, if it's desired for pageviews to be reported to multiple analytics properties.|`undefined`|
 |`CANON_FACEBOOK_PIXEL`|The unique Facebook Pixel ID for the project (ex. `"################"`).|`undefined`|
+|`CANON_GDPR`|When set to `true`, tracking services like Google Analytics and Faceboook Pixel will only be loaded after the user accepts the usage of cookies and tracking. A pop-up Drawer will be shown on the bottom of the screen containing text and buttons that are editable in the locales JSON file.|`false`|
+|`CANON_GDPR_WAIT`|By default, if a user has not chosen whether to accept or reject the GDPR message, we will assume consent and not ask on subsequent page visits. If this env var is set to `true`, tracking services will only execute after the user has explicitly accepted.|`false`|
 |`CANON_GOOGLE_TAG_MANAGER`|The unique Google Tag Manager ID for the project (ex. `"GTM-#######"`).|`undefined`|
 |`CANON_HELMET_FRAMEGUARD`|Pass-through option for the "frameguard" property of the [helmet](https://github.com/helmetjs/helmet#how-it-works) initialization.|`false`|
 |`CANON_HOTJAR`|The unique Hotjar ID for the project (ex. `"#######"`).|`undefined`|

--- a/packages/core/bin/server/steps/store.js
+++ b/packages/core/bin/server/steps/store.js
@@ -1,5 +1,6 @@
 const path = require("path"),
-      shell = require("shelljs");
+      shell = require("shelljs"),
+      yn = require("yn");
 
 let everDetect = false;
 
@@ -20,6 +21,7 @@ module.exports = function(config) {
   const LANGUAGES = process.env.CANON_LANGUAGES || LANGUAGE_DEFAULT;
   store.env = {
     CANON_API: process.env.CANON_API || "http://localhost:3300",
+    CANON_GDPR: yn(process.env.CANON_GDPR) || false,
     CANON_LANGUAGES: LANGUAGES,
     CANON_LANGUAGE_DEFAULT: LANGUAGE_DEFAULT,
     CANON_LOGINS: process.env.CANON_LOGINS || false,

--- a/packages/core/src/CanonProvider.css
+++ b/packages/core/src/CanonProvider.css
@@ -1,0 +1,12 @@
+#cookies-eu-banner {
+  background-color: var(--dark-2);
+  bottom: 0;
+  color: var(--light-1);
+  padding: var(--gutter-sm) var(--gutter-md) calc(var(--gutter-sm) + 1px);
+  position: fixed;
+  text-align: center;
+  width: 100%;
+  & * {
+    margin: 0 var(--gutter-xs);
+  }
+}

--- a/packages/core/src/CanonProvider.jsx
+++ b/packages/core/src/CanonProvider.jsx
@@ -2,11 +2,14 @@ import React, {Component} from "react";
 import {match} from "react-router";
 import PropTypes from "prop-types";
 import {connect} from "react-redux";
+import {withNamespaces} from "react-i18next";
 import Loading from "$app/components/Loading";
 import d3plus from "$app/d3plus.js";
 import {Helmet} from "react-helmet-async";
 import urllite from "urllite";
 import {Portal, Toaster} from "@blueprintjs/core";
+import {titleCase} from "d3plus-text";
+import "./CanonProvider.css";
 
 /**
 blueprint tooltip IE fix; check that the window exists and that we're in IE first
@@ -184,7 +187,7 @@ class CanonProvider extends Component {
 
   render() {
 
-    const {children, helmet, loading, locale} = this.props;
+    const {children, gdpr, helmet, loading, locale, privacy, services, t} = this.props;
 
     return <div id="Canon" onClick={this.onClick.bind(this)}>
       <Helmet
@@ -198,6 +201,12 @@ class CanonProvider extends Component {
       <Portal>
         <Toaster ref={this.toastRef} />
       </Portal>
+      { gdpr ? <div id="cookies-eu-banner" style={{display: "none"}}>
+        <span id="cookies-eu-desc">{t("GDPR.desc", {services})}</span>
+        { privacy ? <a href={privacy} id="cookies-eu-more">{t("GDPR.more")}</a> : null }
+        <button id="cookies-eu-reject" className="bp3-button">{t("GDPR.reject")}</button>
+        <button id="cookies-eu-accept" className="bp3-button">{t("GDPR.accept")}</button>
+      </div> : null }
     </div>;
   }
 }
@@ -216,7 +225,15 @@ CanonProvider.defaultProps = {
   data: {}
 };
 
-export default connect(state => ({
-  data: state.data,
-  loading: state.loading
-}))(CanonProvider);
+export default withNamespaces()(
+  connect(state => {
+    const servicesNames = state.services.map(s => titleCase(s.replace(/\_/g, " ")));
+    return {
+      data: state.data,
+      gdpr: state.env.CANON_GDPR,
+      loading: state.loading,
+      privacy: state.legal.privacy,
+      services: servicesNames
+    };
+  })(CanonProvider)
+);

--- a/packages/core/src/helpers/services.js
+++ b/packages/core/src/helpers/services.js
@@ -1,0 +1,54 @@
+import {titleCase} from "d3plus-text";
+
+const serviceJavaScript = {
+  FACEBOOK_PIXEL: id => `!function(f,b,e,v,n,t,s) {if(f.fbq)return;n=f.fbq=function(){
+        n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+        n.queue=[];t=b.createElement(e);t.async=!0; t.src=v;s=b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t,s)}(window,document,'script', 'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '${id}'); fbq('track', 'PageView');`,
+  GOOGLE_TAG_MANAGER: id => `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${id}');`,
+  GOOGLE_ANALYTICS: id => `(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        ${id.split(",").map((key, i) => `ga('create', '${key}', 'auto', 'tracker${i + 1}');`).join("\n      ")}
+        ${id.split(",").map((key, i) => `ga('tracker${i + 1}.send', 'pageview');`).join("\n      ")}`,
+  HOTJAR: id => `(function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:${id},hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;
+          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`
+};
+
+const serviceHTML = {
+  GOOGLE_TAG_MANAGER: id => `<noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=${id}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>`
+};
+
+const servicesAvailable = Object.keys(serviceJavaScript).filter(s => process.env[`CANON_${s}`] !== undefined);
+
+const servicesScript = servicesAvailable
+  .map(s => `
+        // ${titleCase(s.replace(/\_/g, " "))}
+        ${serviceJavaScript[s](process.env[`CANON_${s}`])}
+        // End ${titleCase(s.replace(/\_/g, " "))}
+  `).join("\n");
+
+const servicesBody = servicesAvailable
+  .filter(s => serviceHTML[s])
+  .map(s => `
+    <!-- ${titleCase(s.replace(/\_/g, " "))} -->
+    ${serviceHTML[s](process.env[`CANON_${s}`])}
+    <!-- End ${titleCase(s.replace(/\_/g, " "))} -->
+  `).join("\n");
+
+export {servicesAvailable, servicesBody, servicesScript};

--- a/packages/core/src/i18n/canon.js
+++ b/packages/core/src/i18n/canon.js
@@ -80,6 +80,12 @@ export default {
       "rows": "rows"
     }
   },
+  "GDPR": {
+    "accept": "Accept",
+    "desc": "By continuing to visit this site, you accept to the use of cookies by {{services}} for statistical purposes.",
+    "more": "Read More",
+    "reject": "Reject"
+  },
   "Loading": {
     "description": "Loading {{progress}} of {{total}} datasets",
     "title": "Please Wait"

--- a/packages/core/src/storeConfig.js
+++ b/packages/core/src/storeConfig.js
@@ -37,6 +37,7 @@ export default function storeConfig(initialState, history, reduxMiddleware = fal
     location: (state = {}) => state,
     mailgun: (state = false) => state,
     routing: routerReducer,
+    services: (state = []) => state,
     social: (state = []) => state
   }, appReducers));
 

--- a/packages/vizbuilder/src/types/state.d.ts
+++ b/packages/vizbuilder/src/types/state.d.ts
@@ -9,6 +9,7 @@ interface GeneralState {
   location: any;
   mailgun: any;
   routing: any;
+  services: any;
   social: any;
   instances: any;
   vizbuilder: VizbuilderState;


### PR DESCRIPTION
This PR closes #685 by adding 2 new environment variables:
* `CANON_GDPR` - setting this to `true` will show a minimally styled fixed position box on the bottom of the screen (shown here in screenshot) that will ask the user to accept/deny the use of tracking code (all text is stored in the locale files for translation/modification). Tracking code is only run when the user clicks "Accept", or they refresh the page (the lack of response is considered "consent").
* `CANON_GDPR_WAIT` - setting this to `true` requires a user to click "Accept" in order to run the tracking code, resulting in the pop-up being shown on every page visit until they either accept or reject.

<img width="1104" alt="Screen Shot 2021-07-28 at 4 16 32 PM" src="https://user-images.githubusercontent.com/1847581/127392308-72470723-ab52-47ca-9a30-4abc60b5ff52.png">
