### PR TITLE
[core] removes postcss-color-function and all color references in CSS

### DIFF
--- a/examples/app/components/mixins.css
+++ b/examples/app/components/mixins.css
@@ -146,8 +146,8 @@ theming
   background: var(--light-1); /* base */
   background-image: linear-gradient(
     180deg,
-    color(var(--light-3) a(0.02)) 0%,
-    color(var(--black) a(0.02)) 100%
+    rgba(var(--light-3-RGB), 0.02) 0%,
+    rgba(var(--black-RGB), 0.02) 100%
   );
   color: var(--dark-2);
 
@@ -155,36 +155,117 @@ theming
     background: var(--dark-2); /* base */
     background-image: linear-gradient(
       180deg,
-      color(var(--light-3) a(0.02)) 0%,
-      color(var(--black) a(0.02)) 100%
+      rgba(var(--light-3-RGB), 0.02) 0%,
+      rgba(var(--black-RGB), 0.02) 100%
     );
     color: var(--dark-1);
   }
 }
 @define-mixin cms-button-shadow {
   box-shadow:
-    0 1px 2px color(var(--black) a(0.1)),
-    0 1px 8px color(var(--black) a(0.1)),
-    inset 0 1px 0 color(var(--white) a(0.33));
+    0 1px 2px rgba(var(--black-RGB), 0.1),
+    0 1px 8px rgba(var(--black-RGB), 0.1),
+    inset 0 1px 0 rgba(var(--white-RGB), 0.33);
 
   @mixin dark-mode {
     box-shadow:
-      0 1px 4px color(var(--black) a(0.333)),
-      0 4px 8px color(var(--black) a(0.2)),
-      inset 0 1px 0 color(var(--dark-2) a(0.333));
+      0 1px 4px rgba(var(--black-RGB), 0.333),
+      0 4px 8px rgba(var(--black-RGB), 0.2),
+      inset 0 1px 0 rgba(var(--dark-2-RGB), 0.333);
   }
 
   &:hover, &:focus {
     box-shadow:
-      0 1px 2px color(var(--black) a(0.1)),
-      0 2px 8px color(var(--black) a(0.2)),
-      inset 0 1px 0 color(var(--white) a(0.33));
+      0 1px 2px rgba(var(--black-RGB), 0.1),
+      0 2px 8px rgba(var(--black-RGB), 0.2),
+      inset 0 1px 0 rgba(var(--white-RGB), 0.33);
 
     @mixin dark-mode {
       box-shadow:
-        0 2px 4px color(var(--black) a(0.5)),
-        0 2px 12px color(var(--black) a(0.333)),
-        inset 0 1px 0 color(var(--dark-2) a(0.333));
+        0 2px 4px rgba(var(--black-RGB), 0.5),
+        0 2px 12px rgba(var(--black-RGB), 0.333),
+        inset 0 1px 0 rgba(var(--dark-2-RGB), 0.333);
+    }
+  }
+}
+@define-mixin cms-button-style {
+  @mixin cms-button-theming;
+  @mixin cms-button-shadow;
+  border: none; /* reset browser default */
+  border-radius: 10em;
+  padding: 0.5em 1.25em;
+
+  /* interactions */
+  &:hover, &:focus {
+    color: var(--accent-black);
+
+    @mixin dark-mode {
+      color: var(--accent-light);
+    }
+
+    & > .cms-button-icon {
+      transform: scale(1.125);
+
+      /* gears keep on turning */
+      &[class*="cog"] {
+         transform: scale(1.125) rotate(-30deg);
+      }
+      &[class*="trash"] {
+        color: var(--alert);
+
+        @mixin dark-mode {
+          color: var(--alert-light);
+        }
+      }
+    }
+  }
+}
+@define-mixin disabled-button {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+@define-mixin cms-disabled-button-style {
+  box-shadow: none !important;
+  background: var(--light-2) !important;
+  color: var(--gray) !important;
+
+  @mixin dark-mode {
+    background: var(--black) !important;
+    color: var(--dark-2) !important;
+  }
+}
+
+/* dialog/alert overlay */
+@define-mixin overlay-theme {
+  @mixin button-reset;
+  z-index: -1;
+
+  &:focus {
+    border: 2px solid var(--accent-dark);
+    outline: none;
+    transition-delay: 0.5s;
+  }
+}
+
+/* text input */
+@define-mixin cms-text-input-style {
+  /* theming */
+  background-color: var(--white);
+  border: 1px solid var(--light-3);
+  color: var(--dark-2);
+
+  &::placeholder {
+    @mixin font-smoothing;
+    color: var(--gray);
+  }
+
+  @mixin dark-mode {
+    background-color: rgba(var(--black-RGB) 0.75);
+    border-color: var(--black);
+    color: var(--light-1);
+
+    &::placeholder {
+      color: var(--dark-1);
     }
   }
 }
@@ -229,10 +310,26 @@ layout
 }
 
 @define-mixin hide-scrollbars {
-  -ms-overflow-style: none;
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+/* overflow with inertia scrolling */
+@define-mixin overflow-container {
+  overflow: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+@define-mixin vertical-overflow-container {
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
+}
+@define-mixin horizontal-overflow-container {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 
@@ -272,6 +369,62 @@ print stylesheet helpers
 }
 
 /* -----------------------------------
+CMS nav links & dropdowns
+----------------------------------- */
+@define-mixin cms-nav-link-theme {
+  color: var(--dark-1);
+
+  &:hover, &:focus, &.is-active {
+    color: var(--dark-2);
+    @mixin dark-mode { color: var(--light-2); }
+  }
+
+  /* dropdown toggled open */
+  &.is-active {
+    color: var(--dark-3);
+    @mixin dark-mode { color: var(--light-1); }
+    & path { fill: var(--accent); }
+  }
+
+  /* current page */
+  &.is-selected {
+    color: var(--black);
+    @mixin dark-mode { color: var(--white); }
+  }
+}
+@define-mixin cms-nav-toggle-transition {
+  transition:
+    background-color 0.2s ease-out,
+    opacity 0.2s ease-out,
+    transform 0.2s ease-out;
+}
+@define-mixin cms-nav-closed-state {
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+  pointer-events: none;
+  /* add a transform as well */
+}
+
+/* -----------------------------------
+Link styles
+----------------------------------- */
+@define-mixin link-theme {
+  font-weight: var(--display-font-weight);
+  letter-spacing: 0.01em;
+  color: var(--accent);
+
+  &:hover, &:focus {
+    text-decoration: underline;
+    color: var(--accent-dark);
+
+    @mixin dark-mode {
+      color: var(--accent-light);
+    }
+  }
+}
+
+/* -----------------------------------
 VarTable & VarList
 ----------------------------------- */
 @define-mixin var-overflow {
@@ -280,8 +433,7 @@ VarTable & VarList
   border-radius: 2px;
   /* handle overflow */
   display: block; /* needed to honor overflow */
-  overflow: auto;
-  -webkit-overflow-scrolling: touch; /* enable inertia scrolling */
+  @mixin overflow-container;
   z-index: 1;
   /* theming */
   background-color: transparent;
@@ -291,7 +443,7 @@ VarTable & VarList
 
   /* DARK THEME */
   @mixin dark-mode {
-    background-color: color(var(--black) a(0.75));
+    background-color: rgba(var(--black-RGB) 0.75);
     border: 1px solid var(--dark-3);
     box-shadow: none;
     color: var(--light-3);
@@ -311,5 +463,19 @@ VarTable & VarList
 
   @mixin dark-mode {
     color: var(--alert-light);
+  }
+}
+
+/* -----------------------------------
+meta editor images
+----------------------------------- */
+@define-mixin meta-editor-img-wrapper {
+  background-color: var(--light-2);
+  border: 1px solid var(--gray);
+  transition: border 0.2s ease-out;
+
+  @mixin dark-mode {
+    background-color: rgba(var(--black-RGB), 0.5);
+    border-color: var(--black);
   }
 }

--- a/examples/app/style.yml
+++ b/examples/app/style.yml
@@ -41,6 +41,19 @@ accent-light: "#FFD65B"
 accent-dark:  "#C4960B"
 accent-black: "#7F6516"
 
+# RGB versions of colors for use with alpha channels
+white-RGB: 255, 255, 255
+light-1-RGB: 248, 249, 250
+light-2-RGB: 236, 239, 241
+light-3-RGB: 207, 218, 226
+gray-RGB: 174, 189, 204
+dark-1-RGB: 138, 151, 174
+dark-2-RGB: 42, 47, 59
+dark-3-RGB: 32, 36, 46
+black-RGB: 24, 26, 33
+
+accent-light-RGB: 255, 214, 91
+
 
 ########################################
 # admin panel
@@ -146,7 +159,7 @@ section-heading-color:      "var(--dark-3)"
 sticky-section-offset:      "50px" # px value required here unfortunately
 sticky-section-height:      "var(--nav-height)"
 sticky-section-bg-color:    "var(--white)"
-sticky-section-shadow:      "0 1px 0.375rem color(var(--black) a(0.125))"
+sticky-section-shadow:      "0 1px 0.375rem rgba(var(--black-RGB), 0.125)"
 # handle grouped SingleColumn sections with flex-basis
 singlecolumn-column-count:  "3"
 singlecolumn-min-width:     "20rem"
@@ -167,7 +180,7 @@ grouping-stat-value-color:  "var(--white)"
 # buttons
 button-border-radius:       "2px"
 button-border-width:        "1px"
-button-bg-color:            "color(var(--white) a(0.5))"
+button-bg-color:            "rgba(var(--white-RGB), 0.5)"
 button-border-color:        "var(--light-3)"
 button-color:               "var(--accent-black)"
 button-padding:             "0.5em 1.25em"
@@ -208,7 +221,7 @@ table-hgroup-bg-color:      "var(--light-2)" # top heading in a group of nested 
 table-hgroup-border-color:  "var(--light-3)"
 table-hgroup-text-color:    "var(--dark-3)"
 table-thead-bg-color:       "var(--dark-1)" # primary table headings
-table-thead-border-color:   "color(var(--dark-2) a(0.25))"
+table-thead-border-color:   "rgba(var(--dark-2-RGB), 0.25)"
 table-thead-text-color:     "var(--light-1)"
 table-cell-bg-color:        "var(--white)" # table cells
 table-cell-border-color:    "var(--light-2)"

--- a/packages/cms/app/style.yml
+++ b/packages/cms/app/style.yml
@@ -41,6 +41,17 @@ accent-light: "#FFD65B"
 accent-dark:  "#C4960B"
 accent-black: "#7F6516"
 
+# RGB versions of colors for use with alpha channels
+white-RGB: 255, 255, 255
+light-1-RGB: 248, 249, 250
+light-2-RGB: 236, 239, 241
+light-3-RGB: 207, 218, 226
+gray-RGB: 174, 189, 204
+dark-1-RGB: 138, 151, 174
+dark-2-RGB: 42, 47, 59
+dark-3-RGB: 32, 36, 46
+black-RGB: 24, 26, 33
+
 
 ########################################
 # admin panel
@@ -48,7 +59,7 @@ accent-black: "#7F6516"
 
 # UI colors
 alert-dark:         "#75224D"
-alert:              "#C6315C"
+alert:              "#992C64"
 alert-light:        "#DB64A6"
 
 type-number:        "#8EB6FF"
@@ -80,7 +91,8 @@ body-font-scale-xl:         "125%"   # 1rem = 20px (min-width: 1400px)
 
 # measurements
 nav-height:                 "50px"
-subnav-height:              "var(--nav-height)"
+test-height: "100px"
+subnav-height:              "var(--test-height)"
 container-width:            "80rem" # 1280px
 hero-container-width:       "var(--container-width)"
 
@@ -145,7 +157,7 @@ section-heading-color:      "var(--dark-3)"
 sticky-section-offset:      "50px" # px value required here unfortunately
 sticky-section-height:      "var(--nav-height)"
 sticky-section-bg-color:    "var(--white)"
-sticky-section-shadow:      "0 1px 0.375rem color(var(--black) a(0.125))"
+sticky-section-shadow:      "0 1px 0.375rem rgba(var(--black-RGB), 0.125)"
 # handle grouped SingleColumn sections with flex-basis
 singlecolumn-column-count:  "3"
 singlecolumn-min-width:     "20rem"
@@ -166,7 +178,7 @@ grouping-stat-value-color:  "var(--white)"
 # buttons
 button-border-radius:       "2px"
 button-border-width:        "1px"
-button-bg-color:            "color(var(--white) a(0.5))"
+button-bg-color:            "rgba(var(--white-RGB), 0.5)"
 button-border-color:        "var(--light-3)"
 button-color:               "var(--accent-black)"
 button-padding:             "0.5em 1.25em"
@@ -207,7 +219,7 @@ table-hgroup-bg-color:      "var(--light-2)" # top heading in a group of nested 
 table-hgroup-border-color:  "var(--light-3)"
 table-hgroup-text-color:    "var(--dark-3)"
 table-thead-bg-color:       "var(--dark-1)" # primary table headings
-table-thead-border-color:   "color(var(--dark-2) a(0.25))"
+table-thead-border-color:   "rgba(var(--dark-2-RGB), 0.25)"
 table-thead-text-color:     "var(--light-1)"
 table-cell-bg-color:        "var(--white)" # table cells
 table-cell-border-color:    "var(--light-2)"

--- a/packages/cms/src/components/Showcase.css
+++ b/packages/cms/src/components/Showcase.css
@@ -130,7 +130,7 @@
 .showcase-token-list .showcase-nested-list {
   column-width: 22rem;
   column-gap: var(--gutter-xl);
-  column-rule: 1px solid color(var(--gray) a(0.125));
+  column-rule: 1px solid rgba(var(--gray-RGB), 0.125);
 
   & > * {
     break-inside: avoid;
@@ -148,7 +148,7 @@
     top: 0; right: calc(0px - var(--gutter-md)); bottom: 0; left: calc(0px - var(--gutter-md));
     content: "";
     display: block;
-    background-color: color(var(--gray) a(0.125));
+    background-color: rgba(var(--gray-RGB), 0.125);
     opacity: 0;
     transition: opacity 0.05s ease-out;
   }
@@ -160,7 +160,7 @@
   bottom: -1px;
   width: 0.75em;
   left: calc(0px - var(--gutter-md));
-  border: 1px solid color(var(--gray) a(0.125));
+  border: 1px solid rgba(var(--gray-RGB), 0.125);
 }
 .showcase-token-label {
   font-weight: var(--heading-font-weight);

--- a/packages/cms/src/components/Viz/Table.css
+++ b/packages/cms/src/components/Viz/Table.css
@@ -105,7 +105,7 @@ NOTE: ripped from ReactTable
   }
 
   &:focus {
-    background-color: color(var(--white) a(0.125));
+    background-color: rgba(var(--white-RGB), 0.125);
     outline: 2px solid var(--accent);
     outline-offset: -2px;
 
@@ -133,7 +133,7 @@ NOTE: ripped from ReactTable
   /* interactions */
   &.-sort-desc, &.-sort-asc,
   &.rt-th.rt-th:hover {
-    background-color: color(var(--table-thead-bg-color) a(0.875));
+    background-color: rgba(var(--dark-1-RGB), 0.875);
 
     & .cp-table-header-icon {
       opacity: 1;

--- a/packages/cms/src/components/cards/Card.css
+++ b/packages/cms/src/components/cards/Card.css
@@ -140,7 +140,7 @@
 
     @mixin dark-mode {
       box-shadow: none;
-      background-color: color(var(--gray) a(0.01));
+      background-color: rgba(var(--gray-RGB), 0.01);
 
       & ~ .cms-card-heading > [class*="cms-card-heading-"] {
         color: var(--accent);

--- a/packages/cms/src/components/editors/AceTheme.css
+++ b/packages/cms/src/components/editors/AceTheme.css
@@ -1,8 +1,15 @@
 @import "../../css/mixins.css";
 
+:root {
+  --ace-light-RGB: 207, 218, 226;
+  --ace-gray-RGB: 174, 189, 204;
+  --ace-dark-RGB: 138, 151, 174;
+  --ace-black-RGB: 32, 36, 46;
+}
+
 .cms .ace_editor {
   background: var(--black);
-  color: color(#CFDAE2 a(0.875));
+  color: rgba(var(--ace-light-RGB), 0.875);
 
   /* current line */
   & .ace_marker-layer .ace_active-line,
@@ -15,7 +22,7 @@
 
   /* selected text */
   & .ace_marker-layer .ace_selection {
-    background: color(#AEBDCC a(0.25));
+    background: rgba(var(--ace-gray-RGB), 0.25);
   }
 
   /* shows matching bracket; not always visible */
@@ -24,13 +31,13 @@
     border: none;
     border-radius: 0;
     margin-top: 1px;
-    background-color: color(#AEBDCC a(0.125));
+    background-color: rgba(var(--ace-gray-RGB), 0.125);
   }
 
   /* gutter with line numbers & errors */
   & .ace_gutter {
-    background-color: color(#20242E a(0.5));
-    color: color(#8A97AE a(0.5));
+    background-color: rgba(var(--ace-black-RGB), 0.5);
+    color: rgba(var(--ace-dark-RGB), 0.5);
 
     /* (!) */
     & .ace_info {
@@ -154,7 +161,7 @@
   /* indentation indicator */
   & .ace_indent-guide {
     background: none;
-    border-right: 1px solid color(#AEBDCC a(0.125));
+    border-right: 1px solid rgba(var(--ace-gray-RGB), 0.125);
     margin-left: -1px;
   }
   /* line length helper */

--- a/packages/cms/src/components/editors/RichTextEditor.css
+++ b/packages/cms/src/components/editors/RichTextEditor.css
@@ -90,7 +90,7 @@
   /* theming */
   background-color: var(--light-2);
   border: 1px solid var(--light-3);
-  box-shadow: 1px 0 1em color(var(--black) a(0.5));
+  box-shadow: 1px 0 1em rgba(var(--black-RGB), 0.5);
   color: var(--dark-3);
   padding: 0.5em 1em;
   white-space: nowrap;

--- a/packages/cms/src/components/fields/FilterSearch.css
+++ b/packages/cms/src/components/fields/FilterSearch.css
@@ -80,7 +80,7 @@
     }
 
     @mixin dark-mode {
-      background-color: color(var(--black) a(0.75));
+      background-color: rgba(var(--black-RGB), 0.75);
       border-color: var(--black);
       color: var(--light-1);
 

--- a/packages/cms/src/components/fields/PreviewSearch.css
+++ b/packages/cms/src/components/fields/PreviewSearch.css
@@ -24,7 +24,7 @@
     color: var(--dark-2);
 
     @mixin dark-mode {
-      background-color: color(var(--black) a(0.75));
+      background-color: rgba(var(--black-RGB), 0.75);
       border-color: var(--black);
       color: var(--light-1);
     }

--- a/packages/cms/src/components/fields/ProfileTile.css
+++ b/packages/cms/src/components/fields/ProfileTile.css
@@ -25,7 +25,7 @@
     text-align: center;
     z-index: 1;
     /* theming */
-    background-color: color(var(--black) a(0.75));
+    background-color: rgba(var(--black-RGB), 0.75);
     border: 2px solid var(--dark-2);
     color: var(--light-3);
     /* transitions */
@@ -58,7 +58,7 @@
 
     /* interactions */
     &:hover, &:focus {
-      background-color: color(var(--black) a(0.25));
+      background-color: rgba(var(--black-RGB), 0.25);
       border-color: var(--gray);
       color: var(--white);
       text-decoration: none;

--- a/packages/cms/src/components/fields/Select.css
+++ b/packages/cms/src/components/fields/Select.css
@@ -85,11 +85,11 @@
   color: var(--dark-2);
 
   @mixin dark-mode {
-    border-color: color(var(--black) a(0.333));
+    border-color: rgba(var(--black-RGB), 0.333);
     box-shadow:
-      0 1px 4px color(var(--black) a(0.333)),
-      0 4px 8px color(var(--black) a(0.2)),
-      inset 0 1px 0 color(var(--dark-2) a(0.333));
+      0 1px 4px rgba(var(--black-RGB), 0.333),
+      0 4px 8px rgba(var(--black-RGB), 0.2),
+      inset 0 1px 0 rgba(var(--dark-2-RGB), 0.333);
     color: var(--gray);
   }
 }
@@ -117,8 +117,8 @@
   background: var(--select-bg-color); /* base */
   background-image: linear-gradient(
     180deg,
-    color(var(--field-border-color) a(0.02)) 0%,
-    color(var(--field-color) a(0.02)) 100%
+    rgba(var(--light-3-RGB), 0.02) 0%,
+    rgba(var(--dark-2-RGB), 0.02) 100%
   );
   border: var(--field-border-width) solid var(--field-border-color);
   border-radius: var(--select-border-radius);

--- a/packages/cms/src/components/interface/Alert.css
+++ b/packages/cms/src/components/interface/Alert.css
@@ -16,10 +16,10 @@
 
   & .cms-alert-overlay {
     @mixin overlay-theme;
-    background-color: color(var(--white) a(0.95));
+    background-color: rgba(var(--white-RGB), 0.95);
 
     @mixin dark-mode {
-      background-color: color(var(--black) a(0.95));
+      background-color: rgba(var(--black-RGB), 0.95);
     }
   }
 }

--- a/packages/cms/src/components/interface/AuthForm.css
+++ b/packages/cms/src/components/interface/AuthForm.css
@@ -22,7 +22,7 @@
   padding: 2rem;
   border-radius: 4px;
   background-color: var(--white);
-  box-shadow: 0 0.125rem 0.75rem color(var(--black) a(0.2));
+  box-shadow: 0 0.125rem 0.75rem rgba(var(--black-RGB), 0.2);
 
   @mixin dark-mode {
     background-color: var(--dark-3);

--- a/packages/cms/src/components/interface/Deck.css
+++ b/packages/cms/src/components/interface/Deck.css
@@ -61,11 +61,11 @@
   background: var(--light-2);
   background-image: linear-gradient(
     180deg,
-    color(var(--light-2) a(0.333)) 0%,
-    color(var(--light-3) a(0.333)) 100%
+    rgba(var(--light-2-RGB), 0.333) 0%,
+    rgba(var(--light-3-RGB), 0.333) 100%
   );
-  border: 1px solid color(var(--light-3) a(0.333));
-  box-shadow: inset 0 1px 0 color(var(--white) a(0.5));
+  border: 1px solid rgba(var(--light-3-RGB), 0.333);
+  box-shadow: inset 0 1px 0 rgba(var(--white-RGB), 0.5);
   border-radius: 4px 4px 0 0;
 
   @mixin dark-mode {

--- a/packages/cms/src/components/interface/Dialog.css
+++ b/packages/cms/src/components/interface/Dialog.css
@@ -82,7 +82,7 @@
 
   & .cms-dialog-overlay {
     @mixin overlay-theme;
-    background-color: color(var(--black) a(0.95));
+    background-color: rgba(var(--black-RGB), 0.95);
   }
 }
 

--- a/packages/cms/src/components/interface/Dropdown.css
+++ b/packages/cms/src/components/interface/Dropdown.css
@@ -120,8 +120,8 @@
 
   @mixin min-sm {
     box-shadow:
-      0 0.25em 0.5em color(var(--black) a(0.125)),
-      0 0.5em 1em color(var(--black) a(0.125));
+      0 0.25em 0.5em rgba(var(--black-RGB), 0.125),
+      0 0.5em 1em rgba(var(--black-RGB), 0.125);
     transition:
       opacity 0.2s ease-out,
       transform 0.2s ease-out;

--- a/packages/cms/src/components/interface/Navbar.css
+++ b/packages/cms/src/components/interface/Navbar.css
@@ -225,7 +225,7 @@
     @mixin button-reset;
     position: fixed;
     z-index: 1;
-    background-color: color(var(--black) a(0.875));
+    background-color: rgba(var(--black-RGB), 0.875);
     transition:
       opacity 0.2s ease-out,
       background-color 0.2s ease-out;

--- a/packages/cms/src/components/interface/Status.css
+++ b/packages/cms/src/components/interface/Status.css
@@ -23,10 +23,10 @@
     opacity 0.1s ease-out;
   /* theming */
   @mixin description-color;
-  background-color: color(var(--white) a(0.9));
+  background-color: rgba(var(--white-RGB), 0.9);
 
   @mixin dark-mode {
-    background-color: color(var(--dark-2) a(0.9));
+    background-color: rgba(var(--dark-2-RGB), 0.9);
   }
 
   &.is-done {

--- a/packages/cms/src/components/sections/components/Subnav.css
+++ b/packages/cms/src/components/sections/components/Subnav.css
@@ -160,8 +160,8 @@
   @mixin min-sm {
     background-color: var(--dark-2);
     box-shadow:
-      0 0.25em 0.5em color(var(--black) a(0.125)),
-      0 0.5em 1em color(var(--black) a(0.125));
+      0 0.25em 0.5em rgba(var(--black-RGB), 0.125),
+      0 0.5em 1em rgba(var(--black-RGB), 0.125);
     transition:
       opacity 0.2s ease-out,
       transform 0.2s ease-out;
@@ -217,7 +217,7 @@
       top: var(--nav-height);
       height: var(--subnav-height);
       background-color: var(--hero-bg-color);
-      box-shadow: 0 1px 0.25rem color(var(--black) a(0.333));
+      box-shadow: 0 1px 0.25rem rgba(var(--black-RGB), 0.333);
     }
 
     /* overflow list */

--- a/packages/cms/src/components/variables/ConsoleVariable.css
+++ b/packages/cms/src/components/variables/ConsoleVariable.css
@@ -1,5 +1,9 @@
 @import "../../css/mixins.css";
 
+:root {
+  --varswap-RGB: 185, 226, 140;
+}
+
 .cms-variable {
   color: inherit;
   display: block;
@@ -84,8 +88,8 @@
 
 /* vars printed by varSwap helper function */
 .cms-var-highlight {
-  background-color: color(var(--type-string) a(0.125));
-  outline: 1px dotted color(var(--type-string) a(0.333));
+  background-color: rgba(var(--varswap-RGB), 0.125);
+  outline: 1px dotted rgba(var(--varswap-RGB), 0.333);
   /* reset <var> */
   font-weight: inherit;
   font-style: inherit;

--- a/packages/cms/src/css/base.css
+++ b/packages/cms/src/css/base.css
@@ -135,5 +135,5 @@ strong, [class] > strong,
 .cms ::selection,
 .cp ::selection {
   color: var(--black);
-  background-color: color(var(--accent-light) a(0.75));
+  background-color: rgba(var(--accent-light-RGB), 0.75);
 }

--- a/packages/cms/src/css/mixins.css
+++ b/packages/cms/src/css/mixins.css
@@ -138,8 +138,8 @@ theming
   background: var(--light-1); /* base */
   background-image: linear-gradient(
     180deg,
-    color(var(--light-3) a(0.02)) 0%,
-    color(var(--black) a(0.02)) 100%
+    rgba(var(--light-3-RGB), 0.02) 0%,
+    rgba(var(--black-RGB), 0.02) 100%
   );
   color: var(--dark-2);
 
@@ -147,36 +147,36 @@ theming
     background: var(--dark-2); /* base */
     background-image: linear-gradient(
       180deg,
-      color(var(--light-3) a(0.02)) 0%,
-      color(var(--black) a(0.02)) 100%
+      rgba(var(--light-3-RGB), 0.02) 0%,
+      rgba(var(--black-RGB), 0.02) 100%
     );
     color: var(--dark-1);
   }
 }
 @define-mixin cms-button-shadow {
   box-shadow:
-    0 1px 2px color(var(--black) a(0.1)),
-    0 1px 8px color(var(--black) a(0.1)),
-    inset 0 1px 0 color(var(--white) a(0.33));
+    0 1px 2px rgba(var(--black-RGB), 0.1),
+    0 1px 8px rgba(var(--black-RGB), 0.1),
+    inset 0 1px 0 rgba(var(--white-RGB), 0.33);
 
   @mixin dark-mode {
     box-shadow:
-      0 1px 4px color(var(--black) a(0.333)),
-      0 4px 8px color(var(--black) a(0.2)),
-      inset 0 1px 0 color(var(--dark-2) a(0.333));
+      0 1px 4px rgba(var(--black-RGB), 0.333),
+      0 4px 8px rgba(var(--black-RGB), 0.2),
+      inset 0 1px 0 rgba(var(--dark-2-RGB), 0.333);
   }
 
   &:hover, &:focus {
     box-shadow:
-      0 1px 2px color(var(--black) a(0.1)),
-      0 2px 8px color(var(--black) a(0.2)),
-      inset 0 1px 0 color(var(--white) a(0.33));
+      0 1px 2px rgba(var(--black-RGB), 0.1),
+      0 2px 8px rgba(var(--black-RGB), 0.2),
+      inset 0 1px 0 rgba(var(--white-RGB), 0.33);
 
     @mixin dark-mode {
       box-shadow:
-        0 2px 4px color(var(--black) a(0.5)),
-        0 2px 12px color(var(--black) a(0.333)),
-        inset 0 1px 0 color(var(--dark-2) a(0.333));
+        0 2px 4px rgba(var(--black-RGB), 0.5),
+        0 2px 12px rgba(var(--black-RGB), 0.333),
+        inset 0 1px 0 rgba(var(--dark-2-RGB), 0.333);
     }
   }
 }
@@ -252,7 +252,7 @@ theming
   }
 
   @mixin dark-mode {
-    background-color: color(var(--black) a(0.75));
+    background-color: rgba(var(--black-RGB) 0.75);
     border-color: var(--black);
     color: var(--light-1);
 
@@ -435,7 +435,7 @@ VarTable & VarList
 
   /* DARK THEME */
   @mixin dark-mode {
-    background-color: color(var(--black) a(0.75));
+    background-color: rgba(var(--black-RGB) 0.75);
     border: 1px solid var(--dark-3);
     box-shadow: none;
     color: var(--light-3);
@@ -467,7 +467,7 @@ meta editor images
   transition: border 0.2s ease-out;
 
   @mixin dark-mode {
-    background-color: color(var(--black) a(0.5));
+    background-color: rgba(var(--black-RGB), 0.5);
     border-color: var(--black);
   }
 }

--- a/packages/cms/src/member/MetaEditor.css
+++ b/packages/cms/src/member/MetaEditor.css
@@ -132,7 +132,7 @@
   }
 
   /* theming */
-  & .rt-tbody .rt-tr.-even .rt-td { background-color: color(var(--white) a(0.5)); }
+  & .rt-tbody .rt-tr.-even .rt-td { background-color: rgba(var(--white-RGB), 0.5); }
   & .rt-tbody                     { @mixin font-xxs; }
   & .-pageJump > input            { @mixin cms-text-input-style; }
   & .-pageJump > *                { margin: 0 0.125em; }
@@ -151,7 +151,7 @@
     & .rt-thead.-headerGroups .rt-th { background-color: var(--dark-3); }
     & .rt-thead.-header .rt-th       { background-color: var(--dark-2); }
     & .rt-tbody .rt-tr.-odd .rt-td   { background-color: transparent; }
-    & .rt-tbody .rt-tr.-even .rt-td  { background-color: color(var(--dark-3) a(0.5)); }
+    & .rt-tbody .rt-tr.-even .rt-td  { background-color: rgba(var(--dark-3-RGB), 0.5); }
     & .rt-resizer                    { border-left-color: var(--light-3); }
 
     /* keep editable text visible */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -112,7 +112,6 @@
     "passport-twitter": "^1.0.4",
     "pg": "^6.4.2",
     "pixrem": "^5.0.0",
-    "postcss-color-function": "^4.1.0",
     "postcss-combine-duplicated-selectors": "^9.4.0",
     "postcss-conditionals": "^2.1.0",
     "postcss-css-variables": "^0.13.0",

--- a/packages/core/src/components/Forms.css
+++ b/packages/core/src/components/Forms.css
@@ -27,6 +27,10 @@
       margin-right: 10px;
     }
 
+    &:hover {
+      filter: brightness(0.5);
+    }
+
     &.facebook {
       background: #3b5998;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0)) left no-repeat, center no-repeat #3b5998;
@@ -34,29 +38,16 @@
       & .icon {
         margin-bottom: 2px;
       }
-
-      &:hover {
-        background-color: color(#3b5998 blackness(50%));
-      }
-
     }
 
     &.github {
       background-color: #ececec;
       background-image: linear-gradient(#f4f4f4, #ececec);
-
       color: #333;
 
       & .icon {
         margin-bottom: 2px;
       }
-
-      &:hover {
-        color: #fff;
-        background-color: #3c8dde;
-        background-image: linear-gradient(#599bdc, #3072b3);
-      }
-
     }
 
     &.google {
@@ -66,49 +57,27 @@
       & .icon {
         margin-bottom: 2px;
       }
-
-      &:hover {
-        background-color: #eee;
-      }
-
     }
 
     &.instagram {
       background: #8a3ab9;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0)) left no-repeat, center no-repeat #8a3ab9;
-
-      &:hover {
-        background-color: color(#8a3ab9 blackness(50%));
-      }
-
     }
 
     &.linkedin {
       background: #fdfdfd;
       background: linear-gradient(#fdfdfd, #eee);
-
       color: #000;
 
       & .icon {
         margin-bottom: 2px;
       }
-
-      &:hover {
-        opacity: 0.8;
-      }
-
     }
 
     &.twitter {
       background: #0084b4;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0)) left no-repeat, center no-repeat #0084b4;
-
-      &:hover {
-        background-color: color(#0084b4 blackness(50%));
-      }
-
     }
-
 
   }
 

--- a/packages/core/src/variables.css
+++ b/packages/core/src/variables.css
@@ -20,6 +20,17 @@
   --accent-dark:  #C4960B;
   --accent-black: #7F6516;
 
+  /* RGB versions of colors for use with alpha channels */
+  --white-RGB: 255, 255, 255;
+  --light-1-RGB: 248, 249, 250;
+  --light-2-RGB: 236, 239, 241;
+  --light-3-RGB: 207, 218, 226;
+  --gray-RGB: 174, 189, 204;
+  --dark-1-RGB: 138, 151, 174;
+  --dark-2-RGB: 42, 47, 59;
+  --dark-3-RGB: 32, 36, 46;
+  --black-RGB: 24, 26, 33;
+
 
   /* ------------------------------------------------
   admin panel
@@ -124,7 +135,7 @@
   --sticky-section-offset:      50px;
   --sticky-section-height:      var(--nav-height);
   --sticky-section-bg-color:    var(--white);
-  --sticky-section-shadow:      0 1px 0.375rem color(var(--black) a(0.125));
+  --sticky-section-shadow:      0 1px 0.375rem rgba(var(--black-RGB), 0.125);
   /* handle grouped SingleColumn sections with flex-basis */
   --singlecolumn-column-count:  3;
   --singlecolumn-min-width:     20rem;
@@ -156,7 +167,7 @@
   /* buttons */
   --button-border-radius:       2px;
   --button-border-width:        1px;
-  --button-bg-color:            color(var(--white) a(0.5));
+  --button-bg-color:            rgba(var(--white-RGB), 0.5);
   --button-border-color:        var(--light-3);
   --button-color:               var(--accent-black);
   --button-padding:             0.5em 1.25em;
@@ -189,7 +200,7 @@
   --table-hgroup-border-color:  var(--light-3);
   --table-hgroup-text-color:    var(--dark-3);
   --table-thead-bg-color:       var(--dark-1);
-  --table-thead-border-color:   color(var(--dark-2) a(0.25));
+  --table-thead-border-color:   rgba(var(--dark-2-RGB), 0.25);
   --table-thead-text-color:     var(--light-1);
   --table-cell-bg-color:        var(--white);
   --table-cell-border-color:    var(--light-2);

--- a/packages/core/webpack/config/postcss.js
+++ b/packages/core/webpack/config/postcss.js
@@ -56,7 +56,6 @@ module.exports = [
   require("postcss-reporter")({
     filter: msg => msg.type === "warning" || msg.type !== "dependency"
   }),
-  require("postcss-color-function")(),
   require("postcss-flexbugs-fixes")(),
   require("postcss-url")({
     url: asset => `${assetBase}${asset.url}`

--- a/packages/create-canon/scaffold/app/style.yml
+++ b/packages/create-canon/scaffold/app/style.yml
@@ -15,7 +15,7 @@
 # VSCode: https://marketplace.visualstudio.com/items?itemName=jaspernorth.vscode-pigments
 
 # GOTCHAS:
-# 1. When aliasing variables in this file (i.e., `section-text-color: "var(--dark-2)"`), these variables will be replaced in css files, but NOT in js files.
+# Make sure there are no more than 1 empty line at the end of the file, or style.yml will not be recognized and your build will fail. ¯\_(ツ)_/¯
 
 # Finally, if you encounter any bugs, are confused by anything, or wish things were better/different, let @perpetualgrimace know!
 
@@ -40,6 +40,19 @@ accent:       "#FFCD33"
 accent-light: "#FFD65B"
 accent-dark:  "#C4960B"
 accent-black: "#7F6516"
+
+# RGB versions of colors for use with alpha channels
+white-RGB: 255, 255, 255
+light-1-RGB: 248, 249, 250
+light-2-RGB: 236, 239, 241
+light-3-RGB: 207, 218, 226
+gray-RGB: 174, 189, 204
+dark-1-RGB: 138, 151, 174
+dark-2-RGB: 42, 47, 59
+dark-3-RGB: 32, 36, 46
+black-RGB: 24, 26, 33
+
+accent-light-RGB: 255, 214, 91
 
 
 ########################################
@@ -80,7 +93,8 @@ body-font-scale-xl:         "125%"   # 1rem = 20px (min-width: 1400px)
 
 # measurements
 nav-height:                 "50px"
-subnav-height:              "var(--nav-height)"
+test-height: "100px"
+subnav-height:              "var(--test-height)"
 container-width:            "80rem" # 1280px
 hero-container-width:       "var(--container-width)"
 
@@ -134,8 +148,6 @@ hero-heading-size:          "var(--font-xxl)"
 hero-subhead-color:         "var(--white)"
 hero-subhead-size:          "var(--font-md)"
 hero-stat-value-color:      "var(--accent)"
-hero-stat-column-count:     "4"
-hero-stat-column-width:     "10rem"
 hero-viz-width:             "20rem"
 
 # sections
@@ -147,7 +159,7 @@ section-heading-color:      "var(--dark-3)"
 sticky-section-offset:      "50px" # px value required here unfortunately
 sticky-section-height:      "var(--nav-height)"
 sticky-section-bg-color:    "var(--white)"
-sticky-section-shadow:      "0 1px 0.375rem color(var(--black) a(0.125))"
+sticky-section-shadow:      "0 1px 0.375rem rgba(var(--black-RGB), 0.125)"
 # handle grouped SingleColumn sections with flex-basis
 singlecolumn-column-count:  "3"
 singlecolumn-min-width:     "20rem"
@@ -155,13 +167,6 @@ singlecolumn-min-width:     "20rem"
 multicolumn-column-count:   "3"
 multicolumn-column-width:   "20rem"
 multicolumn-column-gap:     "var(--gutter-xl)"
-# InfoCard
-infocard-viz-min-width:     "10rem"
-infocard-border-radius:     "4px"
-infocard-border-width:      "1px"
-infocard-border-color:      "var(--light-2)"
-infocard-header-bg-color:   "var(--light-1)"
-infocard-main-bg-color:     "var(--white)"
 # Grouping (intro) section
 grouping-bg-color:          "var(--accent-light)"
 grouping-text-color:        "var(--black)"
@@ -175,7 +180,7 @@ grouping-stat-value-color:  "var(--white)"
 # buttons
 button-border-radius:       "2px"
 button-border-width:        "1px"
-button-bg-color:            "color(var(--white) a(0.5))"
+button-bg-color:            "rgba(var(--white-RGB), 0.5)"
 button-border-color:        "var(--light-3)"
 button-color:               "var(--accent-black)"
 button-padding:             "0.5em 1.25em"
@@ -201,11 +206,28 @@ select-bg-color:            "var(--light-1)"
 # visualizations
 viz-aspect-ratio:           "50%"  # set as padding-top on .cp-viz-container, then .cp-viz fills the height
 viz-min-height:             "40vh" # prevent visualizations from getting too squishy
+
 # percentage bar visualization
 percentage-bar-height:      "var(--gutter-xs)"
 percentage-bar-bg-color:    "var(--light-2)"
 percentage-bar-color:       "var(--accent-dark)"
 percentage-bar-radius:      "0.5em"
+percentage-bar-stroke-color: "var(--light-1)"
+percentage-bar-stroke-width: "2px"
+
+# (react-)table visualization
+table-height:               "60vh" # height of table body
+table-hgroup-bg-color:      "var(--light-2)" # top heading in a group of nested headings
+table-hgroup-border-color:  "var(--light-3)"
+table-hgroup-text-color:    "var(--dark-3)"
+table-thead-bg-color:       "var(--dark-1)" # primary table headings
+table-thead-border-color:   "rgba(var(--dark-2-RGB), 0.25)"
+table-thead-text-color:     "var(--light-1)"
+table-cell-bg-color:        "var(--white)" # table cells
+table-cell-border-color:    "var(--light-2)"
+table-cell-text-color:      "var(--dark-3)"
+table-nested-cell-bg-color: "var(--light-1)" # nested/pivoted cells
+table-icon-color:           "var(--dark-2)" # dotted cell resize handle, pivot triangle
 
 # stats
 stat-label-font-size:       "var(--font-sm)"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,6 @@ importers:
       passport-twitter: ^1.0.4
       pg: ^6.4.2
       pixrem: ^5.0.0
-      postcss-color-function: ^4.1.0
       postcss-combine-duplicated-selectors: ^9.4.0
       postcss-conditionals: ^2.1.0
       postcss-css-variables: ^0.13.0
@@ -348,7 +347,6 @@ importers:
       passport-twitter: 1.0.4
       pg: 6.4.2
       pixrem: 5.0.0
-      postcss-color-function: 4.1.0
       postcss-combine-duplicated-selectors: 9.4.0
       postcss-conditionals: 2.1.0
       postcss-css-variables: 0.13.0
@@ -3118,10 +3116,6 @@ packages:
       object.assign: 4.1.2
     dev: false
 
-  /balanced-match/0.1.0:
-    resolution: {integrity: sha1-tQS9BYabOSWd0MXvw12EMXbczEo=}
-    dev: false
-
   /balanced-match/1.0.0:
     resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
 
@@ -3761,11 +3755,6 @@ packages:
     resolution: {integrity: sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=}
     dev: false
 
-  /clone/1.0.4:
-    resolution: {integrity: sha1-2jCcwmPfFZlMaIypAheco8fNfH4=}
-    engines: {node: '>=0.8'}
-    dev: false
-
   /clone/2.1.2:
     resolution: {integrity: sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=}
     engines: {node: '>=0.8'}
@@ -3841,25 +3830,11 @@ packages:
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  /color-string/0.3.0:
-    resolution: {integrity: sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=}
-    dependencies:
-      color-name: 1.1.4
-    dev: false
-
   /color-string/1.5.5:
     resolution: {integrity: sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==}
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    dev: false
-
-  /color/0.11.4:
-    resolution: {integrity: sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=}
-    dependencies:
-      clone: 1.0.4
-      color-convert: 1.9.3
-      color-string: 0.3.0
     dev: false
 
   /color/3.1.3:
@@ -4237,15 +4212,6 @@ packages:
     dependencies:
       color-convert: 0.5.3
       color-name: 1.1.4
-    dev: false
-
-  /css-color-function/1.3.3:
-    resolution: {integrity: sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=}
-    dependencies:
-      balanced-match: 0.1.0
-      color: 0.11.4
-      debug: 3.2.7
-      rgb: 0.1.0
     dev: false
 
   /css-color-keywords/1.0.0:
@@ -9524,15 +9490,6 @@ packages:
       postcss-value-parser: 4.1.0
     dev: false
 
-  /postcss-color-function/4.1.0:
-    resolution: {integrity: sha512-2/fuv6mP5Lt03XbRpVfMdGC8lRP1sykme+H1bR4ARyOmSMB8LPSjcL6EAI1iX6dqUF+jNEvKIVVXhan1w/oFDQ==}
-    dependencies:
-      css-color-function: 1.3.3
-      postcss: 6.0.23
-      postcss-message-helpers: 2.0.0
-      postcss-value-parser: 3.3.1
-    dev: false
-
   /postcss-color-functional-notation/2.0.1:
     resolution: {integrity: sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==}
     engines: {node: '>=6.0.0'}
@@ -9842,10 +9799,6 @@ packages:
       postcss: 7.0.35
       postcss-selector-parser: 3.1.2
       vendors: 1.0.4
-    dev: false
-
-  /postcss-message-helpers/2.0.0:
-    resolution: {integrity: sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=}
     dev: false
 
   /postcss-minify-font-values/4.0.2:
@@ -11287,11 +11240,6 @@ packages:
 
   /rgb-regex/1.0.1:
     resolution: {integrity: sha1-wODWiC3w4jviVKR16O3UGRX+rrE=}
-    dev: false
-
-  /rgb/0.1.0:
-    resolution: {integrity: sha1-vieykej+/+rBvZlylyG/pA/AN7U=}
-    hasBin: true
     dev: false
 
   /rgba-regex/1.0.0:


### PR DESCRIPTION
@jhmullen here's the big `color( )` removal. I've written the upgrade steps here that can be copy/pasted over to release notes, and I think the following release strategy might work best:
1. release this as canon-core v0.24.0
2. go back to the commit tag for v0.23.0, and cut a v0.23.3 release that reverts the changes introduced in v0.23.1 and v0.23.2 (as they will break any existing `color( )` behavior)

## Upgrade Steps for the Release Notes:

Add the following block to `style.yml`:

```yml
# RGB versions of colors for use with alpha channels
white-RGB: 255, 255, 255
light-1-RGB: 248, 249, 250
light-2-RGB: 236, 239, 241
light-3-RGB: 207, 218, 226
gray-RGB: 174, 189, 204
dark-1-RGB: 138, 151, 174
dark-2-RGB: 42, 47, 59
dark-3-RGB: 32, 36, 46
black-RGB: 24, 26, 33

accent-light-RGB: 255, 214, 91
```

Convert all instances of `color( )` in CSS to use a different method, typically `rgba( )`. For example, this:

```css
color: color(var(--black) a(0.5));
```

Should become this:

```css
color: rgba(var(--black-RGB), 0.5);
```

If you are using custom colors (none of the YML variables posted above), then you will have to convert the color to RGB (Googling the hex value shows the rgb values) and store it either in style.yml or at the top of the CSS file like this:

```css
:root {
  --custom-color: 100, 50, 25;
}
```

And finally, the following REGEX syntax can work well to capture a large portion of the changes with a find/replace:

Find: `color\(var\(--dark-3\) a\(([0-9.]{1,})\)\)`
Replace: `rgba(var(--dark-3-RGB), $1)`