### PR TITLE
[core] removes unnecessary (and often conflicting) 10 pixel padding from scroll behavior

### DIFF
--- a/packages/core/src/client.jsx
+++ b/packages/core/src/client.jsx
@@ -85,7 +85,7 @@ function scrollToHash(hash, tries = 0) {
     const top = elem.getBoundingClientRect().top;
     if (top) {
 
-      const offset = Math.round(top - parseStyle("nav-height") - parseStyle("subnav-height") - 10);
+      const offset = Math.round(top - parseStyle("nav-height") - parseStyle("subnav-height"));
 
       // if the element is not at zero, scroll to it's position
       if (offset !== 0) {


### PR DESCRIPTION
In Healthy Cape Fear, we noticed that clicking the link for a Grouping section from the SubNav would result in the previous Grouping being highlighted in the SubNav. That is because this 10 pixel padding was put in at some point (probably by me) to make scrolling look "prettier" by forcing a little top padding when scrolling to a section. 

The SubNav doesn't take this invisible padding override into account when detecting if a section has hit the "top" of the screen, nor should it IMO. I propose we just remove it from the global behavior in `core`.