### PR TITLE
[core] preserves custom properties in transpiled CSS

### DIFF
--- a/packages/core/webpack/config/postcss.js
+++ b/packages/core/webpack/config/postcss.js
@@ -46,6 +46,7 @@ module.exports = [
     preserve: false
   }),
   require("postcss-css-variables")({
+    preserve: true,
     variables
   }),
   require("postcss-map")({


### PR DESCRIPTION
## Summary

We currently use the `postcss-css-variables` plugin to enable the use of [custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) in our CSS. At one time, this feature was a future spec of CSS, but is actually now supported in all modern browsers.

In it's current implementation, this plugin will take the following source code:

```css
:root {
  --color: green;
}

button {
  background: var(--color);
}
```

And turn it into this, so that it can be read by all browsers:

```css
button {
  background: green;
}
```

My proposed one-line change, adding `preserve: true` to the config of the plugin, makes the output look like this:

```css
:root {
  --color: green;
}

button {
  background: green;
  background: var(--color);
}
```

This allows IE to still render the correct color, but allows for more advanced client-side usage of `var`. For example, when wanting to toggle between 2 instances of a variable definition based on user behavior:

```css
:root {
  --color: green;
}

[data-theme="dark"] {
  --color: red;
}

button {
  background: var(--color);
}
```

## Tests
- [x] works in dev oec-site
- [x] works in prod oec-site
- [x] works in IE11 (unknown CSS properties are simply ignored)