### PR TITLE
Sitemap generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dockerfiles/nginx/conf.d/default.conf
 
 # pm2 ecosystem config
 ecosystem.config.js
+
+examples/.pnpm-debug.log

--- a/examples/canon.js
+++ b/examples/canon.js
@@ -10,6 +10,26 @@ const pdfHeader = `data:image/png;base64,${buffer}`;
 
 /** @type {import("@datawheel/canon-core").Config} */
 module.exports = {
+  sitemap: {
+    paths: {
+      profiles: '/:lang/profile/:profile/:page',
+      stories: '/:lang/story/:page'
+    },
+    rss: {
+      blogName: "My Datawheel blog",
+      blogDescription: "It is a fantastic blog based on data."
+    },
+    getMainPaths: async (app) => {
+      //You can run queries in here and return an array of paths
+      return [
+        "/",
+        "/about",
+        "/about/data",
+        "/blog/es/super-post",
+        "/blog/en/super-posteo"
+      ]
+    }
+  },
   express: {
     bodyParser: {
       json: {

--- a/packages/cms/src/api/sitemap.js
+++ b/packages/cms/src/api/sitemap.js
@@ -1,18 +1,46 @@
 const path = require('path');
 const Sequelize = require("sequelize");
 const d3Collection = require('d3-collection');
-const {hydrateModels} = require("../../src/utils/sequelize/profiles");
+const {hydrateModelsProfile} = require("../../src/utils/sequelize/profiles");
 
 const {
-  CANON_API
+  CANON_API,
+  CANON_LANGUAGES,
+  CANON_SITEMAP_PROFILE_PATH,
+  CANON_SITEMAP_STORY_PATH
 } = process.env;
+
+//Defaults
+const languages = CANON_LANGUAGES ? CANON_LANGUAGES.split(',') : ["en"];
+const sitePath = CANON_API || "http://localhost:3300";
+const profilePath = CANON_SITEMAP_PROFILE_PATH || "/:lang/profile/:profile/:page";
+const storyPath = CANON_SITEMAP_STORY_PATH || "/:lang/story/:page";
 
 const getCustomPaths = () => {
 
 }
 
+const getAllProfilesTypes = async (database) => {
+  const {Profile} = await hydrateModelsProfile(database);
+  const profilesTypes = await Profile.getAllVisible();
+  return profilesTypes;
+};
+
+const getAllProfilesMetaByType = async (database, profileType) => {
+  const {ProfileMeta} = await hydrateModelsProfile(database);
+  const profilesMetas = await ProfileMeta.findAllIn(profileType);
+  return profilesMetas;
+};
+
+const getAllSearchByProfile = async (database, profile) => {
+  const {Search} = await hydrateModelsProfile(database);
+  const profilesMembers = await Search.findAllFromProfile(profile);
+  return profilesMembers;
+};
+
 const getProfileList = async (database, sitePath, profilePath = "/profile", storyPath = "/story") => {
-  const {ProfileMeta, Search} = await hydrateModels(database);
+
+  const {ProfileMeta, Search} = await hydrateModelsProfile(database);
 
   const profiles = await ProfileMeta.findAllIn([]);
 
@@ -129,18 +157,172 @@ const getFullProfileList = async (database, sitePath, profilePath = "/profile", 
   return finalPaths;
 }
 
+const generateOutput = (format, data, res) => {
+
+  let content = [];
+
+  //Formats
+  switch (format) {
+    case "txt":
+      res.setHeader('Content-type', 'text/plain');
+
+      content = data.map(d => d.url);
+
+      break;
+
+    case "xml":
+      res.header('Content-Type', 'text/xml');
+
+      content = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+      ];
+
+      for (const link of data) {
+        content = content.concat(
+          [
+            '  <url>',
+            `    <loc>${link.url}</loc>`,
+            //'    <lastmod>2005-01-01</lastmod>',
+            //'    <changefreq>monthly</changefreq>',
+            //'    <priority>0.4</priority>',
+            '  </url>'
+          ]
+        );
+      }
+
+      content.push('</urlset>');
+
+      break;
+
+    default:
+      break;
+  }
+
+  //Response
+  res.charset = 'UTF-8';
+  res.send(content.join('\n')).end();
+
+}
+
 module.exports = function (app) {
 
   const {db} = app.settings;
 
-  app.get("/api/sitemap.:format", async (req, res) => {
+  app.get("/api/sitemap/list", async (req, res) => {
 
-    const data = {sitemap: true, format: req.params.format}
+    const list = await getAllProfilesTypes(db);
 
-    //data.list = await getFullProfileList(db, CANON_API, "/profile", "/story");
-    data.list = await getProfileList(db, CANON_API, "/profile", "/story");
+    const sitemapCustomUrl = new URL(path.join("/api/sitemap/main"), sitePath)
+    const sitemapStoriesUrl = new URL(path.join("/api/sitemap/stories"), sitePath)
+
+    const data = {
+      title: "Sitemap list",
+      main: {
+        formats: {
+          txt: `${sitemapCustomUrl}.txt`,
+          xml: `${sitemapCustomUrl}.xml`
+        }
+      },
+      stories: {
+        formats: {
+          txt: `${sitemapStoriesUrl}.txt`,
+          xml: `${sitemapStoriesUrl}.xml`,
+          rss: `${sitemapStoriesUrl}.rss`
+        }
+      },
+      profiles: list.map(profileType => {
+        const sitemapProfileUrl = new URL(path.join("/api/sitemap", `profiles/${profileType.id}`), sitePath)
+        return {
+          id: profileType.id,
+          formats: {
+            txt: `${sitemapProfileUrl}.txt`,
+            xml: `${sitemapProfileUrl}.xml`
+          },
+          includes: profileType.meta
+            .filter(profileMeta => profileMeta.visible)
+            .map(profileMeta => {
+              return profileMeta.slug;
+            })
+        }
+      })
+    };
 
     res.send(data).end();
+  });
+
+  app.get("/api/sitemap/main.:format", async (req, res) => {
+
+    const data = {custom: true, format: req.params.format}
+
+    res.send(data).end();
+
+  });
+
+  app.get("/api/sitemap/stories.:format", async (req, res) => {
+
+    const data = {stories: true, format: req.params.format}
+
+    res.send(data).end();
+
+  });
+
+  app.get("/api/sitemap/profiles/:profileId.:format", async (req, res) => {
+
+    const profileId = parseInt(req.params.profileId, 10);
+
+    const format = req.params.format;
+
+    const profilesMeta = await getAllProfilesMetaByType(db, profileId);
+
+    const metaSize = profilesMeta.length;
+
+    const urlTemplate = new URL(path.join(profilePath), sitePath).toString();
+
+    const urlList = [];
+
+    if (metaSize === 2) { // Bilateral
+
+      const profile1 = profilesMeta[0];
+      const profile2 = profilesMeta[1];
+
+      const pages1 = await getAllSearchByProfile(db, profile1);
+      const pages2 = await getAllSearchByProfile(db, profile2);
+
+      for (const page1 of pages1) {
+        for (const page2 of pages2) {
+          const jobParams = {
+            page: new URL(path.join(page1.slug, profile2.slug, page2.slug), sitePath).pathname,
+            profile: profile1.slug
+          };
+          languages.forEach(lang => {
+            if (page1.slug !== page2.slug) {
+              jobParams.lang = lang;
+              urlList.push({url: urlTemplate.replace(/:(\w+)\b/g, (_, key) => jobParams[key] ? jobParams[key] : _)});
+            }
+          });
+        }
+      }
+
+    } else if (metaSize === 1 || metaSize > 2) { // Treat them as single member
+      for (const profile of profilesMeta) {
+        const pages = await getAllSearchByProfile(db, profile);
+        for (const page of pages) {
+          const jobParams = {
+            page: page.slug,
+            profile: profile.slug
+          };
+          languages.forEach(lang => {
+            jobParams.lang = lang;
+            urlList.push({url: urlTemplate.replace(/:(\w+)\b/g, (_, key) => jobParams[key] ? jobParams[key] : _)});
+          });
+        }
+      }
+    }
+
+    console.log(urlList.length);
+
+    return generateOutput(format, urlList, res);
 
   });
 

--- a/packages/cms/src/api/sitemap.js
+++ b/packages/cms/src/api/sitemap.js
@@ -1,24 +1,38 @@
 const path = require('path');
-const Sequelize = require("sequelize");
-const d3Collection = require('d3-collection');
 const {hydrateModelsProfile} = require("../../src/utils/sequelize/profiles");
 
 const {
   CANON_API,
-  CANON_LANGUAGES,
-  CANON_SITEMAP_PROFILE_PATH,
-  CANON_SITEMAP_STORY_PATH
+  CANON_LANGUAGES
 } = process.env;
 
 //Defaults
 const languages = CANON_LANGUAGES ? CANON_LANGUAGES.split(',') : ["en"];
 const sitePath = CANON_API || "http://localhost:3300";
-const profilePath = CANON_SITEMAP_PROFILE_PATH || "/:lang/profile/:profile/:page";
-const storyPath = CANON_SITEMAP_STORY_PATH || "/:lang/story/:page";
 
-const getCustomPaths = () => {
+//Get canon data
+const canonConfigPath = path.resolve("canon.js");
+const canon = require(canonConfigPath);
 
-}
+const sitemapConfig = canon && canon.sitemap ? canon.sitemap : {
+  paths: {
+    profiles: '/:lang/profile/:profile/:page',
+    stories: '/:lang/story/:page'
+  },
+  rss: {
+    blogName: "My Datawheel blog",
+    blogDescription: "This is a fantastic blog based on data."
+  },
+  getMainPaths: async (app) => {
+    //You can run queries in here and return an array of paths
+    return [
+      "/"
+    ]
+  }
+};
+
+const profilePath = sitemapConfig.paths.profiles;
+const storyPath = sitemapConfig.paths.stories;
 
 const getAllProfilesTypes = async (database) => {
   const {Profile} = await hydrateModelsProfile(database);
@@ -38,136 +52,25 @@ const getAllSearchByProfile = async (database, profile) => {
   return profilesMembers;
 };
 
-const getProfileList = async (database, sitePath, profilePath = "/profile", storyPath = "/story") => {
-
-  const {ProfileMeta, Search} = await hydrateModelsProfile(database);
-
-  const profiles = await ProfileMeta.findAllIn([]);
-
-  const profilesNested = d3Collection
-    .nest()
-    .key(item => item.profile_id)
-    .entries(profiles);
-
-  const profileList = [];
-  // TO DO
-  for (const profile of profiles) {
-    console.log(profile.slug);
-    const pages = await Search.findAllFromProfile(profile);
-
-    for (const page of pages) {
-      profileList.push(new URL(path.join(profilePath, profile.slug, page.slug), sitePath))
-    }
-  }
-  return profileList;
-}
-
-// Validate and iterate over every profile and return a final list of urls
-const getFullProfileList = async (database, sitePath, profilePath = "/profile", storyPath = "/story") => {
-
-  const queryList = [
-    //Profile Meta query
-    database.profile_meta.findAll({
-      attributes: ['id', 'profile_id', 'dimension', 'slug'],
-      where: {
-        visible: true
-      },
-      raw: true
-    }),
-
-    //ValidProfiles
-    database.search_content.findAll({
-      attributes: [
-        [Sequelize.fn('DISTINCT', Sequelize.col('id')), 'id']
-      ],
-      where: {
-        attr: {
-          [Sequelize.Op.is]: null
-        }
-      },
-      raw: true
-    }).map(item => item.id),
-
-    //Stories
-    database.story.findAll({
-      attributes: ['slug'],
-      raw: true
-    })
-  ];
-
-  const [profilesMeta, validProfiles, stories] = await Promise.all(queryList);
-
-  const profilesMetaNested = d3Collection
-    .nest()
-    .key(item => item.profile_id)
-    .entries(profilesMeta);
-
-  //Profile information
-  const profiles = await database.search.findAll({
-    attributes: ['dimension', 'hierarchy', 'slug'],
-    raw: true,
-    where: {
-      contentId: validProfiles
-    }
-  });
-
-  const finalPaths = [];
-
-  //Iterate over profile types
-  profilesMetaNested.forEach(profileType => {
-    console.log(`--- Generating links for profile id: ${profileType.key} on ${profileType.values.map(item => item.dimension).join(',')} with slug "${profileType.values.map(item => item.slug).join('/')}"`);
-
-    const profileItems = []
-    profileType.values.forEach(profileDimension => {
-      profileItems.push({slug: profileDimension.slug, profiles: profiles.filter(item => item.dimension === profileDimension.dimension)});
-    });
-
-    if (profileItems.length === 1) { //Single entity profile
-      const singleProfileSlug = profileItems[0].slug;
-      profileItems[0].profiles.forEach(item => {
-        finalPaths.push(new URL(path.join(profilePath, singleProfileSlug, item.slug), sitePath))
-      });
-    } else { //Multilateral profiles
-      /*const multi1ProfileSlug = profileItems[0].slug;
-      const multi2ProfileSlug = profileItems[1].slug;
-      profileItems[0].profiles.forEach(item1 => {
-        profileItems[1].profiles.forEach(item2 => {
-          //if ([item1.hierarchy, item2.hierarchy].indexOf("Institution Type") === -1 && item1.slug !== item2.slug) {
-          if (item1.slug !== item2.slug) { //Non simetric bilateral
-            finalPaths.push(
-              new URL(path.join(
-                profilePath,
-                multi1ProfileSlug,
-                item1.slug,
-                multi2ProfileSlug,
-                item2.slug)
-                , sitePath));
-          }
-        });
-      });*/
-    }
-
-  });
-
-  //Iterate over stories
-  stories.forEach(story => {
-    finalPaths.push(new URL(path.join(storyPath, story.slug), sitePath))
-  });
-
-  return finalPaths;
-}
+const getAllPublicStories = async (database) => {
+  const {Story} = await hydrateModelsProfile(database);
+  const stories = await Story.findAllPublicStories();
+  return stories;
+};
 
 const generateOutput = (format, data, res) => {
 
   let content = [];
 
+  // Limit 50k links per sitemap TODO: split the files, paginated
+  const filteredData = data.slice(0, 50000);
+
   //Formats
   switch (format) {
+
     case "txt":
       res.setHeader('Content-type', 'text/plain');
-
-      content = data.map(d => d.url);
-
+      content = filteredData.map(d => d.url);
       break;
 
     case "xml":
@@ -178,7 +81,7 @@ const generateOutput = (format, data, res) => {
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
       ];
 
-      for (const link of data) {
+      for (const link of filteredData) {
         content = content.concat(
           [
             '  <url>',
@@ -192,6 +95,40 @@ const generateOutput = (format, data, res) => {
       }
 
       content.push('</urlset>');
+
+      break;
+
+    case "rss":
+      res.header('Content-Type', 'text/xml');
+
+      const sitemapStoriesRSS = new URL(path.join("/api/sitemap/stories.rss"), sitePath)
+
+      content = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+        '  <channel>',
+        `  <title>${sitemapConfig.rss.blogName}</title>`,
+        `  <link>${sitePath}</link>`,
+        `  <description>${sitemapConfig.rss.blogDescription}</description>`,
+        `  <atom:link href="${sitemapStoriesRSS}" rel="self" type="application/rss+xml" />`
+      ];
+
+      for (const link of filteredData) {
+        content = content.concat(
+          [
+            '  <item>',
+            `    <title>${link.title}</title> `,
+            `    <pubDate>${link.date}</pubDate> `,
+            `    <link>${link.url}</link> `,
+            `    <guid>${link.url}</guid> `,
+            `    <description>${link.subtitle}</description> `,
+            '  </item>'
+          ]
+        );
+      }
+
+      content.push('  </channel>');
+      content.push('</rss>');
 
       break;
 
@@ -209,61 +146,167 @@ module.exports = function (app) {
 
   const {db} = app.settings;
 
-  app.get("/api/sitemap/list", async (req, res) => {
+  app.get("/api/sitemap.:format", async (req, res) => {
 
+    const format = req.params.format;
     const list = await getAllProfilesTypes(db);
 
-    const sitemapCustomUrl = new URL(path.join("/api/sitemap/main"), sitePath)
-    const sitemapStoriesUrl = new URL(path.join("/api/sitemap/stories"), sitePath)
+    if (["txt", "xml", "json"].indexOf(format) === -1) { //Validate format
+      return res.status(404).send('Sitemap Not Found: Wrong format');
+    } else {
+      const sitemapCustomUrl = new URL(path.join("/api/sitemap/main"), sitePath);
+      const sitemapStoriesUrl = new URL(path.join("/api/sitemap/stories"), sitePath);
 
-    const data = {
-      title: "Sitemap list",
-      main: {
-        formats: {
-          txt: `${sitemapCustomUrl}.txt`,
-          xml: `${sitemapCustomUrl}.xml`
-        }
-      },
-      stories: {
-        formats: {
-          txt: `${sitemapStoriesUrl}.txt`,
-          xml: `${sitemapStoriesUrl}.xml`,
-          rss: `${sitemapStoriesUrl}.rss`
-        }
-      },
-      profiles: list.map(profileType => {
-        const sitemapProfileUrl = new URL(path.join("/api/sitemap", `profiles/${profileType.id}`), sitePath)
-        return {
-          id: profileType.id,
-          formats: {
-            txt: `${sitemapProfileUrl}.txt`,
-            xml: `${sitemapProfileUrl}.xml`
-          },
-          includes: profileType.meta
-            .filter(profileMeta => profileMeta.visible)
-            .map(profileMeta => {
-              return profileMeta.slug;
+      let content = [];
+
+      switch (format) {
+        case 'txt':
+          res.setHeader('Content-type', 'text/plain');
+          content = content.concat([
+            `${sitemapCustomUrl}.txt`,
+            `${sitemapCustomUrl}.xml`,
+            `${sitemapStoriesUrl}.txt`,
+            `${sitemapStoriesUrl}.xml`,
+            `${sitemapStoriesUrl}.rss`
+          ]);
+
+          for (const profileType of list) {
+            const sitemapProfileUrl = new URL(path.join("/api/sitemap", `profiles/${profileType.id}`), sitePath);
+            content.push(`${sitemapProfileUrl}.txt`);
+            content.push(`${sitemapProfileUrl}.xml`);
+          }
+
+          content = content.join('\n');
+
+          break;
+
+        case 'xml':
+          res.header('Content-Type', 'text/xml');
+
+          content = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+          ];
+
+          content = content.concat([
+            `  <sitemap><loc>${sitemapCustomUrl}.xml</loc></sitemap>`,
+            `  <sitemap><loc>${sitemapStoriesUrl}.xml</loc></sitemap>`
+          ]);
+
+          for (const profileType of list) {
+            const sitemapProfileUrl = new URL(path.join("/api/sitemap", `profiles/${profileType.id}`), sitePath);
+            content.push(`  <sitemap><loc>${sitemapProfileUrl}.xml</loc></sitemap>`);
+          }
+
+          content.push('</sitemapindex>');
+
+          content = content.join('\n');
+
+          break;
+
+        case 'json':
+          res.setHeader('Content-Type', 'application/json');
+          const data = {
+            title: "Sitemap list",
+            main: {
+              formats: {
+                txt: `${sitemapCustomUrl}.txt`,
+                xml: `${sitemapCustomUrl}.xml`
+              }
+            },
+            stories: {
+              formats: {
+                txt: `${sitemapStoriesUrl}.txt`,
+                xml: `${sitemapStoriesUrl}.xml`,
+                rss: `${sitemapStoriesUrl}.rss`
+              }
+            },
+            profiles: list.map(profileType => {
+              const sitemapProfileUrl = new URL(path.join("/api/sitemap", `profiles/${profileType.id}`), sitePath)
+              return {
+                id: profileType.id,
+                formats: {
+                  txt: `${sitemapProfileUrl}.txt`,
+                  xml: `${sitemapProfileUrl}.xml`
+                },
+                includes: profileType.meta
+                  .filter(profileMeta => profileMeta.visible)
+                  .map(profileMeta => {
+                    return profileMeta.slug;
+                  })
+              }
             })
-        }
-      })
-    };
+          };
+          content = data;
+          break;
 
-    res.send(data).end();
+        default:
+          break;
+      }
+
+      res.send(content).end();
+    }
+
   });
 
   app.get("/api/sitemap/main.:format", async (req, res) => {
 
-    const data = {custom: true, format: req.params.format}
+    const list = await sitemapConfig.getMainPaths(app);
 
-    res.send(data).end();
+    const format = req.params.format;
+
+    const urlList = list.map(url => {
+      return {
+        url: new URL(path.join(url), sitePath)
+      }
+    });
+
+    return generateOutput(format, urlList, res);
 
   });
 
   app.get("/api/sitemap/stories.:format", async (req, res) => {
 
-    const data = {stories: true, format: req.params.format}
+    const format = req.params.format;
 
-    res.send(data).end();
+    if (["txt", "xml", "rss"].indexOf(format) === -1) { //Validate format
+      return res.status(404).send('Sitemap Not Found: Wrong format');
+    } else {
+
+      const stories = await getAllPublicStories(db);
+
+      const urlTemplate = new URL(path.join(storyPath), sitePath).toString();
+
+      const urlList = [];
+
+      let jobParams;
+      let langParams;
+      let urlObj;
+      for (const story of stories) {
+        jobParams = {
+          page: story.slug
+        };
+        languages.forEach(lang => {
+          jobParams.lang = lang;
+          urlObj = {
+            title: story.slug, //Default, replaced later
+            subtitle: story.slug, //Default, replaced later
+            url: urlTemplate.replace(/:(\w+)\b/g, (_, key) => jobParams[key] ? jobParams[key] : _),
+            date: story.date.toUTCString()
+          };
+
+          langParams = story.content.find(content => content.locale === lang);
+          if (langParams) {
+            urlObj.title = langParams.title.replace(/<\/?[^>]+(>|$)/g, "");
+            urlObj.subtitle = langParams.subtitle.replace(/<\/?[^>]+(>|$)/g, "");
+          }
+
+          urlList.push(urlObj);
+        });
+      }
+
+      return generateOutput(format, urlList, res);
+    }
 
   });
 
@@ -275,54 +318,59 @@ module.exports = function (app) {
 
     const profilesMeta = await getAllProfilesMetaByType(db, profileId);
 
-    const metaSize = profilesMeta.length;
+    if (profilesMeta.length === 0) { //Validate profile id
+      return res.status(404).send('Sitemap Not Found: Wrong profile number');
+    } else if (["txt", "xml"].indexOf(format) === -1) { //Validate format
+      return res.status(404).send('Sitemap Not Found: Wrong format');
+    } else { //Generate sitemap
 
-    const urlTemplate = new URL(path.join(profilePath), sitePath).toString();
+      const metaSize = profilesMeta.length;
 
-    const urlList = [];
+      const urlTemplate = new URL(path.join(profilePath), sitePath).toString();
 
-    if (metaSize === 2) { // Bilateral
+      const urlList = [];
 
-      const profile1 = profilesMeta[0];
-      const profile2 = profilesMeta[1];
+      if (metaSize === 2) { // Bilateral
 
-      const pages1 = await getAllSearchByProfile(db, profile1);
-      const pages2 = await getAllSearchByProfile(db, profile2);
+        const profile1 = profilesMeta[0];
+        const profile2 = profilesMeta[1];
 
-      for (const page1 of pages1) {
-        for (const page2 of pages2) {
-          const jobParams = {
-            page: new URL(path.join(page1.slug, profile2.slug, page2.slug), sitePath).pathname,
-            profile: profile1.slug
-          };
-          languages.forEach(lang => {
-            if (page1.slug !== page2.slug) {
+        const pages1 = await getAllSearchByProfile(db, profile1);
+        const pages2 = await getAllSearchByProfile(db, profile2);
+
+        for (const page1 of pages1) {
+          for (const page2 of pages2) {
+            const jobParams = {
+              page: `${page1.slug}/${profile2.slug}/${page2.slug}`,
+              profile: profile1.slug
+            };
+            languages.forEach(lang => {
+              if (page1.slug !== page2.slug) {
+                jobParams.lang = lang;
+                urlList.push({url: urlTemplate.replace(/:(\w+)\b/g, (_, key) => jobParams[key] ? jobParams[key] : _)});
+              }
+            });
+          }
+        }
+
+      } else if (metaSize === 1 || metaSize > 2) { // Treat them as single member
+        for (const profile of profilesMeta) {
+          const pages = await getAllSearchByProfile(db, profile);
+          for (const page of pages) {
+            const jobParams = {
+              page: page.slug,
+              profile: profile.slug
+            };
+            languages.forEach(lang => {
               jobParams.lang = lang;
               urlList.push({url: urlTemplate.replace(/:(\w+)\b/g, (_, key) => jobParams[key] ? jobParams[key] : _)});
-            }
-          });
+            });
+          }
         }
       }
 
-    } else if (metaSize === 1 || metaSize > 2) { // Treat them as single member
-      for (const profile of profilesMeta) {
-        const pages = await getAllSearchByProfile(db, profile);
-        for (const page of pages) {
-          const jobParams = {
-            page: page.slug,
-            profile: profile.slug
-          };
-          languages.forEach(lang => {
-            jobParams.lang = lang;
-            urlList.push({url: urlTemplate.replace(/:(\w+)\b/g, (_, key) => jobParams[key] ? jobParams[key] : _)});
-          });
-        }
-      }
+      return generateOutput(format, urlList, res);
     }
-
-    console.log(urlList.length);
-
-    return generateOutput(format, urlList, res);
 
   });
 

--- a/packages/cms/src/api/sitemap.js
+++ b/packages/cms/src/api/sitemap.js
@@ -1,0 +1,147 @@
+const path = require('path');
+const Sequelize = require("sequelize");
+const d3Collection = require('d3-collection');
+const {hydrateModels} = require("../../src/utils/sequelize/profiles");
+
+const {
+  CANON_API
+} = process.env;
+
+const getCustomPaths = () => {
+
+}
+
+const getProfileList = async (database, sitePath, profilePath = "/profile", storyPath = "/story") => {
+  const {ProfileMeta, Search} = await hydrateModels(database);
+
+  const profiles = await ProfileMeta.findAllIn([]);
+
+  const profilesNested = d3Collection
+    .nest()
+    .key(item => item.profile_id)
+    .entries(profiles);
+
+  const profileList = [];
+  // TO DO
+  for (const profile of profiles) {
+    console.log(profile.slug);
+    const pages = await Search.findAllFromProfile(profile);
+
+    for (const page of pages) {
+      profileList.push(new URL(path.join(profilePath, profile.slug, page.slug), sitePath))
+    }
+  }
+  return profileList;
+}
+
+// Validate and iterate over every profile and return a final list of urls
+const getFullProfileList = async (database, sitePath, profilePath = "/profile", storyPath = "/story") => {
+
+  const queryList = [
+    //Profile Meta query
+    database.profile_meta.findAll({
+      attributes: ['id', 'profile_id', 'dimension', 'slug'],
+      where: {
+        visible: true
+      },
+      raw: true
+    }),
+
+    //ValidProfiles
+    database.search_content.findAll({
+      attributes: [
+        [Sequelize.fn('DISTINCT', Sequelize.col('id')), 'id']
+      ],
+      where: {
+        attr: {
+          [Sequelize.Op.is]: null
+        }
+      },
+      raw: true
+    }).map(item => item.id),
+
+    //Stories
+    database.story.findAll({
+      attributes: ['slug'],
+      raw: true
+    })
+  ];
+
+  const [profilesMeta, validProfiles, stories] = await Promise.all(queryList);
+
+  const profilesMetaNested = d3Collection
+    .nest()
+    .key(item => item.profile_id)
+    .entries(profilesMeta);
+
+  //Profile information
+  const profiles = await database.search.findAll({
+    attributes: ['dimension', 'hierarchy', 'slug'],
+    raw: true,
+    where: {
+      contentId: validProfiles
+    }
+  });
+
+  const finalPaths = [];
+
+  //Iterate over profile types
+  profilesMetaNested.forEach(profileType => {
+    console.log(`--- Generating links for profile id: ${profileType.key} on ${profileType.values.map(item => item.dimension).join(',')} with slug "${profileType.values.map(item => item.slug).join('/')}"`);
+
+    const profileItems = []
+    profileType.values.forEach(profileDimension => {
+      profileItems.push({slug: profileDimension.slug, profiles: profiles.filter(item => item.dimension === profileDimension.dimension)});
+    });
+
+    if (profileItems.length === 1) { //Single entity profile
+      const singleProfileSlug = profileItems[0].slug;
+      profileItems[0].profiles.forEach(item => {
+        finalPaths.push(new URL(path.join(profilePath, singleProfileSlug, item.slug), sitePath))
+      });
+    } else { //Multilateral profiles
+      /*const multi1ProfileSlug = profileItems[0].slug;
+      const multi2ProfileSlug = profileItems[1].slug;
+      profileItems[0].profiles.forEach(item1 => {
+        profileItems[1].profiles.forEach(item2 => {
+          //if ([item1.hierarchy, item2.hierarchy].indexOf("Institution Type") === -1 && item1.slug !== item2.slug) {
+          if (item1.slug !== item2.slug) { //Non simetric bilateral
+            finalPaths.push(
+              new URL(path.join(
+                profilePath,
+                multi1ProfileSlug,
+                item1.slug,
+                multi2ProfileSlug,
+                item2.slug)
+                , sitePath));
+          }
+        });
+      });*/
+    }
+
+  });
+
+  //Iterate over stories
+  stories.forEach(story => {
+    finalPaths.push(new URL(path.join(storyPath, story.slug), sitePath))
+  });
+
+  return finalPaths;
+}
+
+module.exports = function (app) {
+
+  const {db} = app.settings;
+
+  app.get("/api/sitemap.:format", async (req, res) => {
+
+    const data = {sitemap: true, format: req.params.format}
+
+    //data.list = await getFullProfileList(db, CANON_API, "/profile", "/story");
+    data.list = await getProfileList(db, CANON_API, "/profile", "/story");
+
+    res.send(data).end();
+
+  });
+
+};

--- a/packages/cms/src/utils/sequelize/profiles.js
+++ b/packages/cms/src/utils/sequelize/profiles.js
@@ -1,3 +1,4 @@
+const stylePropObject = require("eslint-plugin-react/lib/rules/style-prop-object");
 const Sequelize = require("sequelize");
 
 module.exports = {
@@ -12,6 +13,7 @@ module.exports = {
 async function hydrateModelsProfile(sequelize) {
   const Op = Sequelize.Op;
 
+  const Story = sequelize.story;
   const Profile = sequelize.profile;
   const ProfileMeta = sequelize.profile_meta;
   const Search = sequelize.search;
@@ -71,5 +73,14 @@ async function hydrateModelsProfile(sequelize) {
     }));
   };
 
-  return {Profile, ProfileMeta, Search, SearchContent};
+  Story.findAllPublicStories = function () {
+    const now = Date.now();
+    return Story
+      .findAll({
+        include: "content"
+      })
+      .then(stories => stories.filter(story => story.visible && story.date < now));
+  };
+
+  return {Story, Profile, ProfileMeta, Search, SearchContent};
 }

--- a/packages/cms/src/utils/sequelize/profiles.js
+++ b/packages/cms/src/utils/sequelize/profiles.js
@@ -1,0 +1,67 @@
+const Sequelize = require("sequelize");
+
+module.exports = {
+  hydrateModels
+};
+
+/**
+ * Creates a new sequelize connection, and imports the needed models into it.
+ *
+ * @param {import(".").WarmupCliOptions} options
+ */
+async function hydrateModels(sequelize) {
+  const Op = Sequelize.Op;
+
+  const ProfileMeta = sequelize.profile_meta;
+  const Search = sequelize.search;
+  const SearchContent = sequelize.search_content;
+
+  ProfileMeta.findAllIn = function () {
+    return ProfileMeta
+      .findAll({
+        where: {
+          cubeName: {[Op.ne]: ""},
+          dimension: {[Op.ne]: ""},
+          [Op.and]: Sequelize.where(
+            Sequelize.fn("array_length", Sequelize.col("levels"), 1),
+            {[Op.gt]: 0}
+          ),
+          measure: {[Op.ne]: ""},
+          slug: {[Op.ne]: ""},
+          visible: true
+        },
+        include: "profile"
+      })
+      .then(profilesMetas => {
+        return profilesMetas.filter(profileMeta => {
+          return !profileMeta.profile || profileMeta.profile.visible;
+        })
+      });
+  };
+
+  Search.hasMany(SearchContent, {
+    foreignKey: "id",
+    sourceKey: "contentId",
+    as: "relatedContent"
+  });
+
+  Search.findAllFromProfile = function (profile) {
+    return Search.findAll({
+      include: [{association: "relatedContent"}],
+      where: {
+        cubeName: profile.cubeName,
+        dimension: profile.dimension
+      },
+      order: [
+        ["zvalue", "DESC"],
+        ["hierarchy", "ASC"],
+        ["slug", "ASC"]
+      ]
+    }).then(pages => pages.filter(search => {
+      const {relatedContent} = search;
+      return !relatedContent || !relatedContent.some(cnt => cnt.attr && cnt.attr.show === false);
+    }));
+  };
+
+  return {ProfileMeta, Search, SearchContent};
+}


### PR DESCRIPTION
New sitemap generation for `canon-cms`:

Features:
- SitemapIndex generated that collects all the generated sitemaps in one single url.
- User defined urls sitemap. 
- Stories sitemap (includes rss).
- Profiles sitemap (one sitemap per profile type).

Take a look into the [readme file](https://github.com/Datawheel/canon/tree/sitemap-generation/packages/cms#sitemaps) to see a full description of the implementation.