### PR TITLE
[core] adds express handlers and examples for socketio integrations

### DIFF
--- a/examples/api/socketRoute.js
+++ b/examples/api/socketRoute.js
@@ -1,0 +1,27 @@
+module.exports = function(app) {
+
+  app.post("/api/sockets", async(req, res) => {
+
+    // retrieve client sessionId from POST body
+    const {sessionId} = req.body;
+
+    // find socket corresponding to client sessionId
+    const sockets = app.get("sockets");
+    const io = app.get("io");
+    const socket = io.to(sockets[sessionId]);
+
+    // emit initial "zero-state" progress
+    const total = 100;
+    socket.emit("progress", {progress: 0, total});
+
+    // create a dummy "progress" emit every 1 second until finished
+    for (let i = 0; i <= total; i += 10) {
+      setTimeout(() => {
+        socket.emit("progress", {progress: i, total});
+        if (i === total) res.json(true).end();
+      }, i * 100);
+    }
+
+  });
+
+};

--- a/examples/app/pages/Docs.jsx
+++ b/examples/app/pages/Docs.jsx
@@ -26,6 +26,7 @@ import FetchData from "./core/FetchData";
 import LazyLoadImage from "./core/LazyLoadImage";
 import LazyLoadImageDemo from "./core/LazyLoadImageDemo";
 import Links from "./core/Links";
+import Socket from "./core/Socket";
 
 // CMS
 import IntroCms from "./cms/Intro";
