### PR TITLE
[core] login toast fix

### DIFF
--- a/packages/cms/src/components/interface/LoginForm.jsx
+++ b/packages/cms/src/components/interface/LoginForm.jsx
@@ -41,13 +41,13 @@ class LoginForm extends Component {
     this.setState({submitted: true});
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
 
     const {auth, mailgun, t} = this.props;
     const {email, submitted} = this.state;
     const Toast = this.context.toast.current;
 
-    if (submitted && !auth.loading) {
+    if (submitted && !auth.loading && prevProps.auth !== auth) {
 
       if (auth.error === WRONG_PW) {
         Toast.show({

--- a/packages/core/src/auth/local.js
+++ b/packages/core/src/auth/local.js
@@ -40,12 +40,12 @@ module.exports = function(app) {
       db.users.findOne({where: {email}, raw: true})
         .then(user => {
 
-          if (user === null) done(null, false, {message: "Incorrect credentials."});
-
-          const hashedPassword = bcrypt.hashSync(password, user.salt);
-
-          if (user.password === hashedPassword) done(null, user);
-          done(null, false, {message: "Incorrect credentials."});
+          if (!user) done(null, false, {message: "Incorrect credentials."});
+          else {
+            const hashedPassword = bcrypt.hashSync(password, user.salt);
+            if (user.password === hashedPassword) done(null, user);
+            else done(null, false, {message: "Incorrect credentials."});
+          }
 
           return user;
 

--- a/packages/core/src/components/Login.jsx
+++ b/packages/core/src/components/Login.jsx
@@ -38,13 +38,13 @@ class Login extends Component {
     this.setState({submitted: true});
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
 
     const {auth, mailgun, t} = this.props;
     const {email, submitted} = this.state;
     const Toast = this.context.toast.current;
 
-    if (submitted && !auth.loading) {
+    if (submitted && !auth.loading && prevProps.auth !== auth) {
 
       if (auth.error === WRONG_PW) {
         Toast.show({


### PR DESCRIPTION
This fixes an issue, visible in the OEC, where regardless of what a user types into the Login form for credentials, it will always show the "Successful login" toast (but they won't be logged in, so no security problem, just confusion). 

Logins still work if the credentials are correct, there was just a race condition between the initial `isAuthenticated` fetch and the first "Submit" click in the form. I'm not comparing the `auth` prop against the previous prop, and only running the Toast logic if they are entirely different objects (meaning an actual redux state change has occurred for that key).