### PR TITLE
Fixes/canon next@0.2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,21 +970,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@mantine/prism": {
-      "version": "5.10.4",
-      "resolved": "https://registry.npmjs.org/@mantine/prism/-/prism-5.10.4.tgz",
-      "integrity": "sha512-5JMFTj7JNvhCQmV75/TmUGOyxHS3zxadr1+273CSOj3gsZK0jfh3FwoAsMG3ziWy8vCEDPEGvHmhlzLOfiREAQ==",
-      "dependencies": {
-        "@mantine/utils": "5.10.4",
-        "prism-react-renderer": "^1.2.1"
-      },
-      "peerDependencies": {
-        "@mantine/core": "5.10.4",
-        "@mantine/hooks": "5.10.4",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@mantine/ssr": {
       "version": "5.10.4",
       "resolved": "https://registry.npmjs.org/@mantine/ssr/-/ssr-5.10.4.tgz",
@@ -3316,6 +3301,11 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4557,6 +4547,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -4984,6 +4982,14 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -5590,16 +5596,6 @@
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/mantine-datatable": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/mantine-datatable/-/mantine-datatable-1.8.6.tgz",
-      "integrity": "sha512-d+0xdN7rRVFln/EqekO71L22oFpSl2KJ/YNFh+isvKr9QrjDLPH0IKPn0FGnSMFTONfK6bNIRjUNSKMSDgbQ7w==",
-      "peerDependencies": {
-        "@mantine/core": "^5.10.4",
-        "@mantine/hooks": "^5.10.4",
-        "react": "^18.2.0"
       }
     },
     "node_modules/merge-stream": {
@@ -6388,6 +6384,73 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-textarea-autosize": {
       "version": "8.3.4",
@@ -7603,6 +7666,26 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -7632,6 +7715,27 @@
         "use-isomorphic-layout-effect": "^1.1.1"
       },
       "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
@@ -7843,12 +7947,12 @@
     },
     "packages/next": {
       "name": "@datawheel/canon-next",
-      "version": "0.1.7",
+      "version": "0.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@mantine/core": "^5.6.3",
-        "@mantine/hooks": "^5.10.4",
-        "@mantine/prism": "^5.10.4",
+        "@mantine/core": "^6.0.13",
+        "@mantine/hooks": "^6.0.13",
+        "@mantine/prism": "^6.0.13",
         "@tabler/icons-react": "^2.4.0",
         "axios": "^1.3.3",
         "buble": "^0.20.0",
@@ -7859,7 +7963,7 @@
         "d3plus-text": "^1.2.1",
         "d3plus-viz": "^1.3.0",
         "jszip": "^3.10.1",
-        "mantine-datatable": "^1.8.6",
+        "mantine-datatable": "^2.5.4",
         "next-i18next": "^13.1.5",
         "react": "^18.0.2",
         "react-inlinesvg": "^3.0.1",
@@ -7874,6 +7978,88 @@
       },
       "peerDependencies": {
         "next": "^13.1.6"
+      }
+    },
+    "packages/next/node_modules/@mantine/core": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-6.0.13.tgz",
+      "integrity": "sha512-FjVUGgat2qISV9WD1maVJa81y7H0JjKJ3m0cJj65PzgrXT20hzdEda7S3i4j+a8vUnx+836x5q/yS+RDHvoSlA==",
+      "dependencies": {
+        "@floating-ui/react": "^0.19.1",
+        "@mantine/styles": "6.0.13",
+        "@mantine/utils": "6.0.13",
+        "@radix-ui/react-scroll-area": "1.0.2",
+        "react-remove-scroll": "^2.5.5",
+        "react-textarea-autosize": "8.3.4"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "6.0.13",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "packages/next/node_modules/@mantine/hooks": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.13.tgz",
+      "integrity": "sha512-fHuE3zXo5OP/Q1dMOTnegU6U+tI9GuhO2tgOz6szVuOxrrk0Hzuq1Na9NUSv27HShSRbAfQk+hvyIh+iVV7KXA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "packages/next/node_modules/@mantine/prism": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@mantine/prism/-/prism-6.0.13.tgz",
+      "integrity": "sha512-048dxoEw4XeJAVh8sBzMguhk+pG8ULDPVGI+aQBsuoERezSV4WVqeKl1+ddoOew3qXbsH/UH4ox5lmf1S4WTwg==",
+      "dependencies": {
+        "@mantine/utils": "6.0.13",
+        "prism-react-renderer": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@mantine/core": "6.0.13",
+        "@mantine/hooks": "6.0.13",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "packages/next/node_modules/@mantine/styles": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-6.0.13.tgz",
+      "integrity": "sha512-+27oX8ObiBv8jHHDxXKjqe+7cfTJyaAV/Ie00T49EE4LuHuS6nL4vlXHmqamFtDCj2ypEWBV0sdXDev/DNAXSg==",
+      "dependencies": {
+        "clsx": "1.1.1",
+        "csstype": "3.0.9"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">=11.9.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "packages/next/node_modules/@mantine/utils": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.13.tgz",
+      "integrity": "sha512-iqIU9wurqAeccVbWjM0yr1JGne5VP+ob55M03QAXOEN4+ck93VDTjCkZJR2RFhDcs5q0twQFoOmU/gULR8aKIA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "packages/next/node_modules/csstype": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+    },
+    "packages/next/node_modules/mantine-datatable": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/mantine-datatable/-/mantine-datatable-2.5.4.tgz",
+      "integrity": "sha512-Sbc3/vNMuG1nwXSNMG3gxBMykuthVf75A5pYWT6T+Jjt5bsFpqfci3oJ4SSSdqzF0fNvaLqCcfdMa/soQjFJFw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/icflorescu"
+      },
+      "peerDependencies": {
+        "@mantine/core": "^6.0.13",
+        "@mantine/hooks": "^6.0.13",
+        "react": "^18.2.0"
       }
     }
   },
