### PR TITLE
implements profile comparison feature based on Data USA

### DIFF
--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -16,6 +16,7 @@ Content Management System for Canon sites.
 - [Hidden Profiles](#hidden-profiles)
 - [Search](#search)
 - [PDF Printing](#pdf-printing)
+- [Profile Comparisons](#profile-comparisons)
 - [Advanced Generator Techniques](#advanced-generator-techniques)
 - [Advanced Visualization Techniques](#advanced-visualization-techniques)
 - [Advanced Selector Techniques](#advanced-selector-techniques)
@@ -744,6 +745,16 @@ pdf: {
 #### Disabling PDF Routes
 
 If needed for security/environment reasons, the pdf generation endpoints can be disabled by setting `CANON_CMS_PDF_DISABLE` to `true`.
+
+---
+
+## Profile Comparisons
+
+To enable a button that appears in every Profile hero section, allowing users to add a side-by-side comparison profile of the same type, set the following environment variable to `true`:
+
+```sh
+export CANON_CONST_PROFILE_COMPARISON=true
+```
 
 ---
 

--- a/packages/cms/src/components/Profile.jsx
+++ b/packages/cms/src/components/Profile.jsx
@@ -19,7 +19,7 @@ class Profile extends Component {
   }
 
   render() {
-    const {profile, formatters, locale} = this.props;
+    const {profile, formatters, locale, router} = this.props;
 
     if (profile.error) {
       const {error, errorCode} = profile;
@@ -41,6 +41,7 @@ class Profile extends Component {
         profile={profile}
         formatters={formatters}
         locale={locale}
+        router={router}
       />
     );
   }

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -310,7 +310,7 @@ class ProfileRenderer extends Component {
           {...searchProps} />
       </div> : null }
       <Button icon={comparisonSearch ? "cross" : "comparison"} onClick={this.toggleComparisonSearch.bind(this)}>
-        {comparisonSearch ? null : "Add Comparison"}
+        {comparisonSearch ? null : t("CMS.Profile.Add Comparison")}
       </Button>
     </div> : null;
 
@@ -590,7 +590,7 @@ class ProfileRenderer extends Component {
             bottom: 0,
             position: "fixed",
             zIndex: 10
-          }}>Remove Comparison</Button> : null}
+          }}>{t("CMS.Profile.Remove Comparison")}</Button> : null}
 
         {/* hidden DOM element for rendering visualization/section to save as image */}
         <Mirror inUse="true" />

--- a/packages/cms/src/components/fields/ProfileSearch.css
+++ b/packages/cms/src/components/fields/ProfileSearch.css
@@ -270,6 +270,7 @@
     & .cms-profilesearch-list-item {
       & .cms-profilesearch-list-item-link {
         background-color: var(--white);
+        color: var(--dark);
         display: block;
         padding: 0.5rem;
         transition: background-color 0.15s ease-out;

--- a/packages/cms/src/components/sections/Hero.css
+++ b/packages/cms/src/components/sections/Hero.css
@@ -4,6 +4,7 @@
   background-color: var(--hero-bg-color);
   color: var(--hero-text-color);
   display: flex;
+  flex: 1 1 100%;
   flex-direction: column;
   position: relative;
   /* fill up the screen, but make room for the nav & subnav */

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -86,11 +86,11 @@ class Hero extends Component {
 
   spanifyTitle(title) {
 
-    const {profile} = this.props;
+    const {hideTitleSearch, profile} = this.props;
     const {variables} = profile;
 
     // stories don't have variables
-    if (variables && title) {
+    if (!hideTitleSearch && variables && title) {
 
       const names = [variables.name1, variables.name2];
 
@@ -114,7 +114,7 @@ class Hero extends Component {
   }
 
   render() {
-    const {contents, loading, sources, profile, t, type} = this.props;
+    const {comparisonButton, contents, hidePDF, loading, sources, profile, t, type} = this.props;
     const {images, creditsVisible, clickedIndex} = this.state;
     const {searchProps} = this.context;
 
@@ -171,10 +171,11 @@ class Hero extends Component {
     return (
       <header className="cp-section cp-hero">
         <div className="cp-section-inner cp-hero-inner">
-          <PDFButton className="cp-hero-pdf" filename={filename(profile.title)} />
+          { hidePDF ? null : <PDFButton className="cp-hero-pdf" filename={filename(profile.title)} /> }
           {/* caption */}
           <div className="cp-section-content cp-hero-caption">
             {heading}
+            {comparisonButton}
             {statContent}
             {paragraphs}
             {sourceContent}
@@ -288,6 +289,11 @@ class Hero extends Component {
     );
   }
 }
+
+Hero.defaultProps = {
+  hidePDF: false,
+  hideTitleSearch: false
+};
 
 Hero.contextTypes = {
   router: PropTypes.object,

--- a/packages/cms/src/components/sections/components/Selector.jsx
+++ b/packages/cms/src/components/sections/components/Selector.jsx
@@ -16,21 +16,25 @@ class Selector extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      comparisons: props && props.default ? props.default.split(",").filter(d => d.length) : [],
+      comparisons: typeof props.default === "string"
+        ? props.default.split(",").filter(d => d.length)
+        : props.default || [],
       activeValue: props.default
     };
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.default !== this.props.default) {
-      this.setState({activeValue: this.props.default});
+      this.setState({
+        comparisons: this.props.default,
+        activeValue: this.props.default
+      });
     }
   }
 
   addComparison(comparison) {
     const {comparisons} = this.state;
     const filteredComparison = comparisons.concat([comparison]);
-    this.setState({comparisons: filteredComparison});
     const {onSelector} = this.context;
     const {name} = this.props;
     onSelector(name, filteredComparison);
@@ -39,7 +43,6 @@ class Selector extends Component {
   removeComparison(option) {
     const {comparisons} = this.state;
     const filteredComparison = comparisons.filter(d => d !== option);
-    this.setState({comparisons: filteredComparison});
     const {onSelector} = this.context;
     const {name} = this.props;
     onSelector(name, filteredComparison);

--- a/packages/core/src/i18n/canon.js
+++ b/packages/core/src/i18n/canon.js
@@ -50,11 +50,13 @@ export default {
       "visualization only": "visualization only"
     },
     "Profile": {
+      "Add Comparison": "Add Comparison",
       "Data Appendix": "Data Appendix",
       "Data Appendix Description": "These data tables represent the underlying datasets used to power each visualization featured in this report.",
       "Download Page as PDF": "Download Page as PDF",
       "image credits": "image credits",
-      "Photograph by": "Photograph by"
+      "Photograph by": "Photograph by",
+      "Remove Comparison": "Remove Comparison"
     },
     "Search": {
       "All": "All",


### PR DESCRIPTION
This PR adds **side-by-side comparisons** for unilateral profiles, presenting the user with an "Add Comparison" button underneath the Hero title/subtitle when `CANON_CONST_PROFILE_COMPARISON` is set to `true`:

<img width="1208" alt="Screen Shot 2022-03-22 at 3 54 39 PM" src="https://user-images.githubusercontent.com/1847581/159576968-6ad5319c-80f5-4b70-879c-3997314b137f.png">

Clicking this button opens an instance of `ProfileSearch`, faceted to show only members belonging to the currently viewed profile:

<img width="1208" alt="Screen Shot 2022-03-22 at 3 54 45 PM" src="https://user-images.githubusercontent.com/1847581/159577067-86f9ef01-10a2-4b7d-88b4-29db1ee36d8c.png">

Clicking on any of these results will cause the following chain of actions:
- the default `Loading` component is shown
- the secondary comparison profile contents are fetched from the same API used for the initial profile
- the comparison contents are folded in alongside each of the current profile's sections, converting each matched set of sections into a grouped pair of `Column`-type sections.
- a "Remove Comparison" button is attached, fixed, to the bottom of the screen
- `?compare=<compareSlug>` is added to the URL

<img width="1208" alt="Screen Shot 2022-03-22 at 3 54 52 PM" src="https://user-images.githubusercontent.com/1847581/159577709-d2378a9f-5099-4ead-bcdb-ea4cb5973540.png">

I had to touch a few extra things to get my new "compare" query arg to play nice with the current selector logic for query args, but in the process I believe I have made the initial fetching of query args more reliable, and it all plays pretty nicely in comparison mode (changing any selector changes _both_ profile instances at the same time):

<img width="1208" alt="Screen Shot 2022-03-22 at 3 55 10 PM" src="https://user-images.githubusercontent.com/1847581/159577963-abe37349-791a-4c33-9841-22c0c15f3417.png">

This will need both a `canon-cms` release and a `canon-core` release, as the new translation strings need to be published via `canon-core`.

## Full Changelist
- passes router via props to ProfileRenderer for usage in constructor 
- adds CANON_CONST_PROFILE_COMPARISON to docs 
- fixes non-anchor link ProfileSearch list font color 
- modifies Selector to use global comparator defaults 
- adds hideTitleSearch, hidePDF, and comparisonButton props to Hero 
- adds flex stretch to Hero 
- implements comparisons in ProfileRenderer 
- adds new `"CMS.Profile.Add Comparison"` and `"CMS.Profile.Remove Comparison"` i18n strings

Closes #1350 