### PR TITLE
[cms] rounds down calculated top position of sections in SubNav

### DIFF
--- a/packages/cms/src/components/sections/components/Subnav.jsx
+++ b/packages/cms/src/components/sections/components/Subnav.jsx
@@ -144,7 +144,7 @@ class Subnav extends Component {
         sections.forEach(section => {
           const elem = this.getSectionWrapper(section.slug);
           const top = elem ? elem.getBoundingClientRect().top : 1;
-          if (top <= topBorder) {
+          if (Math.floor(top) <= topBorder) {
             newSection = section;
           }
         });
@@ -153,7 +153,7 @@ class Subnav extends Component {
           newSection.children.forEach(section => {
             const elem = this.getSectionWrapper(section.slug);
             const top = elem ? elem.getBoundingClientRect().top : 1;
-            if (top <= topBorder) {
+            if (Math.floor(top) <= topBorder) {
               newSubSection = section;
             }
           });


### PR DESCRIPTION
This is an attempt to resolve the behavior seen in Healthy Cape Fear where the SubNav does not highlight the correct Grouping after clicking it in the SubNav: https://alpha.cfc.datawheel.us/profile/geo/cape-fear#social-and-economic-factors

When doing some browser inspection, the `top` values for Cape Fear are coming back with decimal pixel values that I believe are making this not trip.