### PR TITLE
adds viewData and viewDataFormat config options

### DIFF
--- a/packages/cms/src/components/Viz/Viz.jsx
+++ b/packages/cms/src/components/Viz/Viz.jsx
@@ -127,8 +127,8 @@ class Viz extends Component {
                 key="option-key"
                 component={{section, viz: this}}
                 dataAttachments={vizConfig.dataAttachments}
-                data={vizConfig.data}
-                dataFormat={vizProps.dataFormat}
+                data={vizConfig.viewData || vizConfig.data}
+                dataFormat={vizConfig.viewDataFormat || vizProps.dataFormat}
                 slug={slug }
                 title={title || sectionTitle || slug}
                 iconOnly={size && size.width < 320 ? true : false}


### PR DESCRIPTION
These "hidden" options are needed for the Cape Fear project, and are actually also used in the custom Data USA CMS, which allows certain visualizations (like top/bottom rankins charts) to display the entire dataset in the View Data panel.