### PR TITLE
adds custom resolve function to postcss

### DIFF
--- a/packages/core/webpack/config/common.js
+++ b/packages/core/webpack/config/common.js
@@ -1,0 +1,25 @@
+const path = require("path");
+
+const appDir = process.cwd();
+const appPath = path.join(appDir, "app");
+
+/** @type {import("webpack").ResolveOptions} */
+const resolve = {
+  alias: {
+    $root: appDir,
+    $app: appPath
+  },
+  modules: [
+    appPath,
+    appDir,
+    path.resolve(__dirname, "../src"),
+    path.resolve(appDir, "node_modules"),
+    path.resolve(__dirname, "../node_modules"),
+    "node_modules"
+  ],
+  extensions: [".js", ".jsx", ".css"]
+};
+
+module.exports = {
+  resolve
+};

--- a/packages/core/webpack/config/postcss.js
+++ b/packages/core/webpack/config/postcss.js
@@ -30,7 +30,18 @@ for (const key in variables) {
 const assetBase = process.env.CANON_BASE_URL || "";
 
 module.exports = [
-  require("postcss-import")({path: appPath}),
+  require("postcss-import")({
+    path: appPath,
+    resolve(id, basedir) {
+      // Resolve relative paths
+      if (id.startsWith(".")) return path.resolve(basedir, id);
+      // Resolve aliases
+      else if (id.startsWith("$app/")) return path.resolve(appPath, id.slice(5));
+      else if (id.startsWith("$root/")) return path.resolve(appDir, id.slice(6));
+      // Resolve node_modules: `@import 'normalize.css/normalize.css'`
+      return path.resolve('./node_modules', id)
+    }
+  }),
   require("lost")(),
   require("pixrem")(),
   require("postcss-mixins")(),

--- a/packages/core/webpack/dev-client.js
+++ b/packages/core/webpack/dev-client.js
@@ -6,9 +6,10 @@ const HardSourceWebpackPlugin = require("hard-source-webpack-plugin"),
       webpack = require("webpack"),
       yn = require("yn");
 
+const commonConfig = require("./config/common");
+
 const assetsPath = path.join(appDir, process.env.CANON_STATIC_FOLDER || "static", "assets");
 const publicPath = "/assets/";
-const appPath = path.join(appDir, "app");
 
 const loaderPath = require.resolve("./config/loaders");
 delete require.cache[loaderPath];
@@ -44,21 +45,7 @@ module.exports = {
       server: false
     })
   },
-  resolve: {
-    alias: {
-      $root: appDir,
-      $app: appPath
-    },
-    modules: [
-      appPath,
-      appDir,
-      path.resolve(__dirname, "../src"),
-      path.resolve(appDir, "node_modules"),
-      path.resolve(__dirname, "../node_modules"),
-      "node_modules"
-    ],
-    extensions: [".js", ".jsx", ".css"]
-  },
+  resolve: commonConfig.resolve,
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
       /node_modules\/@datawheel\/.*\.(css|scss|sass)$/,

--- a/packages/core/webpack/dev-server.js
+++ b/packages/core/webpack/dev-server.js
@@ -7,9 +7,10 @@ const FriendlyErrorsWebpackPlugin = require("@nuxtjs/friendly-errors-webpack-plu
       path = require("path"),
       webpack = require("webpack");
 
+const commonConfig = require("./config/common");
+
 const assetsPath = path.join(appDir, process.env.CANON_STATIC_FOLDER || "static", "assets");
 const publicPath = "/assets/";
-const appPath = path.join(appDir, "app");
 
 process.traceDeprecation = true;
 
@@ -43,21 +44,7 @@ module.exports = {
       server: true
     })
   },
-  resolve: {
-    alias: {
-      $root: appDir,
-      $app: appPath
-    },
-    modules: [
-      appPath,
-      appDir,
-      path.resolve(__dirname, "../src"),
-      path.resolve(appDir, "node_modules"),
-      path.resolve(__dirname, "../node_modules"),
-      "node_modules"
-    ],
-    extensions: [".js", ".jsx", ".css"]
-  },
+  resolve: commonConfig.resolve,
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
       /\/app\/.*\.(css|scss|sass)$/,

--- a/packages/core/webpack/prod.js
+++ b/packages/core/webpack/prod.js
@@ -11,26 +11,11 @@ const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPl
       path = require("path"),
       webpack = require("webpack");
 
+const commonConfig = require("./config/common");
+
 const assetsPath = path.join(appDir, process.env.CANON_STATIC_FOLDER || "static", "assets");
 const publicPath = "/assets/";
-const appPath = path.join(appDir, "app");
 const timestamp = new Date().getTime();
-
-const resolve = {
-  alias: {
-    $root: appDir,
-    $app: appPath
-  },
-  modules: [
-    appPath,
-    appDir,
-    path.resolve(__dirname, "../src"),
-    path.resolve(appDir, "node_modules"),
-    path.resolve(__dirname, "../node_modules"),
-    "node_modules"
-  ],
-  extensions: [".js", ".jsx", ".css"]
-};
 
 /** @type {import("webpack").Configuration[]} */
 module.exports = [
@@ -66,7 +51,7 @@ module.exports = [
         server: false
       })
     },
-    resolve,
+    resolve: commonConfig.resolve,
     optimization: {
       minimizer: [
         new TerserJSPlugin({}),

--- a/packages/core/webpack/prod.js
+++ b/packages/core/webpack/prod.js
@@ -106,7 +106,7 @@ module.exports = [
     module: {
       rules: commonLoaders({mode: "production", server: true, extract: true})
     },
-    resolve,
+    resolve: commonConfig.resolve,
     optimization: {
       minimizer: [
         new TerserJSPlugin({terserOptions: {keep_fnames: true}}),


### PR DESCRIPTION
The [resolve parameter](https://github.com/postcss/postcss-import/tree/12.0.1#resolve) in `postcss-import` allows a custom resolve procedure, using node's native resolve function. This commit adds the possibility to resolve the `$app` and `$root` aliases, set in webpack.
Still, a more streamlined way, using the same configuration object, would be preferred.

Closes #1283 