### PR TITLE
profile comparison hotfixes

### DIFF
--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -353,7 +353,9 @@ class ProfileRenderer extends Component {
 
           // add member names to each section title to help
           // differentiate the two comparitors
-          title: rawSection.title.replace(/\<\/p\>$/g, ` - ${payload.variables.name}</p>`),
+          title: rawSection.title.includes(payload.variables.name)
+            ? rawSection.title
+            : rawSection.title.replace(/\<\/p\>$/g, ` - ${payload.variables.name}</p>`),
 
           // force all sections to use "SingleColumn" layout for split-screen
           type: "SingleColumn"

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -366,26 +366,23 @@ class ProfileRenderer extends Component {
         // as in the case of the "SingleColumn" layout. this reducer pairs up every base
         // profile section with it's comparitor section (if available) so that they are
         // rendered side-by-side
-        groupedSections = [sections.reduce((arr, rawSection) => {
+        groupedSections = sections.reduce((arr, rawSection) => {
 
-          const section = comparifySection(rawSection, profile);
-
-          const comp = comparison.sections.find(s => s.id === section.id);
+          const comp = comparison.sections.find(s => s.id === rawSection.id);
           if (comp) {
 
+            const section = comparifySection(rawSection, profile);
             const newComp = comparifySection(comp, comparison);
             comparisonSections.push([[section, newComp]]);
 
-          }
-          else {
-            comparisonSections.push([[section]]);
-          }
+            if (arr.length === 0 || rawSection.type === "Grouping") arr.push([[rawSection]]);
+            else arr[arr.length - 1].push([rawSection]);
 
-          arr.push([rawSection]);
+          }
 
           return arr;
 
-        }, [])];
+        }, []);
 
       }
       else {

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -366,23 +366,25 @@ class ProfileRenderer extends Component {
         // as in the case of the "SingleColumn" layout. this reducer pairs up every base
         // profile section with it's comparitor section (if available) so that they are
         // rendered side-by-side
-        groupedSections = sections.reduce((arr, rawSection) => {
+        groupedSections = sections
+          .reduce((arr, rawSection) => {
 
-          const comp = comparison.sections.find(s => s.id === rawSection.id);
-          if (comp) {
+            const comp = comparison.sections.find(s => s.id === rawSection.id);
+            if (comp) {
 
-            const section = comparifySection(rawSection, profile);
-            const newComp = comparifySection(comp, comparison);
-            comparisonSections.push([[section, newComp]]);
+              const section = comparifySection(rawSection, profile);
+              const newComp = comparifySection(comp, comparison);
+              comparisonSections.push([[section, newComp]]);
 
-            if (arr.length === 0 || rawSection.type === "Grouping") arr.push([[rawSection]]);
-            else arr[arr.length - 1].push([rawSection]);
+              if (arr.length === 0 || rawSection.type === "Grouping") arr.push([[rawSection]]);
+              else arr[arr.length - 1].push([rawSection]);
 
-          }
+            }
 
-          return arr;
+            return arr;
 
-        }, []);
+          }, [])
+          .filter(arr => arr.length > 1 || arr[0][0].type !== "Grouping");
 
       }
       else {

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -284,34 +284,36 @@ class ProfileRenderer extends Component {
     // The "Add Comparison" search button that gets added to the Hero section
     // if comparisons are enabled, the profile is not bi-lateral, and there
     // is currently no comparitor.
-    const comparisonButton = comparisonsEnabled && profile.dims.length === 1 && !comparison ? <div>
-      { comparisonSearch ? <div className="cp-comparison-search-container"
-        style={{
-          display: "inline-block",
-          marginRight: 10,
-          maxWidth: 300
-        }}>
-        <ProfileSearch
-          defaultProfiles={`${profile.id}`}
-          filters={false}
-          inputFontSize="md"
-          display="list"
-          position="absolute"
-          renderListItem={(result, i, link, title, subtitle) =>
-            <li key={`r-${i}`} className="cms-profilesearch-list-item">
-              <span onClick={this.addComparison.bind(this, result[0].memberSlug)} className="cms-profilesearch-list-item-link">
-                {title}
-                <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
-              </span>
-            </li>
-          }
-          showExamples={true}
-          {...searchProps} />
-      </div> : null }
-      <Button icon={comparisonSearch ? "cross" : "comparison"} onClick={this.toggleComparisonSearch.bind(this)}>
-        {comparisonSearch ? null : t("CMS.Profile.Add Comparison")}
-      </Button>
-    </div> : null;
+    const comparisonButton = comparisonsEnabled && profile.dims.length === 1 && !comparison
+      ? <div className="cp-comparison-add">
+        { comparisonSearch ? <div className="cp-comparison-search-container"
+          style={{
+            display: "inline-block",
+            marginRight: 10,
+            maxWidth: 300
+          }}>
+          <ProfileSearch
+            defaultProfiles={`${profile.id}`}
+            filters={false}
+            inputFontSize="md"
+            display="list"
+            position="absolute"
+            renderListItem={(result, i, link, title, subtitle) =>
+              <li key={`r-${i}`} className="cms-profilesearch-list-item">
+                <span onClick={this.addComparison.bind(this, result[0].memberSlug)} className="cms-profilesearch-list-item-link">
+                  {title}
+                  <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
+                </span>
+              </li>
+            }
+            showExamples={true}
+            {...searchProps} />
+        </div> : null }
+        <Button icon={comparisonSearch ? "cross" : "comparison"} onClick={this.toggleComparisonSearch.bind(this)}>
+          {comparisonSearch ? null : t("CMS.Profile.Add Comparison")}
+        </Button>
+      </div>
+      : null;
 
     let {sections} = profile;
     // Find the first instance of a Hero section (excludes all following instances)

--- a/packages/cms/src/components/ProfileRenderer.jsx
+++ b/packages/cms/src/components/ProfileRenderer.jsx
@@ -299,12 +299,14 @@ class ProfileRenderer extends Component {
             display="list"
             position="absolute"
             renderListItem={(result, i, link, title, subtitle) =>
-              <li key={`r-${i}`} className="cms-profilesearch-list-item">
-                <span onClick={this.addComparison.bind(this, result[0].memberSlug)} className="cms-profilesearch-list-item-link">
-                  {title}
-                  <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
-                </span>
-              </li>
+              result[0].id === profile.variables.id
+                ? null
+                : <li key={`r-${i}`} className="cms-profilesearch-list-item">
+                  <span onClick={this.addComparison.bind(this, result[0].memberSlug)} className="cms-profilesearch-list-item-link">
+                    {title}
+                    <div className="cms-profilesearch-list-item-sub u-font-xs">{subtitle}</div>
+                  </span>
+                </li>
             }
             showExamples={true}
             {...searchProps} />

--- a/packages/cms/src/components/sections/Hero.jsx
+++ b/packages/cms/src/components/sections/Hero.jsx
@@ -162,6 +162,7 @@ class Hero extends Component {
         {title}
       </Parse>
       {subtitleContent}
+      {comparisonButton}
     </div>;
 
     // custom images can be uploaded with no flickr source. Only show the "image credits" section
@@ -175,7 +176,6 @@ class Hero extends Component {
           {/* caption */}
           <div className="cp-section-content cp-hero-caption">
             {heading}
-            {comparisonButton}
             {statContent}
             {paragraphs}
             {sourceContent}


### PR DESCRIPTION
 - only suffixes comparator name to section titles if it does not already exist in the title
 - fixes nested SubNav in comparisons
 - hides sections when one of the comparators does not exist
 - filters out sections with only their Grouping in comparison mode
 - adds className to comparison button
 - moves comparison button into cp-hero-heading-wrapper
 - hides current profile from comparison search