### PR TITLE
Ignore terms in profile search #1252

### DIFF
--- a/examples/app/pages/cms/Search.jsx
+++ b/examples/app/pages/cms/Search.jsx
@@ -80,6 +80,7 @@ class Search extends Component {
           renderTile={(result, i, tileProps) => <ProfileTile key={`r-${i}`} {...tileProps} data={result} />}
           // renderTile={(result, i, tileProps) => <div>Ceci n'est pas une tuile.</div>}
           showExamples={true}
+          ignoredTerms={["of", "the"]}
         />
       </div>
     );

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -588,6 +588,7 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   filterProfileTitle={(content, meta) => content.label} // profile title used for filters (allows for grouping profiles with matching labels)
   filterQueryArgs={false} // enables filters to update the query string
   formatResults={resp => resp} // callback function to modify the JSON response used for rendering
+  ignoredTerms={[]} // array of ignored terms that will be removed before call /profilesearch endpoint. For example: ["of","the", ...]. Defaults []. You can find a list per language in here: https://countwordsfree.com/stopwords
   inputFontSize={"xxl"} // the CSS size for the input box ("sm", "md", "lg", "xl", "xxl")
   joiner={"&"} // the character used when joining titles in multi-dimensional profiles
   limit={10} // how many results to show

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -75,6 +75,8 @@ class ProfileSearch extends Component {
       filterProfiles: props.defaultProfiles,
       filterLevels: props.defaultLevels,
       id: uuid(),
+      // Build ignored terms regex just once, only if something is passed, default []
+      ignoredTermsRegex: props.ignoredTerms && props.ignoredTerms.length > 0 ? new RegExp(props.ignoredTerms.join("|"), "ig") : false,
       loading: false,
       profiles: false,
       query: props.defaultQuery,
@@ -190,11 +192,20 @@ class ProfileSearch extends Component {
 
   onChange(e) {
 
-    const {filterCubes, filterLevels, filterProfiles, timeout} = this.state;
+    const {filterCubes, filterLevels, filterProfiles, ignoredTermsRegex, timeout} = this.state;
     const {filterQueryArgs, limit, minQueryLength, showExamples, formatResults, locale} = this.props;
 
     let query = e ? e.target.value : this.state.query;
     if (query.length < minQueryLength) query = "";
+
+    // Filter ignored terms from user string
+    let filteredQuery = query.trim();
+    if (ignoredTermsRegex && filteredQuery !== "") {
+      filteredQuery = filteredQuery.replace(ignoredTermsRegex, "");
+    }
+
+    // Remove multiples spaces with just one -caused by the ignore terms regex and trim it
+    filteredQuery = filteredQuery.replace(/\s\s+/g, " ").trim();
 
     clearTimeout(timeout);
 
@@ -216,7 +227,7 @@ class ProfileSearch extends Component {
     }
     else {
 
-      let url = `/api/profilesearch?query=${query}&limit=${limit}&locale=${locale}`;
+      let url = `/api/profilesearch?query=${filteredQuery}&limit=${limit}&locale=${locale}`;
       if (filterProfiles) url += `&profile=${filterProfiles}`;
       if (filterLevels) url += `&hierarchy=${filterLevels}`;
       if (filterCubes) url += `&cubeName=${filterCubes}`;
@@ -521,6 +532,7 @@ ProfileSearch.defaultProps = {
   },
   filterQueryArgs: false,
   formatResults: resp => resp,
+  ignoredTerms: [], // By default ignore nothing
   inputFontSize: "xxl",
   joiner: " & ",
   limit: 10,


### PR DESCRIPTION
## Ignored terms in profile search, fixed: #1252 
I added the ability of pass an array of ignored terms for `<ProfileSearch>` component.

- ProfileSearch receives now a new prop called `ignoredTerms` (empty array by default) then in the constructor a regex is built once. On every change (user input), the regex is applied to the `query` and is passed cleaned to `/profilesearch` service. I created an extra regex to remove mulitple spaces caused by remove some forbidden words or users error.

- Readme file with `<ProfileSearch>`'s props available updated.

Extra: Nice resource here to get a full list of stop words in json in different languages here: https://countwordsfree.com/stopwords