### PR TITLE
Improve search for bilateral profiles #1284

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -1,35 +1,37 @@
 # Canon CMS
+
 Content Management System for Canon sites.
 
 ## Table of Contents
-* [Why?](#why)
-* [Setup and Installation](#setup-and-installation)
-* [Enabling Image Support](#enabling-image-support)
-* [Rendering a Profile](#rendering-a-profile)
-* [Overview and Terminology](#overview-and-terminology)
-* [Environment Variables](#environment-variables)
-* [Sections](#sections)
-* [Custom Sections](#custom-sections)
-* [Custom Visualizations](#custom-visualizations)
-* [Hidden Profiles](#hidden-profiles)
-* [Search](#search)
-* [PDF Printing](#pdf-printing)
-* [Advanced Generator Techniques](#advanced-generator-techniques)
-* [Advanced Visualization Techniques](#advanced-visualization-techniques)
-* [Advanced Selector Techniques](#advanced-selector-techniques)
-* [Automatic Translations](#automatic-translations)
-* [Command Line Reingest](#command-line-reingest)
-* [Authentication](#authentication)
-* [Profile Caching](#profile-caching)
-* [Frequently Asked Questions](#frequently-asked-questions)
-* [Release Notes](#release-notes)
-* [Migration](#migration)
+
+- [Why?](#why)
+- [Setup and Installation](#setup-and-installation)
+- [Enabling Image Support](#enabling-image-support)
+- [Rendering a Profile](#rendering-a-profile)
+- [Overview and Terminology](#overview-and-terminology)
+- [Environment Variables](#environment-variables)
+- [Sections](#sections)
+- [Custom Sections](#custom-sections)
+- [Custom Visualizations](#custom-visualizations)
+- [Hidden Profiles](#hidden-profiles)
+- [Search](#search)
+- [PDF Printing](#pdf-printing)
+- [Advanced Generator Techniques](#advanced-generator-techniques)
+- [Advanced Visualization Techniques](#advanced-visualization-techniques)
+- [Advanced Selector Techniques](#advanced-selector-techniques)
+- [Automatic Translations](#automatic-translations)
+- [Command Line Reingest](#command-line-reingest)
+- [Authentication](#authentication)
+- [Profile Caching](#profile-caching)
+- [Frequently Asked Questions](#frequently-asked-questions)
+- [Release Notes](#release-notes)
+- [Migration](#migration)
 
 ---
 
 ## Why?
 
-Building websites can be hard, especially when they need to display _tons_ of information. For a company like Datawheel, an organization that needs to build maintainable sites that can showcase data from thousands of data "members," the creation of *data-agnostic, dynamic templates* that can render beautiful web pages (or "profiles") is crucial. The Canon CMS fulfills this need by giving content creators and translators the tools they need to be able to author and update page templates easily.
+Building websites can be hard, especially when they need to display _tons_ of information. For a company like Datawheel, an organization that needs to build maintainable sites that can showcase data from thousands of data "members," the creation of _data-agnostic, dynamic templates_ that can render beautiful web pages (or "profiles") is crucial. The Canon CMS fulfills this need by giving content creators and translators the tools they need to be able to author and update page templates easily.
 
 Canon CMS allows users to:
 
@@ -79,11 +81,13 @@ Please note Canon CMS currently only supports Postgres databases.
 There are a number of [canon-core environment variables](https://github.com/Datawheel/canon#additional-environment-variables) that `canon-cms` relies on. Ensure that the the following env vars are set.
 
 Canon CMS relies on `canon` needs, so be sure your `CANON_API` is set:
+
 ```sh
 export CANON_API=http://localhost:3300
 ```
 
 CMS content that you author can be translated into other languages. Set `CANON_LANGUAGE_DEFAULT` to your locale. If you plan to translate your content, set `CANON_LANGUAGES` to a comma separated list of languages you wish to use. Note that while `CANON_LANGUAGES` can be changed later, `CANON_LANGUAGE_DEFAULT` cannot, so remember to set it before starting!
+
 ```sh
 export CANON_LANGUAGE_DEFAULT=en
 export CANON_LANGUAGES=en,es
@@ -92,11 +96,13 @@ export CANON_LANGUAGES=en,es
 #### 4) Configure `canon-cms` vars
 
 Canon CMS requires a `canon-cms` specific env var for the current location of your mondrian or tesseract installation.
+
 ```sh
 export CANON_CMS_CUBES=https://tesseract-url.com/tesseract
 ```
 
 In summary, your env vars should now look like this:
+
 ```sh
 export CANON_API=http://localhost:3300
 export CANON_LANGUAGE_DEFAULT=en
@@ -114,7 +120,7 @@ By default, the CMS will only be enabled on development environments. If you wis
 
 #### 5) (Optional) Add Proxy for Local Tesseract Instance
 
-Your `CANON_CMS_CUBES` variable will (obviously) differ based on your project. If you are developing against a _local instance of tesseract_, you will likely need to add a simple proxy to bypass CORS errors from requesting data between different ports.  To do this, you will need to add a file called `local-proxy.js` in the `/api/` directory in the root level of your project (create one if you don't have one). The file should then look like [this](https://gist.github.com/greenrhyno/018042999a0deab501529224764c0fa4).
+Your `CANON_CMS_CUBES` variable will (obviously) differ based on your project. If you are developing against a _local instance of tesseract_, you will likely need to add a simple proxy to bypass CORS errors from requesting data between different ports. To do this, you will need to add a file called `local-proxy.js` in the `/api/` directory in the root level of your project (create one if you don't have one). The file should then look like [this](https://gist.github.com/greenrhyno/018042999a0deab501529224764c0fa4).
 
 #### 4) Add the Builder Component to a route
 
@@ -143,6 +149,7 @@ export const reducers = {
 ```
 
 #### 6) Start your dev server
+
 ```sh
 npm run dev
 ```
@@ -155,7 +162,7 @@ npm run dev
 
 ## Enabling Image Support
 
-Canon CMS includes the ability to assign each member of a cube (Such as *Massachusetts*, or *Metalworkers*) an acceptably licensed photo from flickr or a custom upload.
+Canon CMS includes the ability to assign each member of a cube (Such as _Massachusetts_, or _Metalworkers_) an acceptably licensed photo from flickr or a custom upload.
 
 ### Custom Uploads (no Flickr Source)
 
@@ -177,11 +184,12 @@ Note: If you decide to change from local to remote at a later time, this is poss
 
 ### Remote (S3 Storage) hosting in Google Cloud
 
-If you choose to host images remotely as opposed to locally, a series of steps must be taken to configure both the flickr authentication and the Google Cloud Storage for image hosting.  Contact the Admin who is in charge of this project's Google Cloud Project, or get permissions to do the following:
+If you choose to host images remotely as opposed to locally, a series of steps must be taken to configure both the flickr authentication and the Google Cloud Storage for image hosting. Contact the Admin who is in charge of this project's Google Cloud Project, or get permissions to do the following:
 
 #### 1) Create a bucket
 
 In the Storage section of Google Cloud Projects, create a bucket and give it a name. Set the var `CANON_CONST_STORAGE_BUCKET` to the name you provided.
+
 ```sh
 export CANON_CONST_STORAGE_BUCKET=your_bucketname
 ```
@@ -191,11 +199,13 @@ export CANON_CONST_STORAGE_BUCKET=your_bucketname
 Follow the instructions [here](https://cloud.google.com/docs/authentication/getting-started) to create a JSON token with "Cloud Storage -> Storage Admin" permissions.
 
 Save the JSON token to disk and set its permissions to `644`.
+
 ```sh
 chmod 644 /path/to/token.json
 ```
 
 Configure the `GOOGLE_APPLICATION_CREDENTIALS` env var to the token's path.
+
 ```sh
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/token.json"
 ```
@@ -272,7 +282,7 @@ A Canon site often takes the form of DataCountry.io, and is made of **Profiles**
 
 - **Generator**: A CMS Entity which hits a provided API and stores the response in a variable called `resp`. Expects you to write javascript that returns an object full of key-value pairs. These KV pairs will be combined with other generators into a giant `variables` object that represents your lookup table for your mad-libs prose.
 
-- **Materializer**: Similar to a Generator, but with no API call. Materializers are guaranteed to be run *after* Generators, and in a strict order. Any materializer can make use of variables generated before it. Useful for datacalls that need to be combined, or for arbitrary variables (like CMS rules or about text)
+- **Materializer**: Similar to a Generator, but with no API call. Materializers are guaranteed to be run _after_ Generators, and in a strict order. Any materializer can make use of variables generated before it. Useful for datacalls that need to be combined, or for arbitrary variables (like CMS rules or about text)
 
 - **Formatter**: A formatter is a javascript function that will be applied to a variable. It receives one input, **n**, and returns a String. For example, take a javascript integer and add commas to make it a human-readable number.
 
@@ -288,25 +298,25 @@ A Canon site often takes the form of DataCountry.io, and is made of **Profiles**
 
 ## Environment Variables
 
-|variable|description|default|
-|---|---|---|
-|`CANON_CMS_CUBES`|Path to the mondrian or tesseract|`undefined (required)`|
-|`CANON_CMS_ENABLE`|Setting this env var to `true` allows access to the cms in production builds.|`false`|
-|`CANON_CMS_MINIMUM_ROLE`|The minimum integer value for a Canon user `role` to access the CMS|`1`|
-|`CANON_CMS_LOGGING`|Enable verbose logging in console.|`false`|
-|`CANON_CMS_REQUESTS_PER_SECOND`|Sets the `requestsPerSecond` value in the [promise-throttle](https://www.npmjs.com/package/promise-throttle) library, used for rate-limiting Generator requests|20|
-|`CANON_CMS_GENERATOR_TIMEOUT`|The number of ms after which a generator request times out, defaults to 5s. Increase this if you are making heavy requests that exceed 5s|5000|
-|`CANON_CMS_DEEPSEARCH_API`|Server location of Deepsearch API|`undefined`|
-|`CANON_CMS_HTACCESS_USER`|Authentication user for PDF generation on .htaccess protected pages|`undefined`|
-|`CANON_CMS_HTACCESS_PW`|Authentication password for PDF generation on .htaccess protected pages|`undefined`|
-|`CANON_CMS_PDF_DISABLE`|Disable the PDF generation endpoint|`undefined`|
-|`FLICKR_API_KEY`|Used to configure Flickr Authentication|`undefined`|
-|`GOOGLE_APPLICATION_CREDENTIALS`|Path to JSON token file for Cloud Storage|`undefined`|
-|`CANON_CONST_STORAGE_BUCKET`|Name of Google Cloud Storage Bucket|`undefined`|
-|`CANON_CONST_IMAGE_SPLASH_SIZE`|Splash width to resize flickr images|1400|
-|`CANON_CONST_IMAGE_THUMB_SIZE`|Thumb width to resize flickr images|200|
-|`CANON_CONST_IMAGE_THUMB_SIZE`|Thumb width to resize flickr images|200|
-|`OLAP_PROXY_SECRET`|For olap services that require a "x-tesseract-jwt-token" header to set in order to gain access, this variable can be used to set a private key for server-side processes.|`undefined`|
+| variable                         | description                                                                                                                                                               | default                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `CANON_CMS_CUBES`                | Path to the mondrian or tesseract                                                                                                                                         | `undefined (required)` |
+| `CANON_CMS_ENABLE`               | Setting this env var to `true` allows access to the cms in production builds.                                                                                             | `false`                |
+| `CANON_CMS_MINIMUM_ROLE`         | The minimum integer value for a Canon user `role` to access the CMS                                                                                                       | `1`                    |
+| `CANON_CMS_LOGGING`              | Enable verbose logging in console.                                                                                                                                        | `false`                |
+| `CANON_CMS_REQUESTS_PER_SECOND`  | Sets the `requestsPerSecond` value in the [promise-throttle](https://www.npmjs.com/package/promise-throttle) library, used for rate-limiting Generator requests           | 20                     |
+| `CANON_CMS_GENERATOR_TIMEOUT`    | The number of ms after which a generator request times out, defaults to 5s. Increase this if you are making heavy requests that exceed 5s                                 | 5000                   |
+| `CANON_CMS_DEEPSEARCH_API`       | Server location of Deepsearch API                                                                                                                                         | `undefined`            |
+| `CANON_CMS_HTACCESS_USER`        | Authentication user for PDF generation on .htaccess protected pages                                                                                                       | `undefined`            |
+| `CANON_CMS_HTACCESS_PW`          | Authentication password for PDF generation on .htaccess protected pages                                                                                                   | `undefined`            |
+| `CANON_CMS_PDF_DISABLE`          | Disable the PDF generation endpoint                                                                                                                                       | `undefined`            |
+| `FLICKR_API_KEY`                 | Used to configure Flickr Authentication                                                                                                                                   | `undefined`            |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to JSON token file for Cloud Storage                                                                                                                                 | `undefined`            |
+| `CANON_CONST_STORAGE_BUCKET`     | Name of Google Cloud Storage Bucket                                                                                                                                       | `undefined`            |
+| `CANON_CONST_IMAGE_SPLASH_SIZE`  | Splash width to resize flickr images                                                                                                                                      | 1400                   |
+| `CANON_CONST_IMAGE_THUMB_SIZE`   | Thumb width to resize flickr images                                                                                                                                       | 200                    |
+| `CANON_CONST_IMAGE_THUMB_SIZE`   | Thumb width to resize flickr images                                                                                                                                       | 200                    |
+| `OLAP_PROXY_SECRET`              | For olap services that require a "x-tesseract-jwt-token" header to set in order to gain access, this variable can be used to set a private key for server-side processes. | `undefined`            |
 
 ---
 
@@ -315,72 +325,88 @@ A Canon site often takes the form of DataCountry.io, and is made of **Profiles**
 Sections are the chunks of content you will use to build a page. Each section contains [metadata](#section-metadata) fields, and various [content entities](#content-entities).
 
 ### Section metadata
+
 Used to customize the way the section behaves. Metadata fields include:
 
 #### Title
+
 The name of the section. This will be used by the heading tag on the profile, and in the admin panel navigation.
 
 #### Slug
-An ID for referencing the section. This is used to link directly to a section via scrolling anchor links, and is used in the construction of share links. Each section on a page *must* have a unique ID.
+
+An ID for referencing the section. This is used to link directly to a section via scrolling anchor links, and is used in the construction of share links. Each section on a page _must_ have a unique ID.
 
 #### Visibility
+
 The truthiness of this value will be used to determine whether or not the section appears on a given profile.
 
 ---
 
 #### Layouts
+
 Change the way the section looks and behaves. Out of the box, the following section layouts are included:
 
 ##### Hero layout
-The hero section is typically the first thing a user sees upon visiting a profile. It fills up most of the screen, displays the title in large type, and features an image or set of images in the background. If the section does not include a visualization, the text will be centered. If the section *does* include a visualization, the layout will switch to two columns, with the visualization on the right.
 
-The first section in each profile is automatically assigned this layout, and *only* the first section in a profile can use this layout.
+The hero section is typically the first thing a user sees upon visiting a profile. It fills up most of the screen, displays the title in large type, and features an image or set of images in the background. If the section does not include a visualization, the text will be centered. If the section _does_ include a visualization, the layout will switch to two columns, with the visualization on the right.
+
+The first section in each profile is automatically assigned this layout, and _only_ the first section in a profile can use this layout.
 
 ##### Default layout
+
 The default layout uses most of the available screen real estate for the visuals, with descriptive text and controls grouped into a sidebar. If the section includes multiple visualizations, they will be arranged into rows or columns, depending on the size of the screen.
 
 This layout is ideal for 1-2 visualizations. If no visualizations are included, the text content will appear in a single column.
 
 ##### Grouping layout
+
 A grouping section is used to group related sections together.
 
 Functionally, it creates hierarchy by nesting each following section, until the next grouping section (which in turn, starts a new grouping). In addition, it acts as a sign post for the section, prominently displaying its title.
 
 ##### Info card layout
+
 Used to display a summary of data with a small footprint, the info card is one of the most situational layouts. Since the layout was designed for primarily text content, it's best to use only a single graphic, or simple visualization such as a **gasp** pie chart.
 
 Any adjacent info cards will be automatically grouped together into columns.
 
 ##### Multicolumn layout
+
 The multicolumn layout takes any content you throw at it, and balances it into columns to the best of its ability. It uses [css multi-column layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Columns), which has excellent browser support but can get funky when there aren't enough paragraphs to split evenly.
 
 This layout is useful for sections with a lot of text and 0-1 visualizations, such as the about section that typically follows the hero section in our DataCountry sites.
 
 ##### Single column layout
+
 On its own, the single column layout is a simple tube of content. However, like the info card section, adjacent single columns will be automatically grouped together into a grid.
 
 Use this layout when you want multiple, similar, evenly spaced columns, with simple visuals at the bottom.
 
 ##### Tabs layout
-At first, this layout may appear to be similar to the [default](#default-layout) layout. However, each visual in the section will become its own *panel*, which can be accessed via the automatically generated button group in the sidebar.
+
+At first, this layout may appear to be similar to the [default](#default-layout) layout. However, each visual in the section will become its own _panel_, which can be accessed via the automatically generated button group in the sidebar.
 
 This layout is ideal for displaying similar or related information in one section, while showing one visual at a time.
 
 🔥**Pro tip**: additional tabs section customization can be achieved via the visualization configuration:
+
 1. label the corresponding tab's button text (`tab: "custom button text"`)
 2. specify an array of selectors for the corresponding tab (`selectors: ["selectorName1", "selectorName2"]`).
 
 ---
 
 #### Positioning
+
 By default, each section will simply appear below the previous section as the user scrolls. In addition, there are two highly situation alternate behaviors:
 
 ##### Sticky positioning
+
 This takes advantage of the `position: sticky` css property — or in the case of Internet Explorer, dirty hacks — and sticks to the top of the screen until the user scrolls to the bottom of the grouping it appears in. This is typically used to keep selectors which effect an entire section grouping visible as you scroll through it.
 
 These sections cannot use certain features of standard sections, due to their added complexity and their need to be space efficient.
 
 ##### Modal positioning
+
 The section will no longer render unless it is called via a function elsewhere. Modals can be assigned any of the standard layouts except for grouping.
 
 For more information, see [Opening a modal window](#opening-a-modal-window)
@@ -388,12 +414,15 @@ For more information, see [Opening a modal window](#opening-a-modal-window)
 ---
 
 ### Content entities
+
 Used to add, edit, and remove content.
 
 #### Subtitles
+
 Short bits of text that appear underneath the section title for added clarification.
 
 #### Stats
+
 Useful for emphasizing bits and pieces of data, stats are made up of the following:
 
 1. **Label**: appears before the number, concisely explaining what it represents.
@@ -403,20 +432,25 @@ Useful for emphasizing bits and pieces of data, stats are made up of the followi
 🔥**Pro tip**: Multiple stats with the same label will be grouped together into columns, and their label will only be displayed once.
 
 #### Paragraphs
+
 Text rendered into paragraph tags.
 
 #### Visualizations
+
 Primarily, visualizations utilize [d3plus](http://d3plus.org/). However, we've also added a few custom visualization types:
 
 ##### Table
+
 Renders data in a [react-table](https://github.com/tannerlinsley/react-table/tree/v6) table. All react-table props are available.
 
-🔥**Pro tip**: we've combined react-table's infinite nesting capability with more accessible table header markup and consistent styles. The config syntax looks like: `columns: ["col1", "col2"]` for a flat array of columns, or `columns: [["header grouping label", ["col1", "col2"]]]` from an array of grouped/named columns. If an item in the array is a *string*, it will simply be converted to a column via that string. If an item in the array is an *array*, we're assuming the first item in the nested array is a string (the name of the column group), followed by an array — which can in turn be an array which contains strings, or an array with a string and an array, and so on.
+🔥**Pro tip**: we've combined react-table's infinite nesting capability with more accessible table header markup and consistent styles. The config syntax looks like: `columns: ["col1", "col2"]` for a flat array of columns, or `columns: [["header grouping label", ["col1", "col2"]]]` from an array of grouped/named columns. If an item in the array is a _string_, it will simply be converted to a column via that string. If an item in the array is an _array_, we're assuming the first item in the nested array is a string (the name of the column group), followed by an array — which can in turn be an array which contains strings, or an array with a string and an array, and so on.
 
 🔥**Pro tip**: You can also pass `headerFormat(key)` and `columnFormat(key, val)` to the config.
 
 ##### Graphic
+
 Renders an image, optionally on top of a [stat](#stats). The config looks like:
+
 ```js
 config: {
   imageURL: "link/to.image",
@@ -457,7 +491,7 @@ return {
 };
 ```
 
-This `cellStyle` method operates much like the `Cell` method of react-table, but again, *you may not return a JSX element*. Make vanilla ES6 modifications to the object and return it.
+This `cellStyle` method operates much like the `Cell` method of react-table, but again, _you may not return a JSX element_. Make vanilla ES6 modifications to the object and return it.
 
 ---
 
@@ -473,9 +507,10 @@ To extend the layout and functionality of sections, custom JSX sections can be c
 - Create an `index.js` file in this directory that exports ALL of your custom components:
 
 ```js
-export {default as CustomSection} from "./CustomSection.jsx";
-export {default as CustomSection2} from "./CustomSection2.jsx";
+export { default as CustomSection } from "./CustomSection.jsx";
+export { default as CustomSection2 } from "./CustomSection2.jsx";
 ```
+
 - Rebuild the server
 - Set your section to the new section type in Section Editor of the CMS.
 
@@ -483,7 +518,7 @@ export {default as CustomSection2} from "./CustomSection2.jsx";
 
 The [Section wrapper](https://github.com/Datawheel/canon/blob/master/packages/cms/src/components/sections/Section.jsx) handles most of the context callbacks, click interaction, anchor links, etc. required by all Sections. As such, the underlying section layouts are fairly sparse; many of them just pass the props through one by one (`Default.jsx` is a good example of this - observe the series of stats/paragraphs/sources variables).
 
-If you need more control over how these sections are laid out, or even want to manipulate the text provided by the API, the *entire* section object is passed down via the `contents` key. In your custom component, you may emulate any `Section.jsx` variable preparation using these contents to maximize customization.
+If you need more control over how these sections are laid out, or even want to manipulate the text provided by the API, the _entire_ section object is passed down via the `contents` key. In your custom component, you may emulate any `Section.jsx` variable preparation using these contents to maximize customization.
 
 ---
 
@@ -498,9 +533,10 @@ To extend the layout and functionality of visualizations, custom JSX visualizati
 - Create an `index.js` file in this directory that exports ALL of your custom components:
 
 ```js
-export {default as CustomViz} from "./CustomViz.jsx";
-export {default as CustomViz2} from "./CustomViz2.jsx";
+export { default as CustomViz } from "./CustomViz.jsx";
+export { default as CustomViz2 } from "./CustomViz2.jsx";
 ```
+
 - Rebuild the server
 - Set your visualization type to the new visualization type in Visualization Editor of the CMS.
 
@@ -514,7 +550,7 @@ Profiles have a `Visibility` Dropdown in the Profile Editor panel that may be se
 
 #### Variant Visibility
 
-Individual profile variants can also be hidden, which will result in the same behavior as above. Importantly, *profile visibility always trumps variant visibility*.
+Individual profile variants can also be hidden, which will result in the same behavior as above. Importantly, _profile visibility always trumps variant visibility_.
 
 #### A note on search
 
@@ -526,7 +562,7 @@ The `/api/search` legacy search route will respect these hidden profiles and not
 
 #### Legacy Search API (Dimensions only)
 
-The CMS is used to create Profiles based on Dimensions, such as "Geography" or "Industry". The individual entities that make up these dimensions (such as *Massachusetts* or *Metalworkers*) are referred to as Members. These members are what make up the slugs/ids in URLS; when visiting `/geo/massachusetts`, `geo` is the profile/dimension slug and `massachusetts` is the member.
+The CMS is used to create Profiles based on Dimensions, such as "Geography" or "Industry". The individual entities that make up these dimensions (such as _Massachusetts_ or _Metalworkers_) are referred to as Members. These members are what make up the slugs/ids in URLS; when visiting `/geo/massachusetts`, `geo` is the profile/dimension slug and `massachusetts` is the member.
 
 These members can be viewed and edited in the in the MetaData section of the CMS. However, they can also be searched via an API endpoint, which can be useful for setting up a search feature on your site. The API endpoint is:
 
@@ -536,16 +572,16 @@ These members can be viewed and edited in the in the MetaData section of the CMS
 
 Arguments are provided by url paramaters:
 
-|parameter|description|
-|---|---|
-|`q`|A string query which uses the SQL `ILIKE` operator to search the `name` and `keywords` of the member. (For better results install `unaccent` package in your Postgres server running: `CREATE EXTENSION IF NOT EXISTS unaccent;`. [More info.](https://www.postgresql.org/docs/9.1/unaccent.html) )|
-|`dimension`|An exact-match string to filter results to members in the provided dimension|
-|`levels`|A comma-separated list of levels to filter results to members by the provided levels|
-|`cubeName`|An exact-match string to filter results to members from the provided cube|
-|`pslug`|If the cubeName is not known, you may provide the unique slug of the desired dimension to limit results to that profile|
-|`limit`|A number, passed through to SQL `LIMIT` to limit results|
-|`id`|Exact match `id` lookup. Keep in mind that a member `id` is not necessarily unique and may require a `dimension` specification|
-|`cms`|If set to true, bypasses all "Hiding" functionality (profile, variant, or member) and shows ALL matching results.
+| parameter   | description                                                                                                                                                                                                                                                                                         |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `q`         | A string query which uses the SQL `ILIKE` operator to search the `name` and `keywords` of the member. (For better results install `unaccent` package in your Postgres server running: `CREATE EXTENSION IF NOT EXISTS unaccent;`. [More info.](https://www.postgresql.org/docs/9.1/unaccent.html) ) |
+| `dimension` | An exact-match string to filter results to members in the provided dimension                                                                                                                                                                                                                        |
+| `levels`    | A comma-separated list of levels to filter results to members by the provided levels                                                                                                                                                                                                                |
+| `cubeName`  | An exact-match string to filter results to members from the provided cube                                                                                                                                                                                                                           |
+| `pslug`     | If the cubeName is not known, you may provide the unique slug of the desired dimension to limit results to that profile                                                                                                                                                                             |
+| `limit`     | A number, passed through to SQL `LIMIT` to limit results                                                                                                                                                                                                                                            |
+| `id`        | Exact match `id` lookup. Keep in mind that a member `id` is not necessarily unique and may require a `dimension` specification                                                                                                                                                                      |
+| `cms`       | If set to true, bypasses all "Hiding" functionality (profile, variant, or member) and shows ALL matching results.                                                                                                                                                                                   |
 
 Example query:
 
@@ -607,21 +643,22 @@ import {ProfileSearch} from "@datawheel/canon-cms";
   subtitleFormat={result => result.memberHierarchy} // overrides for the default result subtitles
   showExamples={false} // setting this to `true` will display results when no query has been entered
   showFilters={false} // show a faceted search underneath the input box
+  showLaterals={false} // Force to return top 5 combination for bilaterals results, even with just one word in q.
 />
 ```
 
 If you would prefer to build your own search component, the DeepSearch API is available at `/api/profilesearch`. Arguments are as follows:
 
-|parameter|description|
-|---|---|
-|`query`|Query to search for|
-|`locale`|Language for results|
-|`limit`|Maximum number of results to return|
-|`profile`|Restrict results to a profile, must be an integer profile id or a profile slug (unary profiles only)|
-|`dimension`|Restrict results by dimension (comma separated)|
-|`hierarchy`|Restrict results by hierarchy (comma separated)|
-|`cubeName`|Restrict results by source cube name (comma separated)|
-|`min_confidence`|Confidence threshold (Deepsearch Only)|
+| parameter        | description                                                                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `query`          | Query to search for                                                                                  |
+| `locale`         | Language for results                                                                                 |
+| `limit`          | Maximum number of results to return                                                                  |
+| `profile`        | Restrict results to a profile, must be an integer profile id or a profile slug (unary profiles only) |
+| `dimension`      | Restrict results by dimension (comma separated)                                                      |
+| `hierarchy`      | Restrict results by hierarchy (comma separated)                                                      |
+| `cubeName`       | Restrict results by source cube name (comma separated)                                               |
+| `min_confidence` | Confidence threshold (Deepsearch Only)                                                               |
 
 Results will be returned in a response object that includes metadata on the results. Matching members separated by profile can be found in the `profiles` key of the response object. A single grouped list of all matching profiles can be found in the `grouped` key of the response object.
 
@@ -662,7 +699,6 @@ Chromium requires a sandboxed namespace in which to run its headless browser. No
 ```sh
 echo 10000 > /proc/sys/user/max_user_namespaces
 ```
-
 
 #### React Component
 
@@ -751,8 +787,8 @@ If you want access to these slugs in your results set, you may add the `slugs` q
 
 The slugs parameter requires two elements for a successful lookup:
 
-1) The CMS-level dimension on which the ID is considered unique (`Exporter`, `HS Product`, etc)
-2) An accessor for the key in the response payload to be used for lookup (`Country`, `HS4`, etc). Note: The CMS will automatically append the ` ID` to your accessor, changing `HS4` to `HS4 ID` for example.
+1. The CMS-level dimension on which the ID is considered unique (`Exporter`, `HS Product`, etc)
+2. An accessor for the key in the response payload to be used for lookup (`Country`, `HS4`, etc). Note: The CMS will automatically append the ` ID` to your accessor, changing `HS4` to `HS4 ID` for example.
 
 These parameters should be added to the generator API, using colons to separate the two required pieces:
 
@@ -762,7 +798,7 @@ If the pieces are the same, one parameter may be used:
 
 `&slugs=Product`
 
-In some rare edge cases, a dimension and id are not enough to disambiguate a member. In these cases, a third argument can be passed, which refers to *the cube on which the given id is considered unique*:
+In some rare edge cases, a dimension and id are not enough to disambiguate a member. In these cases, a third argument can be passed, which refers to _the cube on which the given id is considered unique_:
 
 `&slugs=HS Product:HS4:trade_i_baci_a_92`
 
@@ -770,16 +806,16 @@ Note that when using this cube disambiguation, you may not use the singular para
 
 ### Custom Attributes
 
-The fixed "Attributes" includes basic information about the currently selected member, like dimension, id, and hierarchy. This is useful because it is run *before* other generators, and can therefore be used both in subsequent `variables` object and also in API calls, using the `<bracket>` syntax.
+The fixed "Attributes" includes basic information about the currently selected member, like dimension, id, and hierarchy. This is useful because it is run _before_ other generators, and can therefore be used both in subsequent `variables` object and also in API calls, using the `<bracket>` syntax.
 
 If you would like to inject your own custom variables into the Attributes generator, create an endpoint in your canon API folder:
 
 ```js
 app.post("/api/cms/customAttributes/:pid", (req, res) => {
-
   const pid = parseInt(req.params.pid, 10);
-  const {variables, locale} = req.body;
-  const {id1, dimension1, hierarchy1, slug1, name1, cubeName1, user} = variables;
+  const { variables, locale } = req.body;
+  const { id1, dimension1, hierarchy1, slug1, name1, cubeName1, user } =
+    variables;
 
   /**
    * Make axios calls, run JS, and return your compiled data as a single JS Object. Use the pid
@@ -790,9 +826,7 @@ app.post("/api/cms/customAttributes/:pid", (req, res) => {
     return res.json({
       capitalName: name1.toUpperCase()
     });
-  }
-  else return res.json({});
-
+  } else return res.json({});
 });
 ```
 
@@ -822,7 +856,6 @@ For this reason, the `setVariables` function has been added to Visualizations. T
 ```
 
 Thus, when you click on a section of the primary viz treemap, it calls `setVariables`, sets the `secondaryId`, and the page will re-render to update the secondary viz with the appropriate id (in the above example, the id for Cars).
-
 
 ### Modifying Page State
 
@@ -882,7 +915,7 @@ In advanced mode, an HTML visualization has the following format:
 return {
   type: "HTML",
   html: "<div>Hello World</div>"
-}
+};
 ```
 
 This visualization type can even be used to embed entire iframes:
@@ -891,7 +924,7 @@ This visualization type can even be used to embed entire iframes:
 return {
   type: "HTML",
   html: '<iframe width="100%" height="100%" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0"></iframe>'
-}
+};
 ```
 
 ### Additional File Attachments
@@ -904,11 +937,13 @@ return {
   dataAttachments: "/path/to/file.ext"
 }
 ```
+
 The `dataAttachments` property will also accept a list of files:
 
 ```js
-  dataAttachments: ["/path/to/file1.ext", "/path/to/file2.ext"]
+dataAttachments: ["/path/to/file1.ext", "/path/to/file2.ext"];
 ```
+
 Once the list of attachments has been downloaded, it will be included with the CSV file in a ZIP archive file.
 
 ---
@@ -925,19 +960,19 @@ Dynamic selectors are array variables. The members of that array may be objects 
 
 If the members are **objects**, you must provide the required key `option`, and the optional keys `label` and `allowed`.
 
-|key|required|details
-|---|---|---|
-|`option`|required|Serves as the `value` of the `<Select/>` in the dropdown.
-|`label`|optional|Value shown as label of dropdown. If not provided, defaults to the value of `option`.
-|`allowed`|optional|String reference to variable to use for `allowed`. Defaults to `always`.
+| key       | required | details                                                                               |
+| --------- | -------- | ------------------------------------------------------------------------------------- |
+| `option`  | required | Serves as the `value` of the `<Select/>` in the dropdown.                             |
+| `label`   | optional | Value shown as label of dropdown. If not provided, defaults to the value of `option`. |
+| `allowed` | optional | String reference to variable to use for `allowed`. Defaults to `always`.              |
 
 ```js
 [
-  {option: "year2016", label: "2016", allowed: "profileHas2016Data"},
-  {option: "year2017", label: "2017", allowed: "profileHas2017Data"},
-  {option: "year2018", label: "2018", allowed: "always"},
-  {option: "year2019", label: "2019"}   // allowed=always is implicit, if desired.
-]
+  { option: "year2016", label: "2016", allowed: "profileHas2016Data" },
+  { option: "year2017", label: "2017", allowed: "profileHas2017Data" },
+  { option: "year2018", label: "2018", allowed: "always" },
+  { option: "year2019", label: "2019" } // allowed=always is implicit, if desired.
+];
 ```
 
 Remember - in static selectors, the "label" was implicitly value of the variable. However, in dynamic selectors, **the options you create will not exist in the variables object**. The exist only within this dynamic selector. In the above example, attempting to access `variables.year2018` will not return anything, as no generator ever exported `year2018` as a proper variable in and of itself.
@@ -945,7 +980,7 @@ Remember - in static selectors, the "label" was implicitly value of the variable
 A string configuration is also supported:
 
 ```js
-["option1", "option2", "option3"]
+["option1", "option2", "option3"];
 ```
 
 In this case, `label` will default to `option` and `allowed` will default to `always`. You may also mix and match formats.
@@ -955,7 +990,11 @@ In this case, `label` will default to `option` and `allowed` will default to `al
 Advanced users may have used the following syntax to achieve "labels" on the front end:
 
 ```js
-{{[[selector1]]}}
+{
+  {
+    [[selector1]];
+  }
+}
 ```
 
 On a first pass, a selector swap will change `selector1` to its selected value (say `year2018`), which leaves `{{year2018}}` behind. A second variable swap pass would then change it to `2018`, for use in a human-readable paragraph.
@@ -985,11 +1024,13 @@ If you have already followed the steps for [Enabling Image Support](#enabling-im
 Follow the instructions [here](https://cloud.google.com/docs/authentication/getting-started) to create an authentication token and give it "Cloud Translation -> Cloud Translation API User" permissions.
 
 Save the JSON token to disk and set its permissions to `644`.
+
 ```sh
 chmod 644 /path/to/token.json
 ```
 
 Configure the `GOOGLE_APPLICATION_CREDENTIALS` env var to the token's path.
+
 ```sh
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/token.json"
 ```
@@ -998,12 +1039,13 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/token.json"
 
 ### Usage
 
-Once set up, translation buttons will appear on each TextCard, Section Header, and Profile Header, but *only when a second language is selected*. This second language must be selected and represents the target language for the translation.
+Once set up, translation buttons will appear on each TextCard, Section Header, and Profile Header, but _only when a second language is selected_. This second language must be selected and represents the target language for the translation.
 
 Remember a few key points for translations:
+
 - Translations cost [money](https://cloud.google.com/translate/pricing): $20 per 1,000,000 characters. For reference, this is about $4 per entire-OEC-site-translation per language. Be careful not to overuse it, especially with profile-wide translations.
 - Translating **paves all content in the target language and replaces it**. There is currently no smart detection of whether secondary language content has been updated since the last ingest - it is a one-way blast.
-- Translations currently only cover text content (subtitles, paragraphs, stats). They do not cover visualizations, formatters, or language-specific variables. The translation API should be considered a *starting point* for the SEO-optimized prose of the page.
+- Translations currently only cover text content (subtitles, paragraphs, stats). They do not cover visualizations, formatters, or language-specific variables. The translation API should be considered a _starting point_ for the SEO-optimized prose of the page.
 
 ### Command Line Tool
 
@@ -1033,6 +1075,7 @@ Arguments:
 ```
 
 Example usage:
+
 ```
 npx canon-cms-translate -b http://localhost:3300 -p 1 -t es
 ```
@@ -1079,6 +1122,7 @@ CANON_CMS_LOGGING
 ### Usage
 
 Help command:
+
 ```sh
 Canon CMS / Search Ingestion Script
 Usage: npx canon-cms-ingest <command> [args]
@@ -1096,13 +1140,14 @@ Arguments:
 ```
 
 Example usage:
+
 ```
 npx canon-cms-ingest run -d 1
 ```
 
 ### Notes
 
-Ingests are performed on a *dimension* level, not a profile one. For example, for a bilateral profile like product/country, there are single ids for each dimension (product and country). You can view a list of these by running `npx canon-cms-ingest list`. Then use the id found there to feed into the `-d` argument.
+Ingests are performed on a _dimension_ level, not a profile one. For example, for a bilateral profile like product/country, there are single ids for each dimension (product and country). You can view a list of these by running `npx canon-cms-ingest list`. Then use the id found there to feed into the `-d` argument.
 
 For the sake of permalinks, the ingest preserves slugs by default, even if the underlying data has changed its name. Use the `-s` switch to override this and generate slugs from scratch.
 
@@ -1212,7 +1257,7 @@ Selector values can be referenced anywhere through the site's contents, but if y
 
 At the top of every section editor in the CMS is the "Dimensions" panel. This panel lets you change which dimension is currently being displayed as the values for all of the generators and text. Simply use the search box in that panel to find a different profile dimension to preview!
 
-___
+---
 
 ## Release Notes
 
@@ -1238,23 +1283,23 @@ Here is a list of Minor CMS versions and their release notes:
 - [canon-cms@0.19.0](https://github.com/Datawheel/canon/releases/tag/%40datawheel%2Fcanon-cms%400.19.0)
 - [canon-cms@0.20.0](https://github.com/Datawheel/canon/releases/tag/%40datawheel%2Fcanon-cms%400.20.0)
 
-___
+---
 
 ## Migration
 
 For upgrading to new versions, there are currently several migration scripts:
 
-1) `npx canon-cms-migrate-legacy` (for DataUSA)
-2) `npx canon-cms-migrate-0.1` (for CDC or other 0.1 CMS users)
-3) `npx canon-cms-migrate-0.6` (for 0.6 CMS users)
-4) `npx canon-cms-migrate-0.7` (for 0.7 CMS users)
-5) `npx canon-cms-migrate-0.8` (for 0.8 CMS users)
-6) `npx canon-cms-migrate-0.9` (for 0.9 CMS users, for upgrade to 0.11 ONLY)
-7) `npx canon-cms-migrate-0.11` (for 0.10 or 0.11 CMS users, for upgrade to 0.12 ONLY)
-8) `npx canon-cms-migrate-0.12` (for 0.12 CMS users)
-9) `npx canon-cms-migrate-0.13` (for 0.13 CMS users)
-10) `npx canon-cms-migrate-0.16` (for 0.14, 0.15, or 0.16 CMS users, for upgrade to 0.17, 0.18, 0.19, or 0.20)
-11) `npx canon-cms-migrate-0.20` (for 0.17, 0.18, 0.19, or 0.20 CMS users, for upgrade to 0.21)
+1. `npx canon-cms-migrate-legacy` (for DataUSA)
+2. `npx canon-cms-migrate-0.1` (for CDC or other 0.1 CMS users)
+3. `npx canon-cms-migrate-0.6` (for 0.6 CMS users)
+4. `npx canon-cms-migrate-0.7` (for 0.7 CMS users)
+5. `npx canon-cms-migrate-0.8` (for 0.8 CMS users)
+6. `npx canon-cms-migrate-0.9` (for 0.9 CMS users, for upgrade to 0.11 ONLY)
+7. `npx canon-cms-migrate-0.11` (for 0.10 or 0.11 CMS users, for upgrade to 0.12 ONLY)
+8. `npx canon-cms-migrate-0.12` (for 0.12 CMS users)
+9. `npx canon-cms-migrate-0.13` (for 0.13 CMS users)
+10. `npx canon-cms-migrate-0.16` (for 0.14, 0.15, or 0.16 CMS users, for upgrade to 0.17, 0.18, 0.19, or 0.20)
+11. `npx canon-cms-migrate-0.20` (for 0.17, 0.18, 0.19, or 0.20 CMS users, for upgrade to 0.21)
 
 **Note:** Canon CMS Version 0.10.0 did **NOT** require a database migration, so the `0.9` script will output a `0.11` database.
 
@@ -1265,10 +1310,9 @@ For upgrading to new versions, there are currently several migration scripts:
 - `CANON_LANGUAGE_DEFAULT` - Required for slug generation - slugs for search members are generated based on the default language.
 - `CANON_CMS_LOGGING` - Not required, but recommended to turn on to observe the migration for any errors.
 
-
 ### Instructions
 
-The name of the script represents the version you wish to migrate **FROM**.  So, to upgrade a DB from 0.6 to 0.7, one would use `npx canon-cms-migrate-0.6`.  Currently both `legacy` and `0.1` upgrade directly to `0.6`.  From here on out, versions will upgrade **one dot version at a time** (exception: 0.9 to 0.11).
+The name of the script represents the version you wish to migrate **FROM**. So, to upgrade a DB from 0.6 to 0.7, one would use `npx canon-cms-migrate-0.6`. Currently both `legacy` and `0.1` upgrade directly to `0.6`. From here on out, versions will upgrade **one dot version at a time** (exception: 0.9 to 0.11).
 
 It is necessary that users spin up an entire new database for any CMS migration.
 
@@ -1286,7 +1330,7 @@ CANON_CMS_MIGRATION_NEW_DB_PW
 CANON_CMS_MIGRATION_NEW_DB_HOST
 ```
 
-These variables represent the old db you are migration **from** and the new db you are migrating **to**.  The new db will be **wiped every time** you run the script - the idea here is that you are building a new db from scratch.
+These variables represent the old db you are migration **from** and the new db you are migrating **to**. The new db will be **wiped every time** you run the script - the idea here is that you are building a new db from scratch.
 
 🔥 WHATEVER DB YOU CONFIGURE AS **NEW** WILL BE COMPLETELY DESTROYED AND BUILT FROM SCRATCH 🔥
 🔥 DO NOT SET `CANON_CMS_MIGRATION_NEW_DB_*` TO A CURRENTLY IMPORTANT DB🔥

--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -1,24 +1,21 @@
 const sequelize = require("sequelize");
 const yn = require("yn");
 const d3Array = require("d3-array");
-const {unique} = require("d3plus-common");
+const { unique } = require("d3plus-common");
 const jwt = require("jsonwebtoken");
 const groupMeta = require("../utils/groupMeta");
 const multer = require("multer");
-const upload = multer({storage: multer.memoryStorage()});
+const upload = multer({ storage: multer.memoryStorage() });
 
-const {
-  CANON_CMS_CUBES,
-  CANON_CMS_MINIMUM_ROLE,
-  OLAP_PROXY_SECRET
-} = process.env;
+const { CANON_CMS_CUBES, CANON_CMS_MINIMUM_ROLE, OLAP_PROXY_SECRET } =
+  process.env;
 
 const verbose = yn(process.env.CANON_CMS_LOGGING);
 let Base58, flickr, sharp, storage;
 if (process.env.FLICKR_API_KEY) {
   const Flickr = require("flickr-sdk");
   flickr = new Flickr(process.env.FLICKR_API_KEY);
-  const {Storage} = require("@google-cloud/storage");
+  const { Storage } = require("@google-cloud/storage");
   storage = new Storage();
   sharp = require("sharp");
   Base58 = require("base58");
@@ -30,7 +27,9 @@ const validLicensesString = validLicenses.join();
 const bucket = process.env.CANON_CONST_STORAGE_BUCKET;
 
 let cubeRoot = CANON_CMS_CUBES || "localhost";
-if (cubeRoot.substr(-1) === "/") cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
+if (cubeRoot.substr(-1) === "/") {
+  cubeRoot = cubeRoot.substr(0, cubeRoot.length - 1);
+}
 
 const catcher = e => {
   if (verbose) {
@@ -45,12 +44,26 @@ const thumbWidth = Number(process.env.CANON_CONST_IMAGE_THUMB_WIDTH) || 400;
 let deepsearchAPI = process.env.CANON_CMS_DEEPSEARCH_API;
 if (deepsearchAPI) deepsearchAPI = deepsearchAPI.replace(/\/$/, "");
 const f = (a, b) => [].concat(...a.map(d => b.map(e => [].concat(d, e))));
-const cartesian = (a, b, ...c) => b ? cartesian(f(a, b), ...c) : a;
+const cartesian = (a, b, ...c) => (b ? cartesian(f(a, b), ...c) : a);
 
 let unaccentExtensionInstalled;
 
-const imageIncludeNoBlobs = [{association: "image", attributes: {exclude: ["thumb", "splash"]}, include: [{association: "content"}]}, {association: "content"}];
-const imageIncludeThumbOnly = [{association: "image", attributes: {exclude: ["splash"]}, include: [{association: "content"}]}, {association: "content"}];
+const imageIncludeNoBlobs = [
+  {
+    association: "image",
+    attributes: { exclude: ["thumb", "splash"] },
+    include: [{ association: "content" }]
+  },
+  { association: "content" }
+];
+const imageIncludeThumbOnly = [
+  {
+    association: "image",
+    attributes: { exclude: ["splash"] },
+    include: [{ association: "content" }]
+  },
+  { association: "content" }
+];
 
 // The visibility or invisibility of certain profiles or variants determines which "dimension cube pairs" should be considered valid.
 // When making a query into canon_cms_search, use the de-duplicated, valid, and visible dim/cubes from this array to restrict the results.
@@ -59,7 +72,10 @@ const fetchDimCubes = async db => {
   meta = meta.map(d => d.toJSON());
   let allProfiles = await db.profile.findAll().catch(catcher);
   allProfiles = allProfiles.map(d => d.toJSON());
-  const profileVisibilityHash = allProfiles.reduce((acc, d) => ({...acc, [d.id]: d.visible}), {});
+  const profileVisibilityHash = allProfiles.reduce(
+    (acc, d) => ({ ...acc, [d.id]: d.visible }),
+    {}
+  );
   const allDimCubes = [];
   meta.forEach(m => {
     // Only register this variant as visible if both itself and its parent profile are visible.
@@ -92,135 +108,194 @@ const rowToResult = (row, locale) => {
  * Given a db connection, image id, and image buffer, attempt to upload the image to google cloud.
  * If the upload to cloud fails, store buffer data in psql row
  */
-const uploadImage = async(db, id, imageData, isCustom) => {
+const uploadImage = async (db, id, imageData) => {
   const configs = [
-    {type: "splash", res: splashWidth},
-    {type: "thumb", res: thumbWidth}
+    { type: "splash", res: splashWidth },
+    { type: "thumb", res: thumbWidth }
   ];
   for (const config of configs) {
-    const buffer = await sharp(imageData).resize(config.res).toFormat("jpeg").jpeg({force: true}).toBuffer().catch(catcher);
+    const buffer = await sharp(imageData)
+      .resize(config.res)
+      .toFormat("jpeg")
+      .jpeg({ force: true })
+      .toBuffer()
+      .catch(catcher);
     const file = `${config.type}/${id}.jpg`;
-    const options = {metadata: {contentType: "image/jpeg"}};
+    const options = { metadata: { contentType: "image/jpeg" } };
     // Attempt to upload to google bucket. If it fails, fall back to psql blob
-    const writeResult = await storage.bucket(bucket).file(file).save(buffer, options).catch(e => {
-      if (verbose) console.warn(`Cloud upload error for ${file}, ${e.message}. If not using Cloud hosting, this safely be ignored.`);
-      return false;
-    });
+    const writeResult = await storage
+      .bucket(bucket)
+      .file(file)
+      .save(buffer, options)
+      .catch(e => {
+        if (verbose) {
+          console.warn(
+            `Cloud upload error for ${file}, ${e.message}. If not using Cloud hosting, this safely be ignored.`
+          );
+        }
+        return false;
+      });
     if (writeResult === false) {
-      let payload = {[config.type]: buffer};
-      const customStub = {url: `custom-image-${id}`, author: "", license: null};
-      if (isCustom) payload = {...payload, ...customStub};
-      await db.image.update(payload, {where: {id}}).catch(catcher);
-      await db.image_content.update({meta: ""}, {where: {id}}).catch(catcher);
-    }
-    else {
+      await db.image
+        .update({ [config.type]: buffer }, { where: { id } })
+        .catch(catcher);
+    } else {
       await storage.bucket(bucket).file(file).makePublic().catch(catcher);
     }
   }
 };
 
-module.exports = function(app) {
-
-  const {db} = app.settings;
+module.exports = function (app) {
+  const { db } = app.settings;
   const dbQuery = db.search.sequelize.query.bind(db.search.sequelize);
 
-  app.get("/api/isImageEnabled", async(req, res) => {
-    const payload = {imageEnabled: Boolean(flickr)};
+  app.get("/api/isImageEnabled", async (req, res) => {
+    const payload = { imageEnabled: Boolean(flickr) };
     if (!bucket) {
       payload.cloudEnabled = false;
-    }
-    else {
-      const bucketRef = await storage.bucket(bucket).getMetadata().catch(() => false);
+    } else {
+      const bucketRef = await storage
+        .bucket(bucket)
+        .getMetadata()
+        .catch(() => false);
       payload.cloudEnabled = Boolean(bucketRef);
     }
     return res.json(payload);
   });
 
-  app.post("/api/image/cloudfix", async(req, res) => {
-    if (!flickr) return res.json({error: "Flickr API Key not configured"});
-    const {id} = req.body;
-    const imageRow = await db.image.findOne({where: {id}}).catch(catcher);
-    if (!imageRow) return res.json({error: "No Image Found"});
+  app.post("/api/image/cloudfix", async (req, res) => {
+    if (!flickr) return res.json({ error: "Flickr API Key not configured" });
+    const { id } = req.body;
+    const imageRow = await db.image.findOne({ where: { id } }).catch(catcher);
+    if (!imageRow) return res.json({ error: "No Image Found" });
     for (const type of ["thumb", "splash"]) {
       const file = `${type}/${imageRow.id}.jpg`;
-      const options = {metadata: {contentType: "image/jpeg"}};
-      const writeResult = await storage.bucket(bucket).file(file).save(imageRow[type], options).catch(e => {
-        if (verbose) console.error(`Image upload error for ${file}, ${e.message}`);
-        return false;
-      });
+      const options = { metadata: { contentType: "image/jpeg" } };
+      const writeResult = await storage
+        .bucket(bucket)
+        .file(file)
+        .save(imageRow[type], options)
+        .catch(e => {
+          if (verbose) {
+            console.error(`Image upload error for ${file}, ${e.message}`);
+          }
+          return false;
+        });
       if (writeResult === false) {
-        return res.json({error: "Image upload Error"});
-      }
-      else {
-        await db.image.update({[type]: null}, {where: {id}}).catch(catcher);
+        return res.json({ error: "Image upload Error" });
+      } else {
+        await db.image
+          .update({ [type]: null }, { where: { id } })
+          .catch(catcher);
         await storage.bucket(bucket).file(file).makePublic().catch(catcher);
       }
     }
     // return to the client all searchrows that were affected by this image update
-    const newRows = await db.search.findAll({
-      where: {imageId: imageRow.id},
-      include: imageIncludeThumbOnly
-    }).catch(catcher);
+    const newRows = await db.search
+      .findAll({
+        where: { imageId: imageRow.id },
+        include: imageIncludeThumbOnly
+      })
+      .catch(catcher);
     newRows.forEach(d => {
       if (d && d.image) d.image.thumb = Boolean(d.image.thumb);
     });
     return res.json(newRows);
   });
 
-  app.post("/api/image/upload", upload.single("imgFile"), async(req, res) => {
+  app.post("/api/image/upload", upload.single("imgFile"), async (req, res) => {
     if (!req.file.originalname.match(/\.(jpg|jpeg|png|gif)$/)) {
-      return res.json({error: "File must be an image!"});
+      return res.json({ error: "File must be an image!" });
     }
-    const {contentId} = req.body;
+    const { contentId } = req.body;
     const imageData = req.file.buffer;
-    const searchRow = await db.search.findOne({where: {contentId}}).catch(catcher);
+    const searchRow = await db.search
+      .findOne({ where: { contentId } })
+      .catch(catcher);
     if (!searchRow.imageId) {
-      const payload = {author: null, license: null};
+      const payload = { author: null, license: null };
       const newImage = await db.image.create(payload).catch(catcher);
-      await db.image.update({url: `custom-image-${newImage.id}`}, {where: {id: newImage.id}}).catch(catcher);
-      await db.search.update({imageId: newImage.id}, {where: {contentId}}).catch(catcher);
+      await db.image
+        .update(
+          { url: `custom-image-${newImage.id}` },
+          { where: { id: newImage.id } }
+        )
+        .catch(catcher);
+      await db.search
+        .update({ imageId: newImage.id }, { where: { contentId } })
+        .catch(catcher);
 
-      await uploadImage(db, newImage.id, imageData, true).catch(catcher);
-    }
-    else {
-      const imageRow = await db.image.findOne({where: {id: searchRow.imageId}}).catch(catcher);
+      await uploadImage(db, newImage.id, imageData).catch(catcher);
+    } else {
+      const imageRow = await db.image
+        .findOne({ where: { id: searchRow.imageId } })
+        .catch(catcher);
       if (imageRow) {
-        await uploadImage(db, imageRow.id, imageData, true).catch(catcher);
+        await uploadImage(db, imageRow.id, imageData).catch(catcher);
       }
     }
     return res.json("OK");
   });
 
-  app.post("/api/image/update", async(req, res) => {
-    if (!flickr) return res.json({error: "Flickr API Key not configured"});
-    const {contentId} = req.body;
-    let {id, shortid} = req.body;
+  app.post("/api/image/update", async (req, res) => {
+    if (!flickr) return res.json({ error: "Flickr API Key not configured" });
+    const { contentId } = req.body;
+    let { id, shortid } = req.body;
     if (id && !shortid) shortid = Base58.int_to_base58(id);
     if (!id && shortid) id = Base58.base58_to_int(shortid);
     const url = `https://flic.kr/p/${shortid}`;
-    const info = await flickr.photos.getInfo({photo_id: id}).then(resp => resp.body).catch(catcher);
+    const info = await flickr.photos
+      .getInfo({ photo_id: id })
+      .then(resp => resp.body)
+      .catch(catcher);
     if (info) {
       if (validLicenses.includes(info.photo.license)) {
-        const searchRow = await db.search.findOne({where: {contentId}}).catch(catcher);
-        const imageRow = await db.image.findOne({where: {url}}).catch(catcher);
+        const searchRow = await db.search
+          .findOne({ where: { contentId } })
+          .catch(catcher);
+        const imageRow = await db.image
+          .findOne({ where: { url } })
+          .catch(catcher);
         if (searchRow) {
           if (imageRow) {
-            await db.search.update({imageId: imageRow.id}, {where: {contentId}}).catch(catcher);
-          }
-          else {
+            await db.search
+              .update({ imageId: imageRow.id }, { where: { contentId } })
+              .catch(catcher);
+          } else {
             if (!bucket) {
-              if (verbose) console.error("CANON_CONST_STORAGE_BUCKET not configured, failed to update image");
-            }
-            else {
-              // To add a new image, first fetch the image data
-              const sizeObj = await flickr.photos.getSizes({photo_id: id}).then(resp => resp.body).catch(catcher);
-              let image = sizeObj.sizes.size.find(d => parseInt(d.width, 10) >= 1600);
-              if (!image) image = sizeObj.sizes.size.find(d => parseInt(d.width, 10) >= 1000);
-              if (!image) image = sizeObj.sizes.size.find(d => parseInt(d.width, 10) >= 500);
-              if (!image || !image.source) {
-                return res.json({error: "Flickr Source Error, try another image."});
+              if (verbose) {
+                console.error(
+                  "CANON_CONST_STORAGE_BUCKET not configured, failed to update image"
+                );
               }
-              const imageData = await axios.get(image.source, {responseType: "arraybuffer"}).then(d => d.data).catch(catcher);
+            } else {
+              // To add a new image, first fetch the image data
+              const sizeObj = await flickr.photos
+                .getSizes({ photo_id: id })
+                .then(resp => resp.body)
+                .catch(catcher);
+              let image = sizeObj.sizes.size.find(
+                d => parseInt(d.width, 10) >= 1600
+              );
+              if (!image) {
+                image = sizeObj.sizes.size.find(
+                  d => parseInt(d.width, 10) >= 1000
+                );
+              }
+              if (!image) {
+                image = sizeObj.sizes.size.find(
+                  d => parseInt(d.width, 10) >= 500
+                );
+              }
+              if (!image || !image.source) {
+                return res.json({
+                  error: "Flickr Source Error, try another image."
+                });
+              }
+              const imageData = await axios
+                .get(image.source, { responseType: "arraybuffer" })
+                .then(d => d.data)
+                .catch(catcher);
 
               // Then add a row to the image table with the metadata.
               const payload = {
@@ -229,37 +304,43 @@ module.exports = function(app) {
                 license: info.photo.license
               };
               const newImage = await db.image.create(payload).catch(catcher);
-              await db.search.update({imageId: newImage.id}, {where: {contentId}}).catch(catcher);
+              await db.search
+                .update({ imageId: newImage.id }, { where: { contentId } })
+                .catch(catcher);
 
               // Finally, upload splash and thumb version to google cloud, or psql as a fallback
-              await uploadImage(db, newImage.id, imageData, false).catch(catcher);
+              await uploadImage(db, newImage.id, imageData).catch(catcher);
             }
           }
-          const newRow = await db.search.findOne({
-            where: {contentId},
-            include: imageIncludeThumbOnly
-          }).catch(catcher);
-          if (newRow && newRow.image) newRow.image.thumb = Boolean(newRow.image.thumb);
+          const newRow = await db.search
+            .findOne({
+              where: { contentId },
+              include: imageIncludeThumbOnly
+            })
+            .catch(catcher);
+          if (newRow && newRow.image) {
+            newRow.image.thumb = Boolean(newRow.image.thumb);
+          }
           return res.json(newRow);
-        }
-        else {
+        } else {
           return res.json("Error updating Search");
         }
+      } else {
+        return res.json({ error: "Bad License" });
       }
-      else {
-        return res.json({error: "Bad License"});
-      }
-    }
-    else {
-      return res.json({error: "Malformed URL"});
+    } else {
+      return res.json({ error: "Malformed URL" });
     }
   });
 
-  app.get("/api/cubeData", async(req, res) => {
+  app.get("/api/cubeData", async (req, res) => {
     // Older version of CANON_CMS_CUBES had a full path to the cube (path.com/cubes)
     // CANON_CMS_CUBES was changed to be root only, so fix it here so we can handle
     // both the new style and the old style
-    const url = CANON_CMS_CUBES.replace(/[\/]{0,}(cubes){0,}[\/]{0,}$/, "/cubes");
+    const url = CANON_CMS_CUBES.replace(
+      /[\/]{0,}(cubes){0,}[\/]{0,}$/,
+      "/cubes"
+    );
 
     const s = (a, b) => {
       const ta = a.name.toUpperCase();
@@ -269,42 +350,47 @@ module.exports = function(app) {
 
     const config = {};
     if (OLAP_PROXY_SECRET) {
-      const jwtPayload = {sub: "server", status: "valid"};
-      if (CANON_CMS_MINIMUM_ROLE) jwtPayload.auth_level = +CANON_CMS_MINIMUM_ROLE;
-      const apiToken = jwt.sign(jwtPayload, OLAP_PROXY_SECRET, {expiresIn: "5y"});
-      config.headers = {"x-tesseract-jwt-token": apiToken};
+      const jwtPayload = { sub: "server", status: "valid" };
+      if (CANON_CMS_MINIMUM_ROLE) {
+        jwtPayload.auth_level = +CANON_CMS_MINIMUM_ROLE;
+      }
+      const apiToken = jwt.sign(jwtPayload, OLAP_PROXY_SECRET, {
+        expiresIn: "5y"
+      });
+      config.headers = { "x-tesseract-jwt-token": apiToken };
     }
 
-    const resp = await axios.get(url, config).then(resp => resp.data).catch(catcher);
+    const resp = await axios
+      .get(url, config)
+      .then(resp => resp.data)
+      .catch(catcher);
     const cubes = resp.cubes || [];
 
     const dimensions = [];
 
     cubes.forEach(cube => {
-
       cube.dimensions.forEach(d => {
         const dimension = {};
         dimension.name = `${d.name} (${cube.name})`;
         dimension.cubeName = cube.name;
         dimension.dimName = d.name;
-        dimension.measures = cube.measures.map(m => m.name.replace(/'/g, "\'"));
+        dimension.measures = cube.measures.map(m => m.name.replace(/'/g, "'"));
         const hierarchies = d.hierarchies.map(h => {
+          const levels = h.levels
+            .filter(l => l.name !== "(All)")
+            .map(l => {
+              const parts = l.fullName
+                ? l.fullName.split(".").map(p => p.replace(/^\[|\]$/g, ""))
+                : [d.name, h.name, l.name];
 
-          const levels = h.levels.filter(l => l.name !== "(All)").map(l => {
-            const parts = l.fullName
-              ? l.fullName
-                .split(".")
-                .map(p => p.replace(/^\[|\]$/g, ""))
-              : [d.name, h.name, l.name];
-
-            if (parts.length === 2) parts.unshift(parts[0]);
-            return {
-              dimension: parts[0],
-              hierarchy: parts[1],
-              level: parts[2],
-              properties: l.properties
-            };
-          });
+              if (parts.length === 2) parts.unshift(parts[0]);
+              return {
+                dimension: parts[0],
+                hierarchy: parts[1],
+                level: parts[2],
+                properties: l.properties
+              };
+            });
           return levels;
         });
         dimension.hierarchies = Array.from(new Set(d3Array.merge(hierarchies)));
@@ -315,17 +401,25 @@ module.exports = function(app) {
     return res.json(dimensions.sort(s));
   });
 
-  app.get("/api/flickr/search", async(req, res) => {
-    if (!flickr) return res.json({error: "Flickr API Key not configured"});
-    const {q} = req.query;
-    const result = await flickr.photos.search({
-      text: q,
-      license: validLicensesString,
-      sort: "relevance"
-    }).then(resp => resp.body).catch(catcher);
+  app.get("/api/flickr/search", async (req, res) => {
+    if (!flickr) return res.json({ error: "Flickr API Key not configured" });
+    const { q } = req.query;
+    const result = await flickr.photos
+      .search({
+        text: q,
+        license: validLicensesString,
+        sort: "relevance"
+      })
+      .then(resp => resp.body)
+      .catch(catcher);
     const photos = result.photos.photo;
-    const fetches = photos.reduce((acc, d) => acc.concat(flickr.photos.getSizes({photo_id: d.id})), []);
-    const results = await Promise.all(fetches).then(results => results).catch(catcher);
+    const fetches = photos.reduce(
+      (acc, d) => acc.concat(flickr.photos.getSizes({ photo_id: d.id })),
+      []
+    );
+    const results = await Promise.all(fetches)
+      .then(results => results)
+      .catch(catcher);
     const payload = results.reduce((acc, d, i) => {
       const small = d.body.sizes.size.find(s => s.label === "Small 320");
       if (small) {
@@ -339,39 +433,44 @@ module.exports = function(app) {
     return res.json(payload);
   });
 
-  app.post("/api/image_content/update", async(req, res) => {
-    const {id, locale} = req.body;
+  app.post("/api/image_content/update", async (req, res) => {
+    const { id, locale } = req.body;
     const defaults = req.body;
-    const [row, created] = await db.image_content.findOrCreate({where: {id, locale}, defaults}).catch(catcher);
+    const [row, created] = await db.image_content
+      .findOrCreate({ where: { id, locale }, defaults })
+      .catch(catcher);
     if (created) {
       res.json(created);
-    }
-    else {
+    } else {
       row.updateAttributes(defaults).catch(catcher);
       res.json(row);
     }
   });
 
-  app.post("/api/search/update", async(req, res) => {
-    const {id, locale} = req.body;
-    const update = await db.search_content.update(req.body, {where: {id, locale}}).catch(catcher);
+  app.post("/api/search/update", async (req, res) => {
+    const { id, locale } = req.body;
+    const update = await db.search_content
+      .update(req.body, { where: { id, locale } })
+      .catch(catcher);
     res.json(update);
   });
 
-  const profileSearch = async(req, res) => {
-
+  const profileSearch = async (req, res) => {
     let allDimCubes = await fetchDimCubes(db).catch(catcher);
 
     if (req.query.profile) {
       const profileIds = req.query.profile.split(",").map(Number);
-      allDimCubes = allDimCubes.filter(dc => profileIds.includes(dc.profile_id));
+      allDimCubes = allDimCubes.filter(dc =>
+        profileIds.includes(dc.profile_id)
+      );
     }
     if (req.query.cubeName) {
       const cubeSlugs = req.query.cubeName.split(",");
       allDimCubes = allDimCubes.filter(dc => cubeSlugs.includes(dc.cubeName));
     }
 
-    const locale = req.query.locale || process.env.CANON_LANGUAGE_DEFAULT || "en";
+    const locale =
+      req.query.locale || process.env.CANON_LANGUAGE_DEFAULT || "en";
     const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
     let results = {};
 
@@ -381,7 +480,6 @@ module.exports = function(app) {
       results.results = {};
 
       for (const dc of allDimCubes) {
-
         const searchWhere = {
           cubeName: dc.cubeName,
           dimension: dc.dimension,
@@ -390,8 +488,12 @@ module.exports = function(app) {
 
         // Also allow the user to directly limit searches by dimension and comma separated hierarchy (levels)
         // Note that this can happen in conjunction with the req.query.profile limitation above, as overrides.
-        if (req.query.dimension) searchWhere.dimension = req.query.dimension.split(",");
-        if (req.query.hierarchy) searchWhere.hierarchy = req.query.hierarchy.split(",");
+        if (req.query.dimension) {
+          searchWhere.dimension = req.query.dimension.split(",");
+        }
+        if (req.query.hierarchy) {
+          searchWhere.hierarchy = req.query.hierarchy.split(",");
+        }
 
         let rows = await db.search.findAll({
           where: searchWhere,
@@ -400,74 +502,110 @@ module.exports = function(app) {
           limit
         });
         // Filter out show:false from results
-        rows = rows.filter(d => !d.content.map(c => c.attr).some(a => a && a.show === false));
+        rows = rows.filter(
+          d => !d.content.map(c => c.attr).some(a => a && a.show === false)
+        );
         rows.forEach(row => {
-          if (!results.results[row.dimension]) results.results[row.dimension] = [];
+          if (!results.results[row.dimension]) {
+            results.results[row.dimension] = [];
+          }
           results.results[row.dimension].push(rowToResult(row, locale));
         });
       }
-    }
-    else {
+    } else {
       // If deepsearch is configured, attempt to connect and query
       if (deepsearchAPI) {
         req.query.language = locale;
         // Pass through search params to deepsearch and extract results
-        const url = `${deepsearchAPI}/search?${Object.keys(req.query).map(k => `${k}=${req.query[k]}`).join("&")}`;
-        results = await axios.get(url).then(d => d.data).catch(e => {
-          if (verbose) console.error(`Error connecting to Deepsearch, defaulting to Postgres: ${e}`);
-          return false;
-        });
+        const url = `${deepsearchAPI}/search?${Object.keys(req.query)
+          .map(k => `${k}=${req.query[k]}`)
+          .join("&")}`;
+        results = await axios
+          .get(url)
+          .then(d => d.data)
+          .catch(e => {
+            if (verbose) {
+              console.error(
+                `Error connecting to Deepsearch, defaulting to Postgres: ${e}`
+              );
+            }
+            return false;
+          });
         if (req.query.hierarchy) {
           const validLevels = req.query.hierarchy.split(",");
           Object.keys(results.results).forEach(dim => {
-            results.results[dim] = results.results[dim].filter(r => validLevels.includes(r.metadata.hierarchy));
+            results.results[dim] = results.results[dim].filter(r =>
+              validLevels.includes(r.metadata.hierarchy)
+            );
           });
         }
         if (results) results.origin = "deepsearch";
       }
-      if (!deepsearchAPI || deepsearchAPI && !results) {
-
+      if (!deepsearchAPI || (deepsearchAPI && !results)) {
         // Check just the first time if unaccent Extension is installed.
         // If not launch a warning and use the fallback search.
         // Install it running in the db: "CREATE EXTENSION IF NOT EXISTS unaccent;";
         if (typeof unaccentExtensionInstalled === "undefined") {
-          const [unaccentResult, unaccentMetadata] = await dbQuery("SELECT * FROM pg_extension WHERE extname = 'unaccent';");
+          const [unaccentResult, unaccentMetadata] = await dbQuery(
+            "SELECT * FROM pg_extension WHERE extname = 'unaccent';"
+          );
           unaccentExtensionInstalled = unaccentMetadata.rowCount >= 1;
           if (!unaccentExtensionInstalled) {
-            console.log("WARNING: For better search results, Consider installing the 'unaccent' extension in Postgres by running: CREATE EXTENSION IF NOT EXISTS unaccent;");
-            console.log("Do not forget to restart the web application after installation.");
+            console.log(
+              "WARNING: For better search results, Consider installing the 'unaccent' extension in Postgres by running: CREATE EXTENSION IF NOT EXISTS unaccent;"
+            );
+            console.log(
+              "Do not forget to restart the web application after installation."
+            );
           }
         }
 
         results = {};
-        const {query} = req.query;
+        const { query } = req.query;
         const where = {};
         const searchWhere = {};
         const terms = query.split(" ");
         const orArray = [];
         terms.forEach(term => {
-
           // Use unaccent extension from postgres if exists.
           if (unaccentExtensionInstalled) {
-
             // Where by name
             orArray.push(
-              sequelize.where(
-                sequelize.fn("unaccent", sequelize.col("name")),
-                {[sequelize.Op.iLike]: sequelize.fn("concat", "%", sequelize.fn("unaccent", term), "%")})
+              sequelize.where(sequelize.fn("unaccent", sequelize.col("name")), {
+                [sequelize.Op.iLike]: sequelize.fn(
+                  "concat",
+                  "%",
+                  sequelize.fn("unaccent", term),
+                  "%"
+                )
+              })
             );
 
             // Where by keywords
             orArray.push(
               sequelize.where(
-                sequelize.fn("unaccent", sequelize.fn("array_to_string", sequelize.col("keywords"), " ", "")),
-                {[sequelize.Op.iLike]: sequelize.fn("concat", "%", sequelize.fn("unaccent", term), "%")})
+                sequelize.fn(
+                  "unaccent",
+                  sequelize.fn(
+                    "array_to_string",
+                    sequelize.col("keywords"),
+                    " ",
+                    ""
+                  )
+                ),
+                {
+                  [sequelize.Op.iLike]: sequelize.fn(
+                    "concat",
+                    "%",
+                    sequelize.fn("unaccent", term),
+                    "%"
+                  )
+                }
+              )
             );
-
-          }
-          else {
+          } else {
             // Where by name: Use simple ilike query if unaccent extension doesn't exists.
-            orArray.push({name: {[sequelize.Op.iLike]: `%${term}%`}});
+            orArray.push({ name: { [sequelize.Op.iLike]: `%${term}%` } });
           }
         });
 
@@ -476,30 +614,41 @@ module.exports = function(app) {
           orArray.push(
             sequelize.where(
               sequelize.cast(sequelize.col("keywords"), "varchar"),
-              {[sequelize.Op.iLike]: `%${query}%`}))
-          ;
+              { [sequelize.Op.iLike]: `%${query}%` }
+            )
+          );
         }
 
         where[sequelize.Op.or] = orArray;
         where.locale = locale;
-        const contentRows = await db.search_content.findAll({where}).catch(catcher);
+        const contentRows = await db.search_content
+          .findAll({ where })
+          .catch(catcher);
         searchWhere[sequelize.Op.or] = [
           // If the user searched by name, it must be matched against the result set from the earlier search_content query
-          {contentId: Array.from(new Set(contentRows.map(r => r.id)))},
+          { contentId: Array.from(new Set(contentRows.map(r => r.id))) },
           // If the user searched by direct id, it must be matched against the id itself directly the in search table
-          {id: {[sequelize.Op.iLike]: `%${query}%`}}
+          { id: { [sequelize.Op.iLike]: `%${query}%` } }
         ];
         // If the user has specified a profile(s), restrict the search results to those cubes
         if (req.query.profile) {
           searchWhere.cubeName = allDimCubes.map(dc => dc.cubeName);
           searchWhere.dimension = allDimCubes.map(dc => dc.dimension);
-          searchWhere.hierarchy = unique(d3Array.merge(allDimCubes.map(dc => dc.levels)));
+          searchWhere.hierarchy = unique(
+            d3Array.merge(allDimCubes.map(dc => dc.levels))
+          );
         }
         // Also allow the user to directly limit searches by and comma separated dimension, hierarchy, and cube.
         // Note that this can happen in conjunction with the req.query.profile limitation above, as overrides.
-        if (req.query.dimension) searchWhere.dimension = req.query.dimension.split(",");
-        if (req.query.hierarchy) searchWhere.hierarchy = req.query.hierarchy.split(",");
-        if (req.query.cubeName) searchWhere.cubeName = req.query.cubeName.split(",");
+        if (req.query.dimension) {
+          searchWhere.dimension = req.query.dimension.split(",");
+        }
+        if (req.query.hierarchy) {
+          searchWhere.hierarchy = req.query.hierarchy.split(",");
+        }
+        if (req.query.cubeName) {
+          searchWhere.cubeName = req.query.cubeName.split(",");
+        }
 
         let rows = await db.search.findAll({
           include: imageIncludeNoBlobs,
@@ -513,16 +662,25 @@ module.exports = function(app) {
         results.origin = "legacy";
         results.results = {};
         // Filter out show:false from results
-        rows = rows.filter(d => !d.content.map(c => c.attr).some(a => a && a.show === false));
+        rows = rows.filter(
+          d => !d.content.map(c => c.attr).some(a => a && a.show === false)
+        );
         rows.forEach(row => {
-          if (!results.results[row.dimension]) results.results[row.dimension] = [];
+          if (!results.results[row.dimension]) {
+            results.results[row.dimension] = [];
+          }
           results.results[row.dimension].push(rowToResult(row, locale));
         });
       }
     }
 
     const relevantPids = unique(allDimCubes.map(d => d.profile_id));
-    let profiles = await db.profile.findAll({where: {id: relevantPids, visible: true}, include: {association: "meta"}}).catch(catcher);
+    let profiles = await db.profile
+      .findAll({
+        where: { id: relevantPids, visible: true },
+        include: { association: "meta" }
+      })
+      .catch(catcher);
     profiles = profiles.map(d => d.toJSON());
 
     // When searching for half a bilateral profile, what should be put in the other half?
@@ -541,33 +699,100 @@ module.exports = function(app) {
       const relevantResults = groupedMeta.reduce((acc, group, i) => {
         acc[i] = [];
         group.forEach(m => {
-          const theseResults = results.results[m.dimension] ? results.results[m.dimension].filter(d => d.metadata.cube_name === m.cubeName && m.levels.includes(d.metadata.hierarchy)) : false;
+          const theseResults = results.results[m.dimension]
+            ? results.results[m.dimension].filter(
+                d =>
+                  d.metadata.cube_name === m.cubeName &&
+                  m.levels.includes(d.metadata.hierarchy)
+              )
+            : false;
           if (theseResults) {
-            acc[i] = acc[i].concat(theseResults
-              .map(r => ({
-                slug: m.slug,
-                id: r.metadata.id,
-                memberSlug: r.metadata.slug,
-                memberDimension: m.dimension,
-                memberHierarchy: r.metadata.hierarchy,
-                name: r.name,
-                ranking: r.confidence,
-                attr: r.attr ? r.attr : {}
-              }))
-              .slice(0, limit)
+            acc[i] = acc[i].concat(
+              theseResults
+                .map(r => ({
+                  slug: m.slug,
+                  id: r.metadata.id,
+                  memberSlug: r.metadata.slug,
+                  memberDimension: m.dimension,
+                  memberHierarchy: r.metadata.hierarchy,
+                  name: r.name,
+                  ranking: r.confidence,
+                  attr: r.attr ? r.attr : {}
+                }))
+                .slice(0, limit)
             );
           }
         });
         return acc;
       }, []);
 
+      // isUnary check: single entity profile
+      const isUnary = groupedMeta.length === 1;
+      // showLaterals = true force bilaterals to be included in profilesearch results
+      const showLaterals = req.query.showLaterals === "true";
+
+      // Only whey is a bilateral profile type and showLaterals is forcing the results, run this
+      if (!isUnary & showLaterals) {
+        // Load top per profile type
+        const tops = {};
+        for (let index = 0; index < groupedMeta.length; index++) {
+          const element = groupedMeta[index];
+          const profileIDLateral = element[0].profile_id;
+          const slugLateral = element[0].slug;
+          const dimensionLateral = element[0].dimension;
+          const cubeNameLateral = element[0].cubeName;
+          const hierarchyLateral = element[0].levels;
+          if (!tops[`p${profileIDLateral}`]) {
+            // Search the top 5 profiles based on zvalue
+            const searchTop = await db.search
+              .findAll({
+                limit: 5,
+                where: {
+                  dimension: dimensionLateral,
+                  cubeName: cubeNameLateral,
+                  hierarchy: {
+                    [sequelize.Op.or]: hierarchyLateral
+                  }
+                },
+                raw: true,
+                include: [{ association: "content", where: { locale } }],
+                order: [["zvalue", "DESC NULLS LAST"]]
+              })
+              .catch(catcher);
+
+            // Format top results and store in an object per profile ID.
+            tops[`p${profileIDLateral}`] = [];
+            let searchTopObj;
+            searchTop.forEach(topRecord => {
+              searchTopObj = {
+                slug: slugLateral,
+                id: topRecord.id,
+                memberSlug: topRecord.slug,
+                memberDimension: topRecord.dimension,
+                memberHierarchy: topRecord.hierarchy,
+                name: topRecord["content.name"],
+                attr: topRecord["content.attr"] ? topRecord["content.attr"] : {}
+              };
+              searchTopObj.ranking = 0;
+              return tops[`p${profileIDLateral}`].push(searchTopObj);
+            });
+          }
+
+          // Add the tops to the combinations based on profile type
+          relevantResults[index] = relevantResults[index].concat(
+            tops[`p${profileIDLateral}`]
+          );
+        }
+      }
+
       // Take the cartesian product of the list of lists of results. For example, if you have 5 geos and
       // 5 products, create a list of 25 geo_prod results
       let combinedResults = cartesian(...relevantResults);
 
+      // console.log('profile', profile.id , relevantResults);
+
       // The cartesian product doesn't return a list of lists when only one array is given to it, as in the
       // case for unary profiles, so wrap the results in an array.
-      const isUnary = groupedMeta.length === 1;
       if (isUnary) {
         combinedResults = combinedResults.map(d => [d]);
       }
@@ -581,15 +806,20 @@ module.exports = function(app) {
       }
 
       // If there is no space in the query, Limit results to one-dimensional profiles.
-      const singleFilter = d => !req.query.query || req.query.query.includes(" ") ? true : d.length === 1;
-      const filteredResults = combinedResults.filter(singleFilter);
+      const singleFilter = d =>
+        !req.query.query || req.query.query.includes(" ")
+          ? true
+          : d.length === 1;
+      const filteredResults = showLaterals
+        ? combinedResults
+        : combinedResults.filter(singleFilter);
 
       // Save the results under a slug key for the separated-out search results.
       if (filteredResults.length > 0) {
         results.profiles[slug] = filteredResults
           .map(d => {
-            const avg = d.reduce((acc, d) => acc += d.ranking, 0) / d.length;
-            return d.map(o => ({...o, avg}));
+            const avg = d.reduce((acc, d) => (acc += d.ranking), 0) / d.length;
+            return d.map(o => ({ ...o, avg }));
           })
           .sort((a, b) => b[0].avg - a[0].avg)
           .slice(0, limit);
@@ -598,8 +828,8 @@ module.exports = function(app) {
       results.grouped = results.grouped
         .concat(filteredResults)
         .map(d => {
-          const avg = d.reduce((acc, d) => acc += d.ranking, 0) / d.length;
-          return d.map(o => ({...o, avg}));
+          const avg = d.reduce((acc, d) => (acc += d.ranking), 0) / d.length;
+          return d.map(o => ({ ...o, avg }));
         })
         .sort((a, b) => b[0].avg - a[0].avg)
         .slice(0, limit);
@@ -608,16 +838,17 @@ module.exports = function(app) {
     return res.json(results);
   };
 
-  const search = async(req, res) => {
-
+  const search = async (req, res) => {
     const where = {};
 
-    let {limit = "10"} = req.query;
+    let { limit = "10" } = req.query;
     limit = parseInt(limit, 10);
 
-    const locale = req.query.locale || process.env.CANON_LANGUAGE_DEFAULT || "en";
+    const locale =
+      req.query.locale || process.env.CANON_LANGUAGE_DEFAULT || "en";
 
-    const {id, slug, dimension, levels, cubeName, pslug, parents, cms} = req.query;
+    const { id, slug, dimension, levels, cubeName, pslug, parents, cms } =
+      req.query;
     const q = req.query.q || req.query.query;
 
     let rows = [];
@@ -628,13 +859,14 @@ module.exports = function(app) {
         where,
         include: imageIncludeThumbOnly
       });
-    }
-    else if (id) {
+    } else if (id) {
       where.id = id.includes(",") ? id.split(",") : id;
       if (dimension) where.dimension = dimension;
       if (levels) where.hierarchy = levels.split(",");
       if (pslug) {
-        const thisMeta = await db.profile_meta.findOne({where: {slug: pslug.split(",")}});
+        const thisMeta = await db.profile_meta.findOne({
+          where: { slug: pslug.split(",") }
+        });
         if (thisMeta) {
           where.cubeName = thisMeta.cubeName;
           where.dimension = thisMeta.dimension;
@@ -645,18 +877,22 @@ module.exports = function(app) {
         where,
         include: imageIncludeThumbOnly
       });
-    }
-    else {
-
+    } else {
       // Check just the first time if unaccent Extension is installed.
       // If not launch a warning and use the fallback search.
       // Install it running in the db: "CREATE EXTENSION IF NOT EXISTS unaccent;";
       if (typeof unaccentExtensionInstalled === "undefined") {
-        const [unaccentResult, unaccentMetadata] = await dbQuery("SELECT * FROM pg_extension WHERE extname = 'unaccent';");
+        const [unaccentResult, unaccentMetadata] = await dbQuery(
+          "SELECT * FROM pg_extension WHERE extname = 'unaccent';"
+        );
         unaccentExtensionInstalled = unaccentMetadata.rowCount >= 1;
         if (!unaccentExtensionInstalled) {
-          console.log("WARNING: For better search results, Consider installing the 'unaccent' extension in Postgres by running: CREATE EXTENSION IF NOT EXISTS unaccent;");
-          console.log("Do not forget to restart the web application after installation.");
+          console.log(
+            "WARNING: For better search results, Consider installing the 'unaccent' extension in Postgres by running: CREATE EXTENSION IF NOT EXISTS unaccent;"
+          );
+          console.log(
+            "Do not forget to restart the web application after installation."
+          );
         }
       }
 
@@ -664,38 +900,58 @@ module.exports = function(app) {
       if (q) {
         // Use unaccent extension from postgres if exists.
         if (unaccentExtensionInstalled) {
-
           where[sequelize.Op.or] = [
             // For name
-            sequelize.where(
-              sequelize.fn("unaccent", sequelize.col("name")),
-              {[sequelize.Op.iLike]: sequelize.fn("concat", "%", sequelize.fn("unaccent", q), "%")}),
+            sequelize.where(sequelize.fn("unaccent", sequelize.col("name")), {
+              [sequelize.Op.iLike]: sequelize.fn(
+                "concat",
+                "%",
+                sequelize.fn("unaccent", q),
+                "%"
+              )
+            }),
             // For keywords
             sequelize.where(
-              sequelize.fn("unaccent", sequelize.fn("array_to_string", sequelize.col("keywords"), " ", "")),
-              {[sequelize.Op.iLike]: sequelize.fn("concat", "%", sequelize.fn("unaccent", q), "%")})
+              sequelize.fn(
+                "unaccent",
+                sequelize.fn(
+                  "array_to_string",
+                  sequelize.col("keywords"),
+                  " ",
+                  ""
+                )
+              ),
+              {
+                [sequelize.Op.iLike]: sequelize.fn(
+                  "concat",
+                  "%",
+                  sequelize.fn("unaccent", q),
+                  "%"
+                )
+              }
+            )
           ];
-
         }
         // Use regular ilike search if unaccent is not installed.
         else {
           where[sequelize.Op.or] = [
-            {name: {[sequelize.Op.iLike]: `%${q}%`}},
+            { name: { [sequelize.Op.iLike]: `%${q}%` } },
             sequelize.where(
               sequelize.cast(sequelize.col("keywords"), "varchar"),
-              {[sequelize.Op.iLike]: `%${q}%`})
+              { [sequelize.Op.iLike]: `%${q}%` }
+            )
             // Todo - search attr and imagecontent for query
           ];
         }
 
         if (locale !== "all") where.locale = locale;
 
-        rows = await db.search_content.findAll({where}).catch(catcher);
+        rows = await db.search_content.findAll({ where }).catch(catcher);
         searchWhere[sequelize.Op.or] = [
           // If the user searched by name, it must be matched against the result set from the earlier search_content query
-          {contentId: Array.from(new Set(rows.map(r => r.id)))},
+          { contentId: Array.from(new Set(rows.map(r => r.id))) },
           // If the user searched by direct id, it must be matched against the id itself directly the in search table
-          {id: {[sequelize.Op.iLike]: `%${q}%`}}
+          { id: { [sequelize.Op.iLike]: `%${q}%` } }
         ];
       }
       if (!cms) {
@@ -710,7 +966,9 @@ module.exports = function(app) {
       // In sequelize, the IN statement is implicit (hierarchy: ['Division', 'State'])
       if (levels) searchWhere.hierarchy = levels.split(",");
       if (pslug) {
-        const thisMeta = await db.profile_meta.findAll({where: {slug: pslug.split(",")}});
+        const thisMeta = await db.profile_meta.findAll({
+          where: { slug: pslug.split(",") }
+        });
         if (thisMeta && thisMeta.length > 0) {
           searchWhere.cubeName = thisMeta.map(d => d.cubeName);
           searchWhere.dimension = thisMeta.map(d => d.dimension);
@@ -737,12 +995,13 @@ module.exports = function(app) {
       return res.json(rows);
     }
 
-
     // The CMS uses this endpoint to search for members to preview. CMS editors should be able to view content
     // even if hidden using {show: false}. However, when deepsearch is down, the front-end uses this basic search.
     // If coming from the CMS, don't use the filter - otherwise, use it.
     if (!cms) {
-      rows = rows.filter(d => !d.content.map(c => c.attr).some(a => a && a.show === false));
+      rows = rows.filter(
+        d => !d.content.map(c => c.attr).some(a => a && a.show === false)
+      );
     }
 
     /**
@@ -778,13 +1037,21 @@ module.exports = function(app) {
         const url = `${cubeRoot}/relations.jsonrecords?cube=${d.cubeName}&${d.hierarchy}=${d.id}:parents`;
         const config = {};
         if (OLAP_PROXY_SECRET) {
-          const jwtPayload = {sub: "server", status: "valid"};
-          if (CANON_CMS_MINIMUM_ROLE) jwtPayload.auth_level = +CANON_CMS_MINIMUM_ROLE;
-          const apiToken = jwt.sign(jwtPayload, OLAP_PROXY_SECRET, {expiresIn: "5y"});
-          config.headers = {"x-tesseract-jwt-token": apiToken};
+          const jwtPayload = { sub: "server", status: "valid" };
+          if (CANON_CMS_MINIMUM_ROLE) {
+            jwtPayload.auth_level = +CANON_CMS_MINIMUM_ROLE;
+          }
+          const apiToken = jwt.sign(jwtPayload, OLAP_PROXY_SECRET, {
+            expiresIn: "5y"
+          });
+          config.headers = { "x-tesseract-jwt-token": apiToken };
         }
         const resp = await axios.get(url, config).catch(() => {
-          if (verbose) console.log("Warning: Parent endpoint misconfigured or not available (searchRoute)");
+          if (verbose) {
+            console.log(
+              "Warning: Parent endpoint misconfigured or not available (searchRoute)"
+            );
+          }
           return [];
         });
         if (resp && resp.data && resp.data.data && resp.data.data.length > 0) {
@@ -803,12 +1070,14 @@ module.exports = function(app) {
 
     return res.json({
       results,
-      query: {dimension, id, limit, q, parents}
+      query: { dimension, id, limit, q, parents }
     });
   };
 
-  app.get("/api/profilesearch", async(req, res) => await profileSearch(req, res));
+  app.get(
+    "/api/profilesearch",
+    async (req, res) => await profileSearch(req, res)
+  );
 
-  app.get("/api/search", async(req, res) => await search(req, res));
-
+  app.get("/api/search", async (req, res) => await search(req, res));
 };

--- a/packages/cms/src/components/fields/ProfileSearch.jsx
+++ b/packages/cms/src/components/fields/ProfileSearch.jsx
@@ -193,7 +193,7 @@ class ProfileSearch extends Component {
   onChange(e) {
 
     const {filterCubes, filterLevels, filterProfiles, ignoredTermsRegex, timeout} = this.state;
-    const {filterQueryArgs, limit, minQueryLength, showExamples, formatResults, locale} = this.props;
+    const {filterQueryArgs, limit, minQueryLength, showExamples, formatResults, locale, showLaterals} = this.props;
 
     let query = e ? e.target.value : this.state.query;
     if (query.length < minQueryLength) query = "";
@@ -231,6 +231,7 @@ class ProfileSearch extends Component {
       if (filterProfiles) url += `&profile=${filterProfiles}`;
       if (filterLevels) url += `&hierarchy=${filterLevels}`;
       if (filterCubes) url += `&cubeName=${filterCubes}`;
+      if (showLaterals) url += "&showLaterals=true";
 
       // handle the query
       this.setState({


### PR DESCRIPTION
Fixed: https://github.com/Datawheel/canon/issues/1284

UDD project is using the legacy search and they have a bilateral profile so we need to improve some results.

- New prop in `ProfileSearch` that forces to show more results from bilaterals.
- Change in `api/profilesearch` to include bilaterals combinations using the top 5 by `zvalue` 
- Readme update with the new prop

SORRY: some ESLint and Prettier formatting was applied in the files I changed.