### PR TITLE
Sanitize LUNR search terms

### DIFF
--- a/packages/cms/src/api/searchRoute.js
+++ b/packages/cms/src/api/searchRoute.js
@@ -580,7 +580,14 @@ module.exports = function(app) {
         const {searchIndexByLocale} = app.settings.cache;
 
         if (useLUNR && searchIndexByLocale[locale]) {
-          const terms = query.split(" ").map(d => `+${d}~1*`).join(" ");
+          const terms = query
+            .replace(/[\+\-\~\*\:\^]/g, ' ') //Remove special characters that are reserved by Lunr https://lunrjs.com/guides/searching.html
+            .split(" ") //Split into individual terms
+            .filter(d => d.trim() !== '') //Remove empty trimmed terms
+            .map(d => `+${d}~1*`) //Add wildcard to each term
+            .join(" "); //Join back into a single string
+
+          // Perform the search using lunr index
           const lunrResults = searchIndexByLocale[locale].search(terms);
           contentIds = lunrResults.map(d => d.ref);
         }


### PR DESCRIPTION
Remove Lunr reserved chars from query.

Related with :
- https://github.com/Datawheel/canon/issues/1368
- https://github.com/Datawheel/sebrae-site/issues/136

The search below becomes `+cars~1* +large~1* +sized~1*`. A valid lunr search term.
<img width="895" alt="Screen Shot 2022-07-13 at 17 24 44" src="https://user-images.githubusercontent.com/1203432/178828114-794bc5e9-9a99-4f00-acb5-afd43c0c5815.png">