@@ -8065,9 +8251,9 @@
     "@datawheel/canon-next": {
       "version": "file:packages/next",
       "requires": {
-        "@mantine/core": "^5.6.3",
-        "@mantine/hooks": "^5.10.4",
-        "@mantine/prism": "^5.10.4",
+        "@mantine/core": "^6.0.13",
+        "@mantine/hooks": "^6.0.13",
+        "@mantine/prism": "^6.0.13",
         "@tabler/icons-react": "^2.4.0",
         "axios": "^1.3.3",
         "buble": "^0.20.0",
@@ -8078,13 +8264,69 @@
         "d3plus-text": "^1.2.1",
         "d3plus-viz": "^1.3.0",
         "jszip": "^3.10.1",
-        "mantine-datatable": "^1.8.6",
+        "mantine-datatable": "^2.5.4",
         "next-i18next": "^13.1.5",
         "react": "^18.0.2",
         "react-inlinesvg": "^3.0.1",
         "tsup": "^6.6.3",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz",
-        "yn": "*"
+        "yn": "^5.0.0"
+      },
+      "dependencies": {
+        "@mantine/core": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/@mantine/core/-/core-6.0.13.tgz",
+          "integrity": "sha512-FjVUGgat2qISV9WD1maVJa81y7H0JjKJ3m0cJj65PzgrXT20hzdEda7S3i4j+a8vUnx+836x5q/yS+RDHvoSlA==",
+          "requires": {
+            "@floating-ui/react": "^0.19.1",
+            "@mantine/styles": "6.0.13",
+            "@mantine/utils": "6.0.13",
+            "@radix-ui/react-scroll-area": "1.0.2",
+            "react-remove-scroll": "^2.5.5",
+            "react-textarea-autosize": "8.3.4"
+          }
+        },
+        "@mantine/hooks": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.13.tgz",
+          "integrity": "sha512-fHuE3zXo5OP/Q1dMOTnegU6U+tI9GuhO2tgOz6szVuOxrrk0Hzuq1Na9NUSv27HShSRbAfQk+hvyIh+iVV7KXA==",
+          "requires": {}
+        },
+        "@mantine/prism": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/@mantine/prism/-/prism-6.0.13.tgz",
+          "integrity": "sha512-048dxoEw4XeJAVh8sBzMguhk+pG8ULDPVGI+aQBsuoERezSV4WVqeKl1+ddoOew3qXbsH/UH4ox5lmf1S4WTwg==",
+          "requires": {
+            "@mantine/utils": "6.0.13",
+            "prism-react-renderer": "^1.2.1"
+          }
+        },
+        "@mantine/styles": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-6.0.13.tgz",
+          "integrity": "sha512-+27oX8ObiBv8jHHDxXKjqe+7cfTJyaAV/Ie00T49EE4LuHuS6nL4vlXHmqamFtDCj2ypEWBV0sdXDev/DNAXSg==",
+          "requires": {
+            "clsx": "1.1.1",
+            "csstype": "3.0.9"
+          }
+        },
+        "@mantine/utils": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.13.tgz",
+          "integrity": "sha512-iqIU9wurqAeccVbWjM0yr1JGne5VP+ob55M03QAXOEN4+ck93VDTjCkZJR2RFhDcs5q0twQFoOmU/gULR8aKIA==",
+          "requires": {}
+        },
+        "csstype": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+          "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+        },
+        "mantine-datatable": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/mantine-datatable/-/mantine-datatable-2.5.4.tgz",
+          "integrity": "sha512-Sbc3/vNMuG1nwXSNMG3gxBMykuthVf75A5pYWT6T+Jjt5bsFpqfci3oJ4SSSdqzF0fNvaLqCcfdMa/soQjFJFw==",
+          "requires": {}
+        }
       }
     },
     "@emotion/babel-plugin": {
@@ -8449,15 +8691,6 @@
       "requires": {
         "@mantine/ssr": "5.10.4",
         "@mantine/styles": "5.10.4"
-      }
-    },
-    "@mantine/prism": {
-      "version": "5.10.4",
-      "resolved": "https://registry.npmjs.org/@mantine/prism/-/prism-5.10.4.tgz",
-      "integrity": "sha512-5JMFTj7JNvhCQmV75/TmUGOyxHS3zxadr1+273CSOj3gsZK0jfh3FwoAsMG3ziWy8vCEDPEGvHmhlzLOfiREAQ==",
-      "requires": {
-        "@mantine/utils": "5.10.4",
-        "prism-react-renderer": "^1.2.1"
       }
     },
     "@mantine/ssr": {
@@ -10259,6 +10492,11 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -11263,6 +11501,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -11562,6 +11805,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "is-arguments": {
       "version": "1.1.1",
@@ -11995,12 +12246,6 @@
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
-    },
-    "mantine-datatable": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/mantine-datatable/-/mantine-datatable-1.8.6.tgz",
-      "integrity": "sha512-d+0xdN7rRVFln/EqekO71L22oFpSl2KJ/YNFh+isvKr9QrjDLPH0IKPn0FGnSMFTONfK6bNIRjUNSKMSDgbQ7w==",
-      "requires": {}
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -12508,6 +12753,37 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
+    "react-remove-scroll": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "requires": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      }
     },
     "react-textarea-autosize": {
       "version": "8.3.4",
@@ -13376,6 +13652,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -13394,6 +13678,15 @@
       "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.1"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
       }
     },
     "util-deprecate": {

--- a/packages/next/cms/components/Viz/Graphic.js
+++ b/packages/next/cms/components/Viz/Graphic.js
@@ -1,0 +1,25 @@
+import React from "react";
+import {Group} from "@mantine/core";
+
+import Stat from "../sections/components/Stat";
+
+/** */
+export default function Graphic({config}) {
+  return (
+    <Group className="cp-graphic">
+      {config.imageURL &&
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={config.imageURL} className="cp-graphic-img" alt="" />
+      }
+      {
+        config.value &&
+        <Stat
+          className="cp-graphic-stat"
+          label={config.label}
+          value={config.value}
+          subtitle={config.subtitle}
+        />
+      }
+    </Group>
+  );
+}

--- a/packages/next/cms/components/Viz/Viz.js
+++ b/packages/next/cms/components/Viz/Viz.js
@@ -1,6 +1,6 @@
 /*
   TODO
-   - [ ] port Graphic/HTML/Table viz types
+   - [ ] port HTML/Table viz types
    - [ ] allow CustomVizzes
 */
 
@@ -16,11 +16,11 @@ import propify from "../../utils/d3plusPropify";
 import HTML from "./HTML";
 // User must define custom sections in app/cms/sections, and export them from an index.js in that folder.
 // import * as CustomVizzes from "CustomVizzes";
-// import Graphic from "./Graphic";
+import Graphic from "./Graphic";
 // import HTML from "./HTML";
 import Table from "./Table";
 // const vizTypes = {Table, Graphic, HTML, ...d3plus, ...CustomVizzes};
-const vizTypes = {HTML, Table, ...d3plus};
+const vizTypes = {HTML, Table, Graphic, ...d3plus};
 
 /**
  *

--- a/packages/next/cms/components/fields/ComparisonButton.js
+++ b/packages/next/cms/components/fields/ComparisonButton.js
@@ -38,7 +38,7 @@ const ComparisonButton = ({error = false}) => {
     : comparisonSearchHandlers.toggle;
 
   const label = compareSlug ? t("CMS.Profile.Remove Comparison") : t("CMS.Profile.Add Comparison");
-  return <div className="cp-comparison-add" style={{position: "relative"}}>
+  return <div className={compareSlug ? "cp-comparison-remove" : "cp-comparison-add"} style={{position: "relative"}}>
     {
       comparisonSearch &&
       <ProfileSearch

--- a/packages/next/cms/components/fields/ComparisonButton.js
+++ b/packages/next/cms/components/fields/ComparisonButton.js
@@ -1,8 +1,8 @@
 import React, {useContext} from "react";
-import {useRouter} from "next/router";
+import {useRouter} from "next/router.js";
 
 import {UnstyledButton, Button, Text} from "@mantine/core";
-import {useDisclosure} from "@mantine/hooks";
+import {useDisclosure, useClickOutside} from "@mantine/hooks";
 import {IconSquarePlus, IconSquareMinus} from "@tabler/icons-react";
 
 import ProfileContext from "../ProfileContext";
@@ -11,8 +11,9 @@ import {ProfileSearch} from "./ProfileSearch";
 const ComparisonButton = ({error = false}) => {
   const [comparisonSearch, comparisonSearchHandlers] = useDisclosure(false);
   const router = useRouter();
+  const ref = useClickOutside(() => comparisonSearchHandlers.close());
   const {pathname, query} = router;
-  const {t, variables, compareSlug, profileId} = useContext(ProfileContext);
+  const {t, variables, compareSlug, profileId, comparison} = useContext(ProfileContext);
 
   const addComparison = slug => router.replace(
     {pathname,
@@ -37,8 +38,8 @@ const ComparisonButton = ({error = false}) => {
     ? removeComparison
     : comparisonSearchHandlers.toggle;
 
-  const label = compareSlug ? t("CMS.Profile.Remove Comparison") : t("CMS.Profile.Add Comparison");
-  return <div className={compareSlug ? "cp-comparison-remove" : "cp-comparison-add"} style={{position: "relative"}}>
+  const label = comparison ? t("CMS.Profile.Remove Comparison") : t("CMS.Profile.Add Comparison");
+  return <div ref={ref} className={comparison ? "cp-comparison-remove" : "cp-comparison-add"} style={{position: "relative"}}>
     {
       comparisonSearch &&
       <ProfileSearch
@@ -65,7 +66,7 @@ const ComparisonButton = ({error = false}) => {
     <Button
       onClick={handleClick}
       className={`cp-comparison-button ${error && "cp-comparison-button-error"}`}
-      leftIcon={!compareSlug || error ? <IconSquarePlus size="0.8rem" /> : <IconSquareMinus size="0.8rem" />}
+      leftIcon={!comparison ? <IconSquarePlus size="0.8rem" /> : <IconSquareMinus size="0.8rem" />}
       size="xs"
       color={error ? "red" : "blue"}
       compact>{!error ?  label : t("CMS.Profile.Comparison Error")}</Button>

--- a/packages/next/cms/components/fields/ProfileSearch.js
+++ b/packages/next/cms/components/fields/ProfileSearch.js
@@ -28,6 +28,7 @@ import {IconSearch} from "@tabler/icons-react";
 import NonIdealState from "../../../core/components/NonIdealState";
 
 function DimensionFilters({
+  activeProfile,
   activeDimensions,
   filterHierarchyTitle,
   filterCubeTitle,
@@ -68,7 +69,9 @@ function DimensionFilters({
                   <Tabs.Tab
                     value={l}
                     key={l}
-                  >{filterTitle(l)}</Tabs.Tab>)
+                  >
+                    <Text dangerouslySetInnerHTML={{__html: filterTitle(l, activeProfile[0])}}/>
+                  </Tabs.Tab>)
               }
             </Tabs.List>;
           })}
@@ -424,6 +427,7 @@ export function ProfileSearch({
             activeDimensions &&
             activeDimensions.length > 0 &&
             <DimensionFilters
+              activeProfile={activeProfile}
               profiles={profiles}
               filters={filters}
               filterCubes={filterCubes}

--- a/packages/next/cms/components/fields/ProfileSearch.js
+++ b/packages/next/cms/components/fields/ProfileSearch.js
@@ -41,7 +41,7 @@ function DimensionFilters({
       return dimensionValue === value;
     });
     if (isDimension) {
-      onFilterLevel(false);
+      onFilterLevel("all");
     }
     else {
       onFilterLevel(value);
@@ -49,7 +49,7 @@ function DimensionFilters({
   };
   return (
     <div>
-      <Tabs className="cms-profilsearch-filters-dimensions" onTabChange={tabChangeHandler}>
+      <Tabs className="cms-profilesearch-filters-dimensions" onTabChange={tabChangeHandler}>
         {
           activeDimensions.map(d => {
             const dimensionValue = d.levels ? d.levels.join(",") : d.cubes.join(",");
@@ -98,6 +98,7 @@ function ProfileFilters({
   return (
 
     <Tabs
+      className="cms-profilesearch-filters-profiles"
       variant="pills"
       radius="sm"
       my={"xs"}
@@ -300,7 +301,7 @@ export function ProfileSearch({
 
   const onFilterLevel = useCallback(filters => {
     if (!profiles) return;
-    const newFilters = filters !== "all" ? filters.split(",") : [false];
+    const newFilters = filters !== "all" && filters ? filters.split(",") : [false];
 
     let newCubes = [];
     let newLevels = [];
@@ -339,7 +340,7 @@ export function ProfileSearch({
   }, [filterCubes, filterDimensionTitle, filterLevels, filterProfiles, profiles]);
 
 
-  useEffect(() => onFilterLevel(filterProfiles), [filterProfiles, onFilterLevel]);
+  useEffect(() => onFilterLevel(false), [filterProfiles]);
 
   let activeDimensions;
   if (activeProfile) {

--- a/packages/next/cms/components/fields/ProfileTile.js
+++ b/packages/next/cms/components/fields/ProfileTile.js
@@ -9,7 +9,7 @@ import {max} from "d3-array";
 /** Determines font-size based on title */
 function titleSize(title) {
   const {length} = title;
-  const longestWord = max(length ? title.match(/\w+/g).map(t => t.length) : 0);
+  const longestWord = max(length ? title.match(/[\u0621-\u064A\w]+/g).map(t => t.length) : 0);
   if (length > 30 || longestWord > 25) return "sm";
   if (length > 20 || longestWord > 15) return "md";
   return "lg";

--- a/packages/next/cms/components/sections/Hero.js
+++ b/packages/next/cms/components/sections/Hero.js
@@ -191,6 +191,7 @@ function Hero({
           {/* credits */}
           {type !== "story" && hasAuthor &&
             <Box
+              className="cp-image-credits-btn"
               style={{
                 zIndex: 8, position: "absolute", right: 10, top: 10
               }}
@@ -211,7 +212,7 @@ function Hero({
                   }
                 )}
               </Button>
-              <Collapse pos="absolute" in={creditsVisible}>
+              <Collapse className="cp-image-credits"  pos="absolute" in={creditsVisible}>
                 {profile.images.map((img, i) =>
                   <Paper key={JSON.stringify(img)} shadow="xs" p="xs" mt={5} radius={"sm"}>
                     <Text size="sm">

--- a/packages/next/cms/components/sections/Hero.js
+++ b/packages/next/cms/components/sections/Hero.js
@@ -292,7 +292,10 @@ function Hero({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...searchProps}
         modalProps={{
+          // overridable
           size: "80%",
+          ...searchProps?.modalProps || {},
+          // not-overridable
           className: "cp-hero-search",
           opened: clickedIndex !== undefined,
           onClose: () => setClickedIndex(undefined)

--- a/packages/next/cms/components/sections/Hero.js
+++ b/packages/next/cms/components/sections/Hero.js
@@ -284,9 +284,7 @@ function Hero({
       }
       <ProfileSearchModal
         defaultProfiles={`${profile.id}`}
-        defaultQuery={contents ? stripHTML(contents.title) : ""}
         filters
-        inputFontSize="lg"
         display="grid"
         showExamples
         linkify={linkify}

--- a/packages/next/cms/components/sections/MultiColumn.js
+++ b/packages/next/cms/components/sections/MultiColumn.js
@@ -21,8 +21,9 @@ export default function MultiColumn(
       <Box
         className="cp-section-content cp-multi-column-section-caption"
         sx={{
-          columnWidth: "600px",
-          gridColumnGap: 20
+          columnWidth: "20rem",
+          columnCount: 3,
+          columnFill: "balance"
         }}
       >
         {filters}

--- a/packages/next/cms/components/sections/components/SectionGrouping.js
+++ b/packages/next/cms/components/sections/components/SectionGrouping.js
@@ -16,6 +16,7 @@ export default function SectionGrouping({children, layout}) {
     <div className={`cp-section-grouping ${layoutClass}`}>
       <Group
         className={`cp-section-grouping-inner ${layoutClass}-inner`}
+        align="flex-start"
         spacing="xl"
         noWrap={!smallerThanMd}
         grow

--- a/packages/next/cms/components/sections/components/SectionGrouping.js
+++ b/packages/next/cms/components/sections/components/SectionGrouping.js
@@ -1,6 +1,7 @@
 import React from "react";
-import {Group} from "@mantine/core";
+import {Group, useMantineTheme} from "@mantine/core";
 import toKebabCase from "../../../utils/formatters/toKebabCase";
+import {useMediaQuery} from "@mantine/hooks";
 
 /**
  *
@@ -9,12 +10,14 @@ import toKebabCase from "../../../utils/formatters/toKebabCase";
  */
 export default function SectionGrouping({children, layout}) {
   const layoutClass = `cp-${toKebabCase(layout)}-section-grouping`;
-
+  const theme = useMantineTheme();
+  const smallerThanMd = useMediaQuery(`${theme.breakpoints.md}px`);
   return (
     <div className={`cp-section-grouping ${layoutClass}`}>
       <Group
         className={`cp-section-grouping-inner ${layoutClass}-inner`}
         spacing="xl"
+        noWrap={!smallerThanMd}
         grow
       >
         {children}

--- a/packages/next/cms/components/sections/components/Selector.js
+++ b/packages/next/cms/components/sections/components/Selector.js
@@ -86,9 +86,10 @@ export default function Selector(props) {
     // options under selectCutoff; button group
     if (options.length <= selectCutoff && options.every(b => stripHTML(b.label || variables[b.option]).length < 20)) {
       return (
-        <Stack>
-          <Text>{title}</Text>
+        <Stack className="cp-select" spacing={0}>
+          <Text className="cp-select-label">{title}</Text>
           <SegmentedControl
+            className="cp-select-control"
             defaultValue={activeValue}
             onChange={value => onSelector(name, value, isComparison)}
             data={options.map(o => ({value: o.option, label: stripHTML(o.label || variables[o.option])}))}
@@ -100,6 +101,7 @@ export default function Selector(props) {
     // options over selectCutoff; select menu
     return (
       <Select
+        className="cp-select"
         label={title}
         fontSize={fontSize}
         id={slug}

--- a/packages/next/cms/components/sections/components/Stat.js
+++ b/packages/next/cms/components/sections/components/Stat.js
@@ -10,10 +10,10 @@ import stripP from "../../../utils/formatters/stripP";
  * @returns
  */
 function Stat({
-  label, value, subtitle
+  label, value, subtitle, ...rest
 }) {
   return (
-    <Stack className="cp-stat" align="flex-start" maw={250} spacing={0} my="md">
+    <Stack className="cp-stat" align="flex-start" maw={250} spacing={0} my="md" {...rest}>
       {label &&
         <Text dangerouslySetInnerHTML={{__html: stripP(label)}} span />
       }

--- a/packages/next/cms/hooks/use-comparison.js
+++ b/packages/next/cms/hooks/use-comparison.js
@@ -1,4 +1,4 @@
-import {useRouter} from "next/router";
+import {useRouter} from "next/router.js";
 import {useState, useEffect} from "react";
 import formatProfileResponse from "../utils/formatProfileResponse";
 import axios from "axios";

--- a/packages/next/cms/hooks/use-comparison.js
+++ b/packages/next/cms/hooks/use-comparison.js
@@ -10,7 +10,7 @@ export default function useComparison(profile) {
   const [comparison, setComparison] = useState(null);
   const [comparisonLoading, setComparisonLoading] = useState(false);
   const [comparisonError, setComparisonError] = useState(false);
-  const {query, locale} = useRouter();
+  const {query, locale, pathname, replace} = useRouter();
   const compareSlug = query?.compare;
 
   const slug = profile.meta[0].slug;
@@ -26,6 +26,17 @@ export default function useComparison(profile) {
             setComparison(null);
             setComparisonError(true);
             setComparisonLoading(false);
+
+            const newQuery = {...query};
+            delete newQuery.compare;
+
+            // on Error delete query param
+            replace(
+              {pathname, query: newQuery},
+              undefined,
+              {shallow: true}
+            );
+
             return;
           }
           else {

--- a/packages/next/cms/hooks/use-on-set-variables.js
+++ b/packages/next/cms/hooks/use-on-set-variables.js
@@ -2,7 +2,7 @@
 import React, {useState} from "react";
 import mortarEval from "../utils/mortarEval";
 import prepareProfile from "../utils/prepareProfile";
-import {useRouter} from "next/router";
+import {useRouter} from "next/router.js";
 
 const splitComparisonKeys = obj => {
   const split = {

--- a/packages/next/cms/hooks/use-profile-sections.js
+++ b/packages/next/cms/hooks/use-profile-sections.js
@@ -57,9 +57,25 @@ export default function useProfileSections(profile, comparison, t) {
   // find Hero section
   const heroSection = sections.find(l => l.type === "Hero");
 
+  // filter modal and hero sections from the rest of the report
+  const renderSections = sections
+    .filter(l => l.type !== "Hero" && l.position !== "modal")
+    .map(l => {
+    // rename old section names
+      const slug = l.slug ?? `section-${l.id}`;
+      if (l.type === "TextViz" || l.position === "sticky") return {...l, type: "Default", slug};
+      if (l.type === "Column") return {...l, type: "SingleColumn", slug};
+      return {...l, slug};
+    });
+
   const comparisonSections = [];
 
   if (comparison) {
+
+    // function used to clone and modify a raw "section" in order
+    // to prep it to be viewed side-by-side with a comparitor section
+    // with similar content
+
     const comparifySection = (rawSection, payload) => ({
 
       ...rawSection,
@@ -78,10 +94,20 @@ export default function useProfileSections(profile, comparison, t) {
 
     });
 
-    sections
+    renderSections
       .reduce((arr, rawSection) => {
 
-        const comp = comparison.sections.find(s => s.id === rawSection.id);
+        const comp = comparison
+          .sections
+          .filter(l => l.type !== "Hero" && l.position !== "modal")
+          .map(l => {
+            // rename old section names
+            const slug = l.slug ?? `section-${l.id}`;
+            if (l.type === "TextViz" || l.position === "sticky") return {...l, type: "Default", slug};
+            if (l.type === "Column") return {...l, type: "SingleColumn", slug};
+            return {...l, slug};
+          })
+          .find(s => s.id === rawSection.id);
         if (comp) {
 
           const section = comparifySection(rawSection, profile);
@@ -98,20 +124,8 @@ export default function useProfileSections(profile, comparison, t) {
       }, []);
 
   }
-  // function used to clone and modify a raw "section" in order
-  // to prep it to be viewed side-by-side with a comparitor section
-  // with similar content
 
-  // filter modal and hero sections from the rest of the report
-  const renderSections = sections
-    .filter(l => l.type !== "Hero" && l.position !== "modal")
-    .map(l => {
-    // rename old section names
-      const slug = l.slug ?? `section-${l.id}`;
-      if (l.type === "TextViz" || l.position === "sticky") return {...l, type: "Default", slug};
-      if (l.type === "Column") return {...l, type: "SingleColumn", slug};
-      return {...l, slug};
-    });
+
 
 
   const innerGroups = renderSections

--- a/packages/next/cms/hooks/use-report-state.js
+++ b/packages/next/cms/hooks/use-report-state.js
@@ -1,4 +1,4 @@
-import {useRouter} from "next/router";
+import {useRouter} from "next/router.js";
 import {useEffect, useMemo, useState} from "react";
 import prepareProfile from "../utils/prepareProfile";
 import funcifyFormatterByLocale from "../utils/funcifyFormatterByLocale";

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,15 +1,11 @@
 {
   "name": "@datawheel/canon-next",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Nextjs components for sites migrating away from canon-core.",
   "main": "./dist/index.js",
   "exports": {
-    ".": {
-      "import": "./dist/index.js"
-    },
-    "./utils": {
-      "import": "./dist/utils.js"
-    }
+    ".": "./dist/index.js",
+    "./utils":  "./dist/utils.js"
   },
   "engines": {
     "node": "^16.0.0"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@datawheel/canon-next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Nextjs components for sites migrating away from canon-core.",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawheel/canon-next",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Nextjs components for sites migrating away from canon-core.",
   "main": "./dist/index.js",
   "exports": {
@@ -41,9 +41,9 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@mantine/core": "^5.6.3",
-    "@mantine/hooks": "^5.10.4",
-    "@mantine/prism": "^5.10.4",
+    "@mantine/core": "^6.0.13",
+    "@mantine/hooks": "^6.0.13",
+    "@mantine/prism": "^6.0.13",
     "@tabler/icons-react": "^2.4.0",
     "axios": "^1.3.3",
     "buble": "^0.20.0",
@@ -54,7 +54,7 @@
     "d3plus-text": "^1.2.1",
     "d3plus-viz": "^1.3.0",
     "jszip": "^3.10.1",
-    "mantine-datatable": "^1.8.6",
+    "mantine-datatable": "^2.5.4",
     "next-i18next": "^13.1.5",
     "react": "^18.0.2",
     "react-inlinesvg": "^3.0.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawheel/canon-next",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Nextjs components for sites migrating away from canon-core.",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/next/utils.js
+++ b/packages/next/utils.js
@@ -1,1 +1,2 @@
 export {default as stripHTML} from "./cms/utils/formatters/stripHTML";
+export {default as stripP} from "./cms/utils/formatters/stripP";


### PR DESCRIPTION
I had to do a couple of patch releases with some fixes I needed for monshaat. All very small changes, with bugfixes and added classes for styling. Broad explanation ahead:

`0.2.1`:
- fixes a bug that prevented importing the package

`0.2.2`: 
- adds a className for targeting comparison button state
- if there is an error on the comparison query, delete the query param
- fixes "remove comparison" icon
- fixes bad import on `next/router` -> `next/router.js` (ESM complains)
- adds className to image credits
- fixes ProfileTile's `titleSize` fn for arabic charset.
- adds className for profilesearch filters
- delete unused params on profilesearch (To be added back? throws an error now)
- fixes comparison section types (og profile were Default, but comparison profile TextViz)

`0.2.3` - `0.2.4`: 
- fixes mantine versions issue
`0.2.5`:
- fixes `filterCubeTitles` fn
- adds classes
- adds Graphic vix type

Let me know if you catch any issues