@@ -59,7 +60,8 @@ const PACKAGES = [
       {title: "FetchData", component: FetchData},
       {title: "Lazy Load Images", component: LazyLoadImage},
       {title: "Lazy Load Images DEMO", component: LazyLoadImageDemo},
-      {title: "Links", component: Links}
+      {title: "Links", component: Links},
+      {title: "Web Sockets", component: Socket}
     ]
   },
   {

--- a/examples/app/pages/core/Socket.jsx
+++ b/examples/app/pages/core/Socket.jsx
@@ -1,0 +1,62 @@
+import React, {useState} from "react";
+import {io} from "socket.io-client";
+import {uuid} from "d3plus-common";
+import axios from "axios";
+import {Button, Spinner} from "@blueprintjs/core";
+
+const Socket = () => {
+
+  const [progress, setProgress] = useState(false);
+
+  const onLoad = () => {
+
+    setProgress(false);
+
+    // creates a new socket connection with itself (origin)
+    const socket = io();
+
+    // create and emit a unique sessionId
+    const sessionId = uuid();
+    socket.emit("init", sessionId);
+
+    // on "progress" events, set returned data to progress state
+    socket.on("progress", setProgress);
+
+    // once the handshake "init" has been received, request data
+    socket.on("init", () => {
+
+      axios.post("/api/sockets", {sessionId})
+        .then(() => {
+          // when data has finished, clear progress and disconenct socket
+          setProgress(false);
+          socket.disconnect();
+        });
+
+    });
+
+  };
+
+  return (
+    <div id="sockets">
+      <Button
+        icon={
+          progress
+            ? <Spinner
+              size={16}
+              value={
+                progress.progress && progress.total
+                  ? progress.progress / progress.total
+                  : undefined
+              } />
+            : "download"
+        }
+        disabled={progress}
+        onClick={onLoad}
+      >
+        Click to Test Socket Progress
+      </Button>
+    </div>
+  );
+};
+
+export default Socket;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -144,6 +144,8 @@
     "redux-thunk": "^2.0.1",
     "sequelize": "^4.13.10",
     "shelljs": "^0.8.3",
+    "socket.io": "^4.5.4",
+    "socket.io-client": "^4.5.4",
     "terser-webpack-plugin": "^4.2.3",
     "url-loader": "^2.1.0",
     "urllite": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
     dependencies:
       '@datawheel/canon-cms': link:../packages/cms
       '@datawheel/canon-core': link:../packages/core
-      '@datawheel/canon-logiclayer': 0.5.1_react@16.14.0
+      '@datawheel/canon-logiclayer': link:../packages/logiclayer
       axios: 0.21.1
       d3plus-react: 1.0.0_prop-types@15.7.2+react@16.14.0
       d3plus-text: 1.0.1
@@ -261,6 +261,8 @@ importers:
       redux-thunk: ^2.0.1
       sequelize: ^4.13.10
       shelljs: ^0.8.3
+      socket.io: ^4.5.4
+      socket.io-client: ^4.5.4
       terser-webpack-plugin: ^4.2.3
       url-loader: ^2.1.0
       urllite: ^0.5.0
@@ -387,6 +389,8 @@ importers:
       redux-thunk: 2.3.0
       sequelize: 4.44.4
       shelljs: 0.8.4
+      socket.io: 4.5.4
+      socket.io-client: 4.5.4
       terser-webpack-plugin: 4.2.3_webpack@4.44.2
       url-loader: 2.3.0_file-loader@4.3.0+webpack@4.44.2
       urllite: 0.5.0
@@ -1681,7 +1685,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.12.13
       '@babel/parser': 7.12.14
       '@babel/types': 7.12.13
-      debug: 4.3.1
+      debug: 4.3.4
       globals: 11.12.0
       lodash: 4.17.20
     transitivePeerDependencies:
@@ -1785,28 +1789,6 @@ packages:
       tslib: 1.13.0
     dev: false
 
-  /@blueprintjs/core/3.51.3_react@16.14.0:
-    resolution: {integrity: sha512-Z3xGWBMBuboKFx19uxWNAUjITsCmpm+594R/KEAM578uT6yoydT6s5S7N12APAsFe8w3H1Yu2hbWHlHTvRfOhA==}
-    hasBin: true
-    peerDependencies:
-      react: ^15.3.0 || 16 || 17
-      react-dom: ^15.3.0 || 16 || 17
-    dependencies:
-      '@blueprintjs/colors': 4.0.0-alpha.1
-      '@blueprintjs/icons': 3.31.0
-      '@types/dom4': 2.0.2
-      classnames: 2.3.1
-      dom4: 2.1.6
-      normalize.css: 8.0.1
-      popper.js: 1.16.1
-      react: 16.14.0
-      react-lifecycles-compat: 3.0.4
-      react-popper: 1.3.11_react@16.14.0
-      react-transition-group: 2.9.0_react@16.14.0
-      resize-observer-polyfill: 1.5.1
-      tslib: 1.13.0
-    dev: false
-
   /@blueprintjs/datetime/3.23.4:
     resolution: {integrity: sha512-tC0DH6jKMLdZjXlAH7UoP3gzTjCm8iYKGY9jMyqPqTj869AJHnqW5NlCZKp+xMiy6FJ53oJjjKdhw6l5p46BZA==}
     peerDependencies:
@@ -1868,26 +1850,6 @@ packages:
   /@csstools/convert-colors/1.4.0:
     resolution: {integrity: sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==}
     engines: {node: '>=4.0.0'}
-    dev: false
-
-  /@datawheel/canon-logiclayer/0.5.1_react@16.14.0:
-    resolution: {integrity: sha512-uRon8X3oqbMlIJZlT42LA4LflQHGLcKQSN9p6MMFCLZzeWBdCkIIswJbO0M381FlDl0rNF9sQ1RGe+D2/zBbUw==}
-    peerDependencies:
-      '@datawheel/canon-core': ^0.21.0
-    dependencies:
-      '@blueprintjs/core': 3.51.3_react@16.14.0
-      axios: 0.21.1
-      d3-array: 2.11.0
-      d3-collection: 1.0.7
-      d3plus-common: 1.0.4
-      mondrian-rest-client: 1.1.4
-      promise-throttle: 1.1.2
-      sequelize: 4.44.4
-      yn: 4.0.0
-    transitivePeerDependencies:
-      - debug
-      - react
-      - react-dom
     dev: false
 
   /@datawheel/olap-client/2.0.0-beta.2:
@@ -2036,18 +1998,6 @@ packages:
       gud: 1.0.0
       prop-types: 15.7.2
       react: 16.13.1
-      warning: 4.0.3
-    dev: false
-
-  /@hypnosphi/create-react-context/0.3.1_prop-types@15.7.2+react@16.14.0:
-    resolution: {integrity: sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==}
-    peerDependencies:
-      prop-types: ^15.0.0
-      react: '>=0.14.0'
-    dependencies:
-      gud: 1.0.0
-      prop-types: 15.7.2
-      react: 16.14.0
       warning: 4.0.3
     dev: false
 
@@ -2358,6 +2308,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /@socket.io/component-emitter/3.1.0:
+    resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
+    dev: false
+
   /@szmarczak/http-timer/1.1.2:
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
     engines: {node: '>=6'}
@@ -2372,6 +2326,16 @@ packages:
 
   /@types/clipboard/2.0.1:
     resolution: {integrity: sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==}
+    dev: false
+
+  /@types/cookie/0.4.1:
+    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+    dev: false
+
+  /@types/cors/2.8.13:
+    resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
+    dependencies:
+      '@types/node': 14.14.41
     dev: false
 
   /@types/dom4/2.0.1:
@@ -3257,6 +3221,11 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /base64id/2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
     dev: false
 
   /base64url/3.0.1:
@@ -4188,6 +4157,11 @@ packages:
 
   /cookie/0.4.0:
     resolution: {integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie/0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -5673,6 +5647,45 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+
+  /engine.io-client/6.2.3:
+    resolution: {integrity: sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+      engine.io-parser: 5.0.4
+      ws: 8.2.3
+      xmlhttprequest-ssl: 2.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /engine.io-parser/5.0.4:
+    resolution: {integrity: sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==}
+    engines: {node: '>=10.0.0'}
+    dev: false
+
+  /engine.io/6.2.1:
+    resolution: {integrity: sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@types/cookie': 0.4.1
+      '@types/cors': 2.8.13
+      '@types/node': 14.14.41
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.4.2
+      cors: 2.8.5
+      debug: 4.3.4
+      engine.io-parser: 5.0.4
+      ws: 8.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
 
   /enhanced-resolve/4.5.0:
     resolution: {integrity: sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==}
@@ -8061,7 +8074,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 14.14.25
+      '@types/node': 14.14.41
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -11250,21 +11263,6 @@ packages:
       warning: 4.0.3
     dev: false
 
-  /react-popper/1.3.11_react@16.14.0:
-    resolution: {integrity: sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==}
-    peerDependencies:
-      react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@babel/runtime': 7.15.4
-      '@hypnosphi/create-react-context': 0.3.1_prop-types@15.7.2+react@16.14.0
-      deep-equal: 1.1.1
-      popper.js: 1.16.1
-      prop-types: 15.7.2
-      react: 16.14.0
-      typed-styles: 0.0.7
-      warning: 4.0.3
-    dev: false
-
   /react-popper/1.3.7_react@16.14.0:
     resolution: {integrity: sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==}
     peerDependencies:
@@ -11400,19 +11398,6 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       react-lifecycles-compat: 3.0.4
     dev: true
-
-  /react-transition-group/2.9.0_react@16.14.0:
-    resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
-    peerDependencies:
-      react: '>=15.0.0'
-      react-dom: '>=15.0.0'
-    dependencies:
-      dom-helpers: 3.4.0
-      loose-envify: 1.4.0
-      prop-types: 15.7.2
-      react: 16.14.0
-      react-lifecycles-compat: 3.0.4
-    dev: false
 
   /react-viewport-list/1.3.3_react@16.14.0:
     resolution: {integrity: sha512-AYe9jnCduMqkv5LiG5z4kF3QiIxQitBqtyBd2ZeOBPVwtBdxKHBF+ivmW2inlF8bEBCXb32z6pvnBkR1aGPkfw==}
@@ -12242,6 +12227,50 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
+    dev: false
+
+  /socket.io-adapter/2.4.0:
+    resolution: {integrity: sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==}
+    dev: false
+
+  /socket.io-client/4.5.4:
+    resolution: {integrity: sha512-ZpKteoA06RzkD32IbqILZ+Cnst4xewU7ZYK12aS1mzHftFFjpoMz69IuhP/nL25pJfao/amoPI527KnuhFm01g==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+      engine.io-client: 6.2.3
+      socket.io-parser: 4.2.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /socket.io-parser/4.2.1:
+    resolution: {integrity: sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /socket.io/4.5.4:
+    resolution: {integrity: sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      debug: 4.3.4
+      engine.io: 6.2.1
+      socket.io-adapter: 2.4.0
+      socket.io-parser: 4.2.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: false
 
   /socks-proxy-agent/2.1.1:
@@ -13786,6 +13815,19 @@ packages:
         optional: true
     dev: false
 
+  /ws/8.2.3:
+    resolution: {integrity: sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /x-xss-protection/1.3.0:
     resolution: {integrity: sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg==}
     engines: {node: '>=4.0.0'}
@@ -13829,6 +13871,11 @@ packages:
     resolution: {integrity: sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==}
     engines: {node: '>=0.1'}
     deprecated: Deprecated due to CVE-2021-21366 resolved in 0.5.0
+    dev: false
+
+  /xmlhttprequest-ssl/2.0.0:
+    resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
+    engines: {node: '>=0.4.0'}
     dev: false
 
   /xmlhttprequest/1.8.0:


### PR DESCRIPTION
The core change here is in `packages/core/bin/server/steps/router.js`, where I have added a Socket.IO wrapper to extend the internal Express router to accept Socket connections. This allows for API endpoints to send progress to the browser, allowing for indicators such as this new example:

https://user-images.githubusercontent.com/1847581/207712880-d7ba394d-304b-45fc-8d51-b2a2e2650682.mov